### PR TITLE
feat(unlock-app) - add data-testid to form elements

### DIFF
--- a/packages/ui/lib/components/Form/Input.tsx
+++ b/packages/ui/lib/components/Form/Input.tsx
@@ -58,6 +58,7 @@ export const Input = forwardRef(
       description,
       label,
       icon,
+      name,
       ...inputProps
     } = props
     const [isCopied, setCopy] = useClipboard(props.value as string)
@@ -103,6 +104,7 @@ export const Input = forwardRef(
             value={value}
             ref={ref}
             className={inputClass}
+            data-testid={name || label}
           />
           <div className="absolute inset-y-0 right-0 flex items-center pr-1 ml-4">
             {copy && !hidden && (

--- a/packages/ui/lib/components/Form/TextBox.tsx
+++ b/packages/ui/lib/components/Form/TextBox.tsx
@@ -39,6 +39,7 @@ export const TextBox = forwardRef(
       success,
       description,
       label,
+      name,
       ...restProps
     } = props
 
@@ -71,6 +72,7 @@ export const TextBox = forwardRef(
           value={value}
           ref={ref}
           className={textBoxClass}
+          data-testid={name || label}
         />
       </FieldLayout>
     )


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Add `data-testid` to form elements in order to get items quickly during tests and avoid manually adding everytime 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

