### PR TITLE
feat(checkout): Add expectedAddress option to paywallConfig

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -114,10 +114,11 @@ export function Select({ checkoutService, injectedProvider }: Props) {
   const web3Service = useWeb3Service()
   const expectedAddress = paywallConfig.expectedAddress
 
-  const isNotExpectedAddress =
+  const isNotExpectedAddress = !!(
     account &&
     expectedAddress &&
     expectedAddress.toLowerCase() !== account.toLowerCase()
+  )
 
   const { isInitialLoading: isMembershipsLoading, data: memberships } =
     useQuery(

--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -26,6 +26,7 @@ import { LabeledItem } from '../LabeledItem'
 import * as Avatar from '@radix-ui/react-avatar'
 import { numberOfAvailableKeys } from '~/utils/checkoutLockUtils'
 import { useCheckoutSteps } from './useCheckoutItems'
+import { minifyAddress } from '@unlock-protocol/ui'
 
 interface Props {
   injectedProvider: unknown
@@ -111,6 +112,12 @@ export function Select({ checkoutService, injectedProvider }: Props) {
   const config = useConfig()
   const { account, changeNetwork, isUnlockAccount } = useAuth()
   const web3Service = useWeb3Service()
+  const expectedAddress = paywallConfig.expectedAddress
+
+  const isNotExpectedAddress =
+    account &&
+    expectedAddress &&
+    expectedAddress.toLowerCase() !== account.toLowerCase()
 
   const { isInitialLoading: isMembershipsLoading, data: memberships } =
     useQuery(
@@ -151,7 +158,8 @@ export function Select({ checkoutService, injectedProvider }: Props) {
     isMembershipsLoading ||
     !lock ||
     // if locks are sold out and the user is not an existing member of the lock
-    (lock?.isSoldOut && !(membership?.member || membership?.expired))
+    (lock?.isSoldOut && !(membership?.member || membership?.expired)) ||
+    isNotExpectedAddress
 
   const stepItems = useCheckoutSteps(checkoutService)
 
@@ -342,6 +350,12 @@ export function Select({ checkoutService, injectedProvider }: Props) {
           injectedProvider={injectedProvider}
         >
           <div className="grid">
+            {isNotExpectedAddress && (
+              <p className="mb-2 text-sm text-center">
+                Switch to wallet address {minifyAddress(expectedAddress)} to
+                continue.
+              </p>
+            )}
             <Button
               disabled={isDisabled}
               onClick={async (event) => {

--- a/unlock-app/src/unlockTypes.tsx
+++ b/unlock-app/src/unlockTypes.tsx
@@ -232,6 +232,11 @@ export const PaywallConfigSchema = z
       })
       .default(true)
       .optional(),
+    expectedAddress: z
+      .string({
+        description: 'Expected wallet address for user.',
+      })
+      .optional(),
   })
   .passthrough()
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Fixes https://github.com/unlock-protocol/unlock/issues/10566

![screenshot 2023-01-31 at 17 04 24](https://user-images.githubusercontent.com/73341821/215831860-4ff82bc1-cfea-4cdc-9f54-aa23a4cf447b.png)

We disable continue button when user is not connected with the correct address and show a warning to switch. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

