### PR TITLE
feat(unlock-app) - loading locks by group

### DIFF
--- a/unlock-app/src/components/interface/locks/List/elements/LockCard.tsx
+++ b/unlock-app/src/components/interface/locks/List/elements/LockCard.tsx
@@ -70,7 +70,11 @@ const Detail = ({
   )
 }
 
-export const LocksByNetworkPlaceholder = () => {
+export const LocksByNetworkPlaceholder = ({
+  networkName,
+}: {
+  networkName: string
+}) => {
   const DetailPlaceholder = () => {
     return (
       <div className="flex flex-col gap-1">
@@ -112,13 +116,9 @@ export const LocksByNetworkPlaceholder = () => {
     )
   }
 
-  const NetworkNamePlaceholder = () => {
-    return <div className="w-56 h-6 animate-pulse bg-slate-200"></div>
-  }
-
   return (
     <div className="flex flex-col gap-4">
-      <NetworkNamePlaceholder />
+      <h2 className="text-lg font-bold text-brand-ui-primary">{networkName}</h2>
       <div className="flex flex-col gap-6">
         <LockCardPlaceHolder />
         <LockCardPlaceHolder />

--- a/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
+++ b/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
@@ -24,7 +24,7 @@ const LocksByNetwork = ({ network, isLoading, locks }: LocksByNetworkProps) => {
   const { networks } = useConfig()
   const { name: networkName } = networks[network]
 
-  if (isLoading) return <LocksByNetworkPlaceholder />
+  if (isLoading) return <LocksByNetworkPlaceholder networkName={networkName} />
   if (locks?.length === 0) return null
 
   return (

--- a/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
+++ b/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
@@ -103,12 +103,11 @@ export const LockList = ({ owner }: LockListProps) => {
     queries,
   })
 
-  const isLoading = results?.some(({ isLoading }) => isLoading)
-
   return (
     <div className="grid gap-20 mb-20">
       {networkItems.map(([network], index) => {
         const locksByNetwork: any = results?.[index]?.data || []
+        const isLoading = results?.[index]?.isLoading || false
 
         return (
           <LocksByNetwork


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
use `isLoading` for any specific network without using a global loading.
In this way we can show the locks for a specific network as soon is loaded 
<img width="1170" alt="Screenshot 2022-12-05 at 16 00 07" src="https://user-images.githubusercontent.com/20865711/205669508-38ee33b9-bf4a-4ee0-a032-0d38d3456e9a.png">

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

