### PR TITLE
feature(ui): adding a prop to make a modal that's empty

### DIFF
--- a/packages/ui/lib/components/Modal/Modal.tsx
+++ b/packages/ui/lib/components/Modal/Modal.tsx
@@ -5,9 +5,37 @@ interface Props {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   children?: ReactNode
+  empty?: boolean
 }
 
-export function Modal({ isOpen, setIsOpen, children }: Props) {
+export function Modal({ isOpen, setIsOpen, children, empty }: Props) {
+  let content
+  if (empty) {
+    content = (
+      <div className="min-h-screen min-w-full flex flex-col items-center justify-center overflow-auto">
+        {children}
+      </div>
+    )
+  } else {
+    content = (
+      <div className="block p-4 overflow-hidden transition-all transform bg-white border border-gray-100 rounded-lg shadow-xl sm:max-w-lg sm:w-full">
+        <div className="flex items-center justify-end">
+          <button
+            className="hover:fill-brand-ui-primary"
+            aria-label="close"
+            onClick={(event) => {
+              event.preventDefault()
+              setIsOpen(false)
+            }}
+          >
+            <CloseIcon className="fill-inherit" size={24} />
+          </button>
+        </div>
+        {children}
+      </div>
+    )
+  }
+
   return (
     <Transition.Root show={isOpen} as={React.Fragment}>
       <Dialog
@@ -37,21 +65,7 @@ export function Modal({ isOpen, setIsOpen, children }: Props) {
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div className="block p-4 overflow-hidden transition-all transform bg-white border border-gray-100 rounded-lg shadow-xl sm:max-w-lg sm:w-full">
-              <div className="flex items-center justify-end">
-                <button
-                  className="hover:fill-brand-ui-primary"
-                  aria-label="close"
-                  onClick={(event) => {
-                    event.preventDefault()
-                    setIsOpen(false)
-                  }}
-                >
-                  <CloseIcon className="fill-inherit" size={24} />
-                </button>
-              </div>
-              {children}
-            </div>
+            {content}
           </Transition.Child>
         </div>
       </Dialog>


### PR DESCRIPTION
# Description

Using this to create a way to "embed" the Checkout modal on the event landing page.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

