### PR TITLE
fix(ci): add docker cache manifest to image

### DIFF
--- a/.github/workflows/_docker-cache.yml
+++ b/.github/workflows/_docker-cache.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
+          build-args: BUILDKIT_INLINE_CACHE=1
           # Build only desired target
           target: deps
           push: true 

--- a/.github/workflows/_docker-cache.yml
+++ b/.github/workflows/_docker-cache.yml
@@ -19,9 +19,8 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           IMAGE="unlockprotocol/unlock-dev"
-          echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-          echo ::set-output name=tag::${TAG}
-          echo ::set-output name=latest::${IMAGE}:latest
+          echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+          echo "latest=${IMAGE}:latest" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - docker-cache-manifest
+
 jobs:
   run-all-tests:
     uses: ./.github/workflows/_tests.yml

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - docker-cache-manifest
-
 jobs:
   run-all-tests:
     uses: ./.github/workflows/_tests.yml


### PR DESCRIPTION
# Description

Currently the docker image we are pushing doesn't contain the cache manifest, so docker can not use it as `cache_from`. This adds the correct [buildkit arg](https://docs.docker.com/engine/reference/builder/#buildkit-built-in-build-args) to actually allow the image to be used as cache.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #10489
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

