### PR TITLE
feat(unlock-app)  - fix lock deployment status change

### DIFF
--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
@@ -89,7 +89,7 @@ export const CreateLockFormSummary = ({
 }: CreateLockFormSummaryProps) => {
   const router = useRouter()
   const web3Service = useWeb3Service()
-  const { networks, requiredConfirmations } = useConfig()
+  const { networks } = useConfig()
   const {
     unlimitedDuration = false,
     unlimitedQuantity = false,
@@ -114,7 +114,7 @@ export const CreateLockFormSummary = ({
   }
 
   const { data, isError } = useQuery(
-    ['getTransactionDetails'],
+    ['getTransactionDetails', transactionHash, network],
     () => {
       return getTransactionDetails(transactionHash!)
     },
@@ -124,8 +124,7 @@ export const CreateLockFormSummary = ({
   )
 
   const hasError = isError && data
-  const isDeployed =
-    (data?.confirmations || 0) >= requiredConfirmations && !isError
+  const isDeployed = (data?.confirmations || 0) > 1 && !isError
 
   const currentStatus: DeployStatus = hasError
     ? 'txError'

--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockFormSummary.tsx
@@ -87,6 +87,7 @@ export const CreateLockFormSummary = ({
   showStatus = false,
   transactionHash,
 }: CreateLockFormSummaryProps) => {
+  const requiredConfirmations = 2 // Required confirmations block to switch to 'deployed' status
   const router = useRouter()
   const web3Service = useWeb3Service()
   const { networks } = useConfig()
@@ -124,7 +125,8 @@ export const CreateLockFormSummary = ({
   )
 
   const hasError = isError && data
-  const isDeployed = (data?.confirmations || 0) > 1 && !isError
+  const isDeployed =
+    (data?.confirmations || 0) > requiredConfirmations && !isError
 
   const currentStatus: DeployStatus = hasError
     ? 'txError'


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

https://user-images.githubusercontent.com/20865711/203975319-a6ef191c-4df0-4003-91cc-40a88a89f852.mov



Set the default required confirmations block to the min value in order to see the `deployed` status as soon the lock is deployed. 
We don't need to wait for 12 confirmations blocks 

The min value is set to `2` in order to give time to subgraph to get the new created lock before we redirect in the lock list page. 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

