### PR TITLE
feat(unlock-app) - remove spinner loading

### DIFF
--- a/unlock-app/src/components/interface/Authenticate.jsx
+++ b/unlock-app/src/components/interface/Authenticate.jsx
@@ -38,18 +38,17 @@ const Providers = ({ network, networkConfig, children, authenticate }) => {
     return new Web3Service(networkConfig)
   }, [networkConfig])
 
-  const { tryAutoLogin, isLoading } = useAutoLogin({
+  const { tryAutoLogin } = useAutoLogin({
     authenticate,
   })
 
   useEffect(() => {
     tryAutoLogin()
   }, [])
+
   return (
     <StorageServiceProvider value={storageService}>
-      <Web3ServiceProvider value={web3Service}>
-        {isLoading ? <Loading /> : children}
-      </Web3ServiceProvider>
+      <Web3ServiceProvider value={web3Service}>{children}</Web3ServiceProvider>
     </StorageServiceProvider>
   )
 }
@@ -155,7 +154,7 @@ Authenticate.defaultProps = {
   optional: false,
   onCancel: null,
   embedded: false,
-  onAuthenticated: () => { },
+  onAuthenticated: () => {},
   providerAdapter: null,
 }
 

--- a/unlock-app/src/components/interface/Authenticate.jsx
+++ b/unlock-app/src/components/interface/Authenticate.jsx
@@ -48,7 +48,9 @@ const Providers = ({ network, networkConfig, children, authenticate }) => {
 
   return (
     <StorageServiceProvider value={storageService}>
-      <Web3ServiceProvider value={web3Service}>{children}</Web3ServiceProvider>
+      <Web3ServiceProvider value={web3Service}>
+        {web3Service && <>{children}</>}
+      </Web3ServiceProvider>
     </StorageServiceProvider>
   )
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- Remove the spinner inside `Authenticate` that shows a spinner when `tryAutologin` promise is pending 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

