### PR TITLE
feat(checkout): Wait for 2 confirmation before updating status on mint

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -47,7 +47,9 @@ export function Minting({
           )
 
           const transaction = await provider.waitForTransaction(
-            mint!.transactionHash!
+            mint!.transactionHash!,
+            2,
+            60000
           )
 
           if (transaction.status !== 1) {

--- a/unlock-app/src/components/interface/checkout/main/Renewed.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Renewed.tsx
@@ -46,7 +46,7 @@ export function Renewed({
           const provider = new ethers.providers.JsonRpcProvider(
             network.provider
           )
-          await provider.waitForTransaction(transactionHash)
+          await provider.waitForTransaction(transactionHash, 2, 60000)
           communication?.emitTransactionInfo({
             hash: transactionHash,
             lock: lock?.address,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Waits for secondary confirmation before updating status (by default, it is 1) with a timeout of 1 minute. 

Fixes https://github.com/unlock-protocol/unlock/issues/10510

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

