### PR TITLE
feat(unlock-app) - settings upgrade lock

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+# 0.32.9
+
+- add `publicLockLatestVersion` in web3Service
+- add `upgradeLock` in walletService
+
 # 0.32.8
 
 - fix `updateRefundPenalty` and `renounceLockManager` in walletService

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.32.8",
+  "version": "0.32.9",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/unlock-js/src/Unlock/v11/index.js
+++ b/packages/unlock-js/src/Unlock/v11/index.js
@@ -1,8 +1,10 @@
 import abis from '../../abis'
 import createLock from './createLock'
+import upgradeLock from './upgradeLock'
 
 export default {
   createLock,
+  upgradeLock,
   version: 'v11',
   Unlock: abis.Unlock.v11,
 }

--- a/packages/unlock-js/src/Unlock/v11/upgradeLock.js
+++ b/packages/unlock-js/src/Unlock/v11/upgradeLock.js
@@ -1,0 +1,40 @@
+/**
+ * Upgrade an existing lock to a higher version
+ * @notice The version number can only be incremented by 1
+ * @param {string} lockAddress the address of the existing (upgradeable) lock
+ * @param {number} lockVersion the version number to upgrade the lock
+ * @param {function} callback invoked with the upgrade transaction hash
+ */
+export default async function (lockAddress, lockVersion, callback) {
+  if (typeof lockVersion !== 'number')
+    throw Error('lockVersion should be a number')
+
+  const unlockContract = await this.getUnlockContract()
+
+  // send the upgrade tx
+  const transactionPromise = unlockContract.upgradeLock(
+    lockAddress,
+    lockVersion
+  )
+
+  const hash = await this._handleMethodCall(transactionPromise)
+  if (callback) {
+    callback(null, hash, await transactionPromise)
+  }
+
+  // Let's now wait for the lock to be upgraded
+  const receipt = await this.provider.waitForTransaction(hash)
+  const parser = unlockContract.interface
+  const upgradeLockEvent = receipt.logs
+    .map((log) => {
+      return parser.parseLog(log)
+    })
+    .filter((event) => event.name === 'UpgradeLock')[0]
+
+  if (upgradeLockEvent) {
+    return upgradeLockEvent.args.version
+  }
+
+  // There was no UpgradeLock log (transaction failed?)
+  return null
+}

--- a/packages/unlock-js/src/walletService.ts
+++ b/packages/unlock-js/src/walletService.ts
@@ -866,4 +866,29 @@ export default class WalletService extends UnlockService {
       callback
     )
   }
+
+  /**
+   * Upgrade a lock to a specific version
+   * @param {*} params
+   * @param {*} callback
+   */
+  async upgradeLock(
+    params: {
+      lockAddress: string
+      lockVersion: number
+    },
+    transactionOptions?: TransactionOptions,
+    callback?: WalletServiceCallback
+  ): Promise<string> {
+    const version = await this.unlockContractAbiVersion()
+    if (version <= 10) {
+      throw new Error('Upgrade lock only available for lock v10+')
+    }
+    if (!params.lockAddress) throw new Error('Missing lockAddress')
+    return version.upgradeLock.bind(this)(
+      params.lockAddress,
+      params.lockVersion,
+      callback
+    )
+  }
 }

--- a/packages/unlock-js/src/web3Service.ts
+++ b/packages/unlock-js/src/web3Service.ts
@@ -891,4 +891,18 @@ export default class Web3Service extends UnlockService {
     const address = await lockContract.onKeyGrantHook()
     return address
   }
+
+  /**
+   * Returns last lock version
+   * @param {Number} network
+   */
+  async publicLockLatestVersion(network: number) {
+    const provider = this.providerForNetwork(network)
+    const { unlockAddress } = this.networks[network] ?? {}
+    if (!unlockAddress) {
+      throw new Error('unlockAddress is not defined for the provided network. ')
+    }
+    const unlockContract = await this.getUnlockContract(unlockAddress, provider)
+    return await unlockContract.publicLockLatestVersion()
+  }
 }

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingMisc.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingMisc.tsx
@@ -1,5 +1,5 @@
-import { Lock } from '~/unlockTypes'
 import { UpdateHooksForm } from '../forms/UpdateHooksForm'
+import { UpdateVersionForm } from '../forms/UpdateVersionForm'
 import { SettingCard } from './SettingCard'
 
 interface SettingMiscProps {
@@ -7,7 +7,28 @@ interface SettingMiscProps {
   network: number
   isManager: boolean
   isLoading: boolean
-  lock?: Lock
+  publicLockVersion?: number
+  publicLockLatestVersion?: number
+}
+
+const UpgradeCard = ({ isLastVersion }: { isLastVersion: boolean }) => {
+  if (isLastVersion) {
+    return (
+      <span className="text-base">You are running the latest version.</span>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1 p-4 bg-gray-100 rounded-lg ">
+      <span className="text-base font-bold text-brand-ui-primary">
+        Upgrade Available 🔆
+      </span>
+      <span className="text-base text-brand-dark">
+        This lock is deployed on an earlier version of the smart contract. An
+        upgrade is available to the latest features.
+      </span>
+    </div>
+  )
 }
 
 export const SettingMisc = ({
@@ -15,8 +36,14 @@ export const SettingMisc = ({
   lockAddress,
   network,
   isLoading,
-  lock,
+  publicLockVersion,
+  publicLockLatestVersion,
 }: SettingMiscProps) => {
+  const isLastVersion =
+    publicLockVersion !== undefined &&
+    publicLockLatestVersion !== undefined &&
+    publicLockVersion === publicLockLatestVersion
+
   return (
     <div className="grid grid-cols-1 gap-6">
       <SettingCard
@@ -43,9 +70,27 @@ export const SettingMisc = ({
           network={network}
           isManager={isManager}
           disabled={!isManager}
-          version={lock?.publicLockVersion}
+          version={publicLockVersion!}
         />
       </SettingCard>
+
+      {(publicLockVersion ?? 0) >= 10 && (
+        <SettingCard
+          label="Versioning"
+          description={<UpgradeCard isLastVersion={isLastVersion} />}
+          isLoading={isLoading}
+          disabled={isLastVersion}
+        >
+          <UpdateVersionForm
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            disabled={!isManager}
+            version={publicLockVersion ?? 0}
+            isLastVersion={isLastVersion}
+          />
+        </SettingCard>
+      )}
     </div>
   )
 }

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateVersionForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateVersionForm.tsx
@@ -1,0 +1,82 @@
+import { useMutation } from '@tanstack/react-query'
+import { Button, Icon } from '@unlock-protocol/ui'
+import { AiOutlineAlert as AlertIcon } from 'react-icons/ai'
+import { ToastHelper } from '~/components/helpers/toast.helper'
+import { useWalletService } from '~/utils/withWalletService'
+
+interface UpdateVersionFormProps {
+  lockAddress: string
+  network: number
+  isManager: boolean
+  disabled: boolean
+  version: number
+  isLastVersion: boolean
+}
+
+const UpgradeHooksAlert = () => {
+  return (
+    <div className="flex items-center gap-2 p-4 bg-yellow-100 rounded-lg">
+      <div className="w-8">
+        <Icon size={20} icon={AlertIcon} />
+      </div>
+      <span className="text-sm text-brand-dark">
+        If you are using any hooks on the contract, please reach out in discord
+        community before upgrading to ensure the compatibility.
+      </span>
+    </div>
+  )
+}
+
+export const UpdateVersionForm = ({
+  lockAddress,
+  disabled,
+  isManager,
+  version,
+  isLastVersion,
+}: UpdateVersionFormProps) => {
+  const walletService = useWalletService()
+  const nextVersion = version + 1
+
+  const upgradeLockVersion = async () => {
+    return await walletService.upgradeLock({
+      lockAddress,
+      lockVersion: nextVersion,
+    })
+  }
+
+  const upgradeLockVersionMutation = useMutation(upgradeLockVersion)
+
+  const onUpgradeLockVersion = async () => {
+    const upgradeLockVersionPromise = upgradeLockVersionMutation.mutateAsync()
+    await ToastHelper.promise(upgradeLockVersionPromise, {
+      success: `Lock upgraded to ${nextVersion} version.`,
+      error: 'Impossible to upgrade version',
+      loading: 'Upgrading lock version.',
+    })
+  }
+
+  const disabledInput = disabled || upgradeLockVersionMutation.isLoading
+
+  if (isLastVersion) return null
+
+  return (
+    <div className="flex flex-col gap-8">
+      <span className="text-xl font-bold">{`Version ${nextVersion}`}</span>
+      {isManager && (
+        <>
+          <Button
+            className="w-full md:w-1/3"
+            disabled={disabledInput}
+            loading={upgradeLockVersionMutation.isLoading}
+            onClick={() => {
+              onUpgradeLockVersion()
+            }}
+          >
+            Upgrade
+          </Button>
+          <UpgradeHooksAlert />
+        </>
+      )}
+    </div>
+  )
+}

--- a/unlock-app/src/components/interface/locks/Settings/index.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/index.tsx
@@ -7,7 +7,7 @@ import { useLockManager } from '~/hooks/useLockManager'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { addressMinify } from '~/utils/strings'
 import { SettingHeader } from './elements/SettingHeader'
-import { useQuery } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { useWeb3Service } from '~/utils/withWeb3Service'
 import { SettingGeneral } from './elements/SettingGeneral'
 import { SettingMisc } from './elements/SettingMisc'
@@ -76,6 +76,22 @@ const LockSettingsPage = ({ lockAddress, network }: LockSettingsPageProps) => {
       refetchInterval: 1000,
     }
   )
+
+  const [{ data: publicLockLatestVersion }, { data: publicLockVersion }] =
+    useQueries({
+      queries: [
+        {
+          queryKey: ['publicLockLatestVersion', network],
+          queryFn: async () =>
+            await web3Service.publicLockLatestVersion(network),
+        },
+        {
+          queryKey: ['publicLockVersion', lockAddress, network],
+          queryFn: async () =>
+            await web3Service.publicLockVersion(lockAddress, network),
+        },
+      ],
+    })
 
   const isLoading = isLoadingLock || isLoadingManager
 
@@ -159,7 +175,8 @@ const LockSettingsPage = ({ lockAddress, network }: LockSettingsPageProps) => {
           network={network}
           isManager={isManager}
           isLoading={isLoading}
-          lock={lock}
+          publicLockLatestVersion={publicLockLatestVersion}
+          publicLockVersion={publicLockVersion}
         />
       ),
       sidebar: (


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

**Lock with last version**

<img width="983" alt="Screenshot 2022-11-24 at 21 10 47" src="https://user-images.githubusercontent.com/20865711/203861690-0d30c256-6bf2-4993-bdb4-ba386be25ac5.png">


**Upgradable lock**

<img width="1153" alt="Screenshot 2022-11-24 at 21 25 19" src="https://user-images.githubusercontent.com/20865711/203861644-f6a314ab-bde6-4391-a671-f30905506bd7.png">

<img width="1153" alt="Screenshot 2022-11-24 at 21 25 19" src="https://user-images.githubusercontent.com/20865711/203861663-56719cf5-3883-45f8-b4e3-651f5fe3c55b.png">

**Upgrade lock version** 

<img width="1003" alt="Screenshot 2022-11-24 at 21 53 20" src="https://user-images.githubusercontent.com/20865711/203861628-e62e7f8a-e0f8-4c95-8670-8efab7c65fc8.png">



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

