### PR TITLE
fix(ci): docker build cache manifest

### DIFF
--- a/.github/workflows/_docker-cache.yml
+++ b/.github/workflows/_docker-cache.yml
@@ -21,6 +21,7 @@ jobs:
           IMAGE="unlockprotocol/unlock-dev"
           echo ::set-output name=tagged_image::${IMAGE}:${TAG}
           echo ::set-output name=tag::${TAG}
+          echo ::set-output name=latest::${IMAGE}:latest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -51,7 +52,8 @@ jobs:
           # Build only desired target
           target: deps
           push: true 
-          tags: ${{ steps.prep.outputs.tagged_image }},latest
+          build-args: BUILDKIT_INLINE_CACHE=1
+          tags: ${{ steps.prep.outputs.tagged_image }},${{ steps.prep.outputs.latest }}
           cache-from: type=local,src=/tmp/.buildx-cache
           # Note the mode=max here
           # More: https://github.com/moby/buildkit#--export-cache-options

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - buildx-cache-manifest
-
 jobs:
   run-all-tests:
     uses: ./.github/workflows/_tests.yml

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - buildx-cache-manifest
 
 jobs:
   run-all-tests:


### PR DESCRIPTION
# Description

Adds proper support for layers cache by adding buildx manifest to image at build step. Also fix image name for `latest`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

