### PR TITLE
refactor(unlock-app): Do not skip recipient even with flag on another purchase

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
@@ -593,12 +593,6 @@ export const checkoutMachine = createMachine(
         on: {
           MAKE_ANOTHER_PURCHASE: [
             {
-              target: 'PAYMENT',
-              cond: (ctx) => {
-                return ctx.skipQuantity && ctx.skipRecipient
-              },
-            },
-            {
               target: 'METADATA',
               cond: (ctx) => {
                 return ctx.skipQuantity

--- a/unlock-app/src/utils/paywallConfig.ts
+++ b/unlock-app/src/utils/paywallConfig.ts
@@ -14,8 +14,6 @@ export function getPaywallConfigFromQuery(
       parsedConfig = JSON.parse(decodedConfig)
       parsedConfig.minRecipients = parsedConfig?.minRecipients || 1
       parsedConfig.maxRecipients = parsedConfig?.maxRecipients || 1
-      // by default, set to true
-      parsedConfig.skipRecipient = true
     } catch (e) {
       console.error(
         'paywall config in URL not valid JSON, continuing with undefined'


### PR DESCRIPTION

<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Based on the feedback, we show recipient field when user makes another purchase instead of defaulting to skip. Since most likely, they are buying for a different address. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

