### PR TITLE
fix(unlock-app): Allow purchase when total price is same as balance

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm.tsx
@@ -277,7 +277,7 @@ export function Confirm({
 
       const isTokenPayable =
         pricingData?.total &&
-        parseFloat(pricingData?.total) < parseFloat(balance)
+        parseFloat(pricingData?.total) <= parseFloat(balance)
       const isGasPayable = parseFloat(networkBalance) > 0 // TODO: improve actual calculation (from estimate!). In the meantime, the wallet should warn them!
 
       return {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Found a little bug introduced in warning moved to confirm page. For erc20, it should allow buying if the price and balance are both 0. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

