### PR TITLE
feat(tests): run integrations tests / e2e env locally without docker

### DIFF
--- a/docker/development/eth-node/.gitignore
+++ b/docker/development/eth-node/.gitignore
@@ -1,2 +1,3 @@
 cache
 .yarn
+networks.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ yarn test --network localhost
 
 ## Add a test
 
-1. Run the The Unlock protocol using docker: `sh ./bin/tests.sh`.
+1. Run the The Unlock protocol on your machine (see the Development section above)
 
 2. Create a file in the `/test` folder with your logic.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,29 +2,45 @@
 
 This folder contains tests to make sure that the different parts of the Unlock Protocol plays nicely together (i.e. contracts, subgraph, server, ui, etc...).
 
-### Run the entire test suite
+## Run the entire test suite
 
 ```
 sh ./bin/tests.sh run
 ```
 
-### Development
+## Development
 
-For development, you will need to first run the docker stack
+For development, you will need to first launch an ETH node, deploy the Unlock contracts and subgraph.
+
+The ETH node [provisioning script](../docker/development/eth-node/scripts/provision.ts) deploy a fresh instance of the Unlock contract, create a few locks and purchase some keys.
+
+### Boostrap e2e env using Docker (for CI)
+
+Run everything containerized (mimick the CI context)
 
 ```
 sh ./bin/tests.sh
 ```
 
+### Boostrap e2e env locally
+
+Run deployment and provisioning from your local machine (usually faster)
+
+```shell
+sh ./bin/tests-local.sh run
+```
+
+### Run the tests
+
 Then run the tests against the local instance of the protocol
 
 ```
-yarn test
+yarn test --network localhost
 ```
 
-#### Add a test
+## Add a test
 
-1. Run the The Unlock protocol using docker: `sh ./bin/tests.sh`. This will deploy a fresh instance of the Unlock contract, create a few locks and purchase some keys -- see the [provisioning script](../docker/development/eth-node/scripts/provision.ts). This will also start a graph node and deploy the Unlock subgraph for testing purposes.
+1. Run the The Unlock protocol using docker: `sh ./bin/tests.sh`.
 
 2. Create a file in the `/test` folder with your logic.
 

--- a/tests/bin/tests-local.sh
+++ b/tests/bin/tests-local.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_ROOT=`pwd`/`dirname "$0"`/../..
+echo "running from: $REPO_ROOT"
+BASE_DOCKER_FOLDER=$REPO_ROOT/docker
+BASE_DOCKER_COMPOSE=$BASE_DOCKER_FOLDER/docker-compose.yml
+DOCKER_COMPOSE_FILE=$BASE_DOCKER_FOLDER/docker-compose.integration.yml
+
+COMPOSE_CONFIG="-f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE"
+
+# Setting the right env var
+export UNLOCK_ENV=test
+
+# clean things up 
+docker-compose $COMPOSE_CONFIG down
+
+# Take db, IPFS, graph and postgres nodes up
+docker-compose $COMPOSE_CONFIG up -d postgres ipfs graph-node eth-node
+
+# # deploy contracts
+cd $REPO_ROOT/docker/development/eth-node
+yarn
+yarn provision --network localhost
+
+# copy the generated subgraph config file
+rm -rf $REPO_ROOT/subgraph/networks.json 
+cp $REPO_ROOT/docker/development/eth-node/networks.json $REPO_ROOT/subgraph/networks.json
+
+# prepare subgraph deployment
+cd $REPO_ROOT/subgraph
+yarn prepare:abis
+yarn codegen
+yarn graph build --network localhost
+
+# now deploy the subgraph
+yarn workspace @unlock-protocol/subgraph run graph create testgraph --node http://localhost:8020/ --version 0.0.1
+yarn graph deploy testgraph --node http://localhost:8020/ --ipfs http://localhost:5001 --version-label 0.0.1 --network localhost

--- a/tests/hardhat.config.ts
+++ b/tests/hardhat.config.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra'
 
 const SUBGRAPH_NETWORKS_CONFIG_PATH = process.env.CI
   ? '/home/unlock/networks.json'
-  : path.join(__dirname, '..', './docker/development/subgraph/networks.json')
+  : path.join(__dirname, '..', './subgraph/networks.json')
 
 const { localhost: subgraphConfig } = fs.readJSONSync(
   SUBGRAPH_NETWORKS_CONFIG_PATH
@@ -28,7 +28,6 @@ const config: HardhatUserConfig = {
     },
     docker: {
       unlockAddress,
-      url: 'http://localhost:8545',
     },
   },
   mocha: {

--- a/tests/test/subgraph.ts
+++ b/tests/test/subgraph.ts
@@ -133,7 +133,7 @@ describe('Upgrade a lock', function () {
   })
 })
 
-describe.only('(v11) key cancellation bug', function () {
+describe('(v11) key cancellation bug', function () {
   let lock: Contract
   let lockAddress: string
   let tokenIds: any

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,6 +3444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hookform/resolvers@npm:2.9.10":
+  version: 2.9.10
+  resolution: "@hookform/resolvers@npm:2.9.10"
+  peerDependencies:
+    react-hook-form: ^7.0.0
+  checksum: ae3395372d6ff11506a72bb6b3c57046bd14b457c2fe1f0485f60cf2dba0ef4484e3a2fb5a0f6a217f6d701393ebc3683a2ede7c81c6f13e71f965f520c7af16
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.6":
   version: 0.11.7
   resolution: "@humanwhocodes/config-array@npm:0.11.7"
@@ -10983,6 +10992,7 @@ __metadata:
     "@babel/core": 7.20.5
     "@babel/plugin-proposal-optional-chaining": 7.18.9
     "@headlessui/react": 1.7.4
+    "@hookform/resolvers": 2.9.10
     "@radix-ui/react-avatar": 1.0.1
     "@sentry/nextjs": 7.24.2
     "@stripe/react-stripe-js": 1.15.0
@@ -24938,7 +24948,7 @@ fsevents@~2.1.1:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 71abe7f31555f169a47510675596f79193c8f55e4beeb4e6efa06c22d41988fa9c747d5e398af7f8401cca22c08ffb7a6d57b03d764c14858513c9eba23b53b8
+  checksum: 7a45a5a606a1e651c891467a693552b5237f8e90410f9c9daad4621ff0693d1c92b69aa35fc30eccf7c3b92ee724f15fc297e054086cfb312717ef01f48d2290
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This adds a script to run the e2e stack (start ETH node + deploy contract and subgraph) without having to dockerify everything. The docker run is useful for CI but can really be very slow to bootstrap. This is a much faster alternative, more suited for local development.

### How to use

```shell
# start the e2e instances
cd tests
sh bin/tests-local.sh

# check if graph works properly (should return 2 locks created during initial provisioning)
curl http://localhost:8000/subgraphs/name/testgraph \
  -X POST \
  -H 'content-type: application/json' \
  --silent --data '{ "query" : "{ locks { address, version }}" }'

# run the (mocha) tests
yarn test --network localhost
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

