### PR TITLE
feature(unlock-app): refactored bulk airdrop

### DIFF
--- a/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
@@ -129,7 +129,6 @@ export function AirdropKeysDrawer({
       )
       .catch((error: any) => {
         console.log(error)
-        window.debug = error
         throw new Error('We were unable to airdrop these memberships.')
       })
 

--- a/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
@@ -51,7 +51,14 @@ export function AirdropKeysDrawer({
   const handleConfirm = async (items: AirdropMember[]) => {
     // Create metadata
     const users = items.map(({ recipient: userAddress, ...rest }) => {
-      const data = omit(rest, ['manager', 'neverExpire', 'count', 'expiration'])
+      const data = omit(rest, [
+        'manager',
+        'neverExpire',
+        'count',
+        'expiration',
+        'balance',
+        'line',
+      ])
       const metadata = Object.entries(data).reduce<Metadata>(
         (result, [key, value]) => {
           const [name, designation] = key.split('.')

--- a/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
@@ -114,18 +114,24 @@ export function AirdropKeysDrawer({
     }, initialValue)
 
     // Grant keys
-    await walletService.grantKeys(
-      {
-        ...options,
-        lockAddress,
-      },
-      {},
-      (error) => {
-        if (error) {
-          throw error
+    await walletService
+      .grantKeys(
+        {
+          ...options,
+          lockAddress,
+        },
+        {},
+        (error) => {
+          if (error) {
+            throw error
+          }
         }
-      }
-    )
+      )
+      .catch((error: any) => {
+        console.log(error)
+        window.debug = error
+        throw new Error('We were unable to airdrop these memberships.')
+      })
 
     ToastHelper.success(
       `Successfully granted ${options.recipients.length} keys to ${items.length} recipients`

--- a/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
@@ -15,6 +15,8 @@ export const AirdropMember = z
     ),
     manager: z.string().optional(),
     email: z.string().optional(),
+    balance: z.number().optional(),
+    line: z.number().optional(),
   })
   .passthrough()
 

--- a/unlock-app/src/hooks/useEns.ts
+++ b/unlock-app/src/hooks/useEns.ts
@@ -6,9 +6,10 @@ const config = configure()
 const publicProvider = config.networks[1].publicProvider
 
 export const getNameOrAddressForAddress = async (
-  address: string
+  _address: string
 ): Promise<string> => {
   try {
+    const address = _address.trim()
     const isNotENS = ethers.utils.isAddress(address)
     if (isNotENS) {
       return address
@@ -22,13 +23,14 @@ export const getNameOrAddressForAddress = async (
     return address
   } catch (error) {
     // Resolution failed. So be it, we'll show the 0x address
-    console.error(`We could not resolve ENS name for ${address}`)
-    return address
+    console.error(`We could not resolve ENS name for ${_address}`)
+    return _address
   }
 }
 
-export const getAddressForName = async (name: string): Promise<string> => {
+export const getAddressForName = async (_name: string): Promise<string> => {
   try {
+    const name = _name.trim()
     const isAddress = ethers.utils.isAddress(name)
     if (isAddress) {
       return name


### PR DESCRIPTION
# Description

We got some feedback about our bulk feedback that I am incorporating in that PR.
We're also limiting to 50 per airdrop which should let us avoid the block limit on most networks (tested).
The "filtering" also lets users re-upload the same file multiple times to make sure they all get airdropped.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

Improved bulk airdrop.

