### PR TITLE
fix(ci): copy package json files separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # syntax = docker/dockerfile:experimental
 
-#
-# 1. install only deps (to be cached)
-#
-FROM node:16-bullseye as deps
+ARG NODE_VERSION=16
+
+###################################################################
+# Stage 1: Install all workspaces (dev)dependencies               #
+#          and generates node_modules folder(s)                   #
+###################################################################
+FROM node:${NODE_VERSION}-bullseye as deps
 LABEL Unlock <ops@unlock-protocol.com>
 
 # Setting user as root to handle apt install
@@ -15,6 +18,7 @@ RUN apt-get update \
     apt-get install --assume-yes \
     bash \
     git \
+    rsync \
     python3 \
     postgresql \
     default-jdk \
@@ -22,45 +26,44 @@ RUN apt-get update \
     build-essential \
     ca-certificates
 
-# switch to user
+# setup folder
 ENV DEST_FOLDER=/home/unlock
-
 RUN mkdir $DEST_FOLDER
+WORKDIR ${DEST_FOLDER}
 
-# copy files 
-WORKDIR /tmp
-COPY . .
+# We use rsync to prepare all package.json files that are necessary 
+# for packages install and used to invalidate buidkit docker cache
+RUN --mount=type=bind,target=/docker-context \
+    rsync -amv --delete \
+          --exclude='node_modules' \
+          --exclude='*/node_modules' \
+          --include='package.json' \
+          --include='*/' --exclude='*' \
+          /docker-context/ $DEST_FOLDER;
 
-# copy all package.json files
-RUN find . -maxdepth 3 -mindepth 2 -type f -name "package.json" ! -path '**node_modules**' ! -path './docker' -exec cp --parents '{}' $DEST_FOLDER \;
-COPY package.json $DEST_FOLDER
-COPY yarn.lock $DEST_FOLDER
+# yarn related files
+COPY yarn.lock .
+COPY .yarnrc.yml .
+COPY .yarn/plugins .yarn/plugins
+COPY .yarn/releases .yarn/releases
 
-# copy al yarn related files
-COPY .yarnrc.yml $DEST_FOLDER
-COPY .prettierrc $DEST_FOLDER
-COPY .yarn/plugins $DEST_FOLDER/.yarn/plugins
-COPY .yarn/releases $DEST_FOLDER/.yarn/releases
-RUN chown -R node:node $DEST_FOLDER
-
-# specify yarn cache folder location (to be used by docker buildkit)
-USER node
-RUN echo "cacheFolder: ${DEST_FOLDER}/yarn-cache" >> $DEST_FOLDER/.yarnrc.yml
-RUN mkdir $DEST_FOLDER/yarn-cache
+# use custom .yarn/cache folder (for local dev)
+RUN echo "cacheFolder: ${DEST_FOLDER}/yarn-cache" >> .yarnrc.yml
+RUN mkdir ./yarn-cache
+RUN chown -R node:node .
 
 # install deps
-WORKDIR ${DEST_FOLDER}
-RUN --mount=type=cache,target=/home/unlock/yarn-cache,uid=1000,gid=1000 yarn
+USER node
+RUN --mount=type=cache,target=${DEST_FOLDER}/yarn-cache,uid=1000,gid=1000 yarn
 
-#
-# 2. build packages and prepare image for testing/dev
-#
+###################################################################
+# Stage 2: Build packages and app
+###################################################################
 FROM deps as dev
 
-# enforce perms
-WORKDIR /home/unlock
+ENV DEST_FOLDER=/home/unlock
 
-# default user
+# enforce perms
 USER node
 COPY --chown=node . .
 
@@ -68,8 +71,17 @@ COPY --chown=node . .
 RUN java -version
 RUN javac -version
 
+# copy all package.json again
+RUN --mount=type=bind,target=/docker-context \
+    rsync -amv --delete \
+          --exclude='node_modules' \
+          --exclude='*/node_modules' \
+          --include='package.json' \
+          --include='*/' --exclude='*' \
+          /docker-context/ $DEST_FOLDER;
+
 # Run yarn to install missing dependencies from cached image
-RUN yarn
+RUN --mount=type=cache,target=${DEST_FOLDER}/yarn-cache,uid=1000,gid=1000 yarn
 
 # build all packages in packages/**
 RUN yarn build
@@ -77,9 +89,13 @@ RUN yarn build
 # Build locksmith and other apps separately to reduce startup time on heroku
 RUN yarn apps:build
 
-#
-## 3. export image for prod app
-##
+# copy all files at the end
+COPY . .
+
+
+###################################################################
+# Stage 3. export minimal image for prod app
+###################################################################
 FROM dev as prod
 
 # default values

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,15 +71,6 @@ COPY --chown=node . .
 RUN java -version
 RUN javac -version
 
-# copy all package.json again
-RUN --mount=type=bind,target=/docker-context \
-    rsync -amv --delete \
-          --exclude='node_modules' \
-          --exclude='*/node_modules' \
-          --include='package.json' \
-          --include='*/' --exclude='*' \
-          /docker-context/ $DEST_FOLDER;
-
 # Run yarn to install missing dependencies from cached image
 RUN --mount=type=cache,target=${DEST_FOLDER}/yarn-cache,uid=1000,gid=1000 yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,6 @@ RUN yarn build
 # Build locksmith and other apps separately to reduce startup time on heroku
 RUN yarn apps:build
 
-# copy all files at the end
-COPY . .
-
 
 ###################################################################
 # Stage 3. export minimal image for prod app

--- a/locksmith/README.md
+++ b/locksmith/README.md
@@ -39,4 +39,4 @@ Once the database has been configured (per above), make sure to migrate by calli
 
 ### Running Locksmith
 
-For running in production, use `yarn start` otherwise `yarn dev` which will restart the server on file changes.
+For running in production, use `yarn start` otherwise `yarn dev` which will restart the server on file changes. 


### PR DESCRIPTION
# Description

To prevent the `COPY . .` to invalidate docker cache on each file change, we copy package.json files separately (using rsync) and build packages.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

