### PR TITLE
fix(unlock-app): using a better button label when the price is 0

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm.tsx
@@ -471,6 +471,25 @@ export function Confirm({
         )
       }
       case 'crypto': {
+        let buttonLabel = ''
+        const isFree = pricingData?.prices.reduce((previousTotal, item) => {
+          return previousTotal && parseFloat(item.amount) === 0
+        }, true)
+
+        if (isFree) {
+          if (isConfirming) {
+            buttonLabel = 'Claiming'
+          } else {
+            buttonLabel = 'Claim'
+          }
+        } else {
+          if (isConfirming) {
+            buttonLabel = 'Paying using crypto'
+          } else {
+            buttonLabel = 'Pay using crypto'
+          }
+        }
+
         return (
           <div className="grid">
             <Button
@@ -481,7 +500,7 @@ export function Confirm({
                 onConfirmCrypto()
               }}
             >
-              {isConfirming ? 'Paying using crypto' : 'Pay using crypto'}
+              {buttonLabel}
             </Button>
           </div>
         )


### PR DESCRIPTION
# Description

We should not show "purchase" when the lock is free.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

