### PR TITLE
fix(smart-contracts): keep ownership record when a key is cancelled

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -144,8 +144,11 @@ contract MixinKeys is MixinErrors, MixinLockCore {
 
     emit Transfer(_ownerOf[_tokenId], address(0), _tokenId);
 
-    // delete ownership and expire key
+    // expire key
     _cancelKey(_tokenId);
+
+    // delete owner
+    _ownerOf[_tokenId] = address(0);
   }
 
   /**
@@ -367,9 +370,6 @@ contract MixinKeys is MixinErrors, MixinLockCore {
   function _cancelKey(uint _tokenId) internal {
     // expire the key
     _keys[_tokenId].expirationTimestamp = block.timestamp;
-
-    // delete previous owner
-    _ownerOf[_tokenId] = address(0);
   }
 
   /**

--- a/smart-contracts/contracts/mixins/MixinRefunds.sol
+++ b/smart-contracts/contracts/mixins/MixinRefunds.sol
@@ -92,7 +92,7 @@ contract MixinRefunds is
   ) internal {
     address payable keyOwner = payable(ownerOf(_tokenId));
 
-    // delete ownership info and expire the key
+    // expire the key without affecting the ownership record
     _cancelKey(_tokenId);
 
     // emit event

--- a/smart-contracts/test/Lock/cancelAndRefund.js
+++ b/smart-contracts/test/Lock/cancelAndRefund.js
@@ -127,6 +127,10 @@ contract('Lock / cancelAndRefund', (accounts) => {
       const isValid = await lock.getHasValidKey(keyOwners[0])
       assert.equal(isValid, false)
     })
+    
+    it('should retain ownership info', async () => {
+      assert.equal(await lock.ownerOf(tokenIds[0]), keyOwners[0])
+    })
 
     it("should increase the owner's balance with the amount of funds withdrawn from the lock", async () => {
       const txHash = await ethers.provider.getTransaction(txObj.tx)


### PR DESCRIPTION
# Description

This PR modifies the way cancellation works by affecting only the timestamp of the key while keeping the ownership record intact. Previously, we were replacing the key owner address by `address(0)` on cancellation.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #10939 
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

