### PR TITLE
feat(locksmith) - custom email content endpoint

### DIFF
--- a/locksmith/__tests__/controllers/v2/customEmailController.test.ts
+++ b/locksmith/__tests__/controllers/v2/customEmailController.test.ts
@@ -3,8 +3,7 @@ import { loginRandomUser } from '../../test-helpers/utils'
 import app from '../../app'
 import { vi } from 'vitest'
 
-const lockAddress = '0x62ccb13a72e6f991de53b9b7ac42885151588cd2'
-const lockManager = `0x00192fb10df37c9fb26829eb2cc623cd1bf599e8`
+let lockAddress = '0x62ccb13a72e6f991de53b9b7ac42885151588cd2'
 const template = 'keyMinded'
 
 const network = 5
@@ -15,10 +14,7 @@ vi.mock('@unlock-protocol/unlock-js', () => {
     Web3Service: vi.fn().mockImplementation(() => {
       return {
         isLockManager: (lock: string, manager: string) => {
-          return (
-            lockAddress.toLowerCase() === lock.toLowerCase() ||
-            manager === lockManager
-          )
+          return lockAddress.toLowerCase() === lock.toLowerCase()
         },
       }
     }),
@@ -63,11 +59,33 @@ describe('Email Controller v2', () => {
       })
 
     expect(response.status).toBe(200)
-    expect(response.body).toContain('Custom Email Content')
+    expect(response.body.content).toContain('Custom Email Content')
   })
 
-  it('Correctly save and get custom email content saved previously', async () => {
+  it('Get saved details from not lock manager fails', async () => {
     expect.assertions(2)
+    const { loginResponse, address } = await loginRandomUser(app)
+    expect(loginResponse.status).toBe(200)
+
+    // save custom email content
+    await request(app)
+      .post(`/v2/email/${network}/locks/${lockAddress}/custom/${template}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+      .send({
+        content: customEmailContent,
+      })
+
+    // get for non-lock manager should fail
+    lockAddress = address
+    const response = await request(app)
+      .get(`/v2/email/${network}/locks/${lockAddress}/custom/${template}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+
+    expect(response.status).toBe(404)
+  })
+
+  it('Correctly save and get custom email content saved for lock manager', async () => {
+    expect.assertions(3)
     const { loginResponse } = await loginRandomUser(app)
     expect(loginResponse.status).toBe(200)
 
@@ -85,6 +103,6 @@ describe('Email Controller v2', () => {
       .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
 
     expect(response.status).toBe(200)
-    expect(response.body).toContain('Custom Email Content')
+    expect(response.body.content).toContain('Custom Email Content')
   })
 })

--- a/locksmith/__tests__/controllers/v2/customEmailController.test.ts
+++ b/locksmith/__tests__/controllers/v2/customEmailController.test.ts
@@ -1,0 +1,90 @@
+import request from 'supertest'
+import { loginRandomUser } from '../../test-helpers/utils'
+import app from '../../app'
+import { vi } from 'vitest'
+
+const lockAddress = '0x62ccb13a72e6f991de53b9b7ac42885151588cd2'
+const lockManager = `0x00192fb10df37c9fb26829eb2cc623cd1bf599e8`
+const template = 'keyMinded'
+
+const network = 5
+const customEmailContent = `Custom Email Content`
+
+vi.mock('@unlock-protocol/unlock-js', () => {
+  return {
+    Web3Service: vi.fn().mockImplementation(() => {
+      return {
+        isLockManager: (lock: string, manager: string) => {
+          return (
+            lockAddress.toLowerCase() === lock.toLowerCase() ||
+            manager === lockManager
+          )
+        },
+      }
+    }),
+  }
+})
+
+describe('Email Controller v2', () => {
+  it('Save custom email throws an error when is not authenticated', async () => {
+    expect.assertions(2)
+    const { loginResponse } = await loginRandomUser(app)
+    expect(loginResponse.status).toBe(200)
+
+    const response = await request(app).post(
+      `/v2/email/${network}/locks/${lockAddress}/custom/${template}`
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('Get custom email throws an error when is not authenticated', async () => {
+    expect.assertions(2)
+    const { loginResponse } = await loginRandomUser(app)
+    expect(loginResponse.status).toBe(200)
+
+    const response = await request(app).get(
+      `/v2/email/${network}/locks/${lockAddress}/custom/${template}`
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('Correctly save email custom content when user is lock manager', async () => {
+    expect.assertions(3)
+    const { loginResponse } = await loginRandomUser(app)
+    expect(loginResponse.status).toBe(200)
+
+    const response = await request(app)
+      .post(`/v2/email/${network}/locks/${lockAddress}/custom/${template}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+      .send({
+        content: customEmailContent,
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toContain('Custom Email Content')
+  })
+
+  it('Correctly save and get custom email content saved previously', async () => {
+    expect.assertions(2)
+    const { loginResponse } = await loginRandomUser(app)
+    expect(loginResponse.status).toBe(200)
+
+    // save custom content for a specific template
+    await request(app)
+      .post(`/v2/email/${network}/locks/${lockAddress}/custom/${template}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+      .send({
+        content: customEmailContent,
+      })
+
+    // check if the custom content saved is present
+    const response = await request(app)
+      .get(`/v2/email/${network}/locks/${lockAddress}/custom/${template}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+
+    expect(response.status).toBe(200)
+    expect(response.body).toContain('Custom Email Content')
+  })
+})

--- a/locksmith/migrations/20230203140302-custom-email-content.js
+++ b/locksmith/migrations/20230203140302-custom-email-content.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('CustomEmailContents', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      lockAddress: {
+        type: Sequelize.STRING,
+      },
+      network: {
+        type: Sequelize.INTEGER,
+      },
+      template: {
+        type: Sequelize.STRING,
+      },
+      content: {
+        type: Sequelize.STRING,
+        defaultValue: '',
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('CustomEmailContents')
+  },
+}

--- a/locksmith/migrations/20230203140302-custom-email-content.js
+++ b/locksmith/migrations/20230203140302-custom-email-content.js
@@ -23,7 +23,7 @@ module.exports = {
         allowNull: false,
       },
       content: {
-        type: Sequelize.STRING,
+        type: Sequelize.TEXT,
         allowNull: false,
         defaultValue: '',
       },

--- a/locksmith/migrations/20230203140302-custom-email-content.js
+++ b/locksmith/migrations/20230203140302-custom-email-content.js
@@ -12,15 +12,19 @@ module.exports = {
       },
       lockAddress: {
         type: Sequelize.STRING,
+        allowNull: false,
       },
       network: {
         type: Sequelize.INTEGER,
+        allowNull: false,
       },
       template: {
         type: Sequelize.STRING,
+        allowNull: false,
       },
       content: {
         type: Sequelize.STRING,
+        allowNull: false,
         defaultValue: '',
       },
       createdAt: {

--- a/locksmith/src/controllers/v2/customEmailController.ts
+++ b/locksmith/src/controllers/v2/customEmailController.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from 'express'
+import * as z from 'zod'
+import Normalizer from '../../utils/normalizer'
+import logger from '../../logger'
+import { CustomEmailContent } from '../../models/customEmailContent'
+
+const CustomEmail = z.object({
+  content: z
+    .string({
+      description: 'Custom content of the email',
+    })
+    .optional()
+    .default(''),
+})
+
+export class CustomEmailController {
+  async saveCustomContent(request: Request, response: Response) {
+    try {
+      const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
+      const network = Number(request.params.network)
+      const template = request.params.template?.toUpperCase()
+
+      const { content } = await CustomEmail.parseAsync(request.body)
+
+      const [customEmail] = await CustomEmailContent.upsert(
+        {
+          lockAddress,
+          network,
+          content,
+          template,
+        },
+        {
+          returning: true,
+          conflictFields: ['lockAddress'],
+        }
+      )
+      return response.status(200).send(customEmail?.content)
+    } catch (err: any) {
+      console.log(err)
+      logger.error(err.message)
+      return response.status(500).send({
+        message: 'Could not save custom email content.',
+      })
+    }
+  }
+
+  async getCustomContent(request: Request, response: Response) {
+    try {
+      const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
+      const network = Number(request.params.network)
+      const template = request.params.template?.toUpperCase()
+
+      const customEmail = await CustomEmailContent.findOne({
+        where: {
+          lockAddress,
+          network,
+          template,
+        },
+      })
+
+      if (customEmail) {
+        return response.status(200).send(customEmail?.content)
+      }
+      return response.status(404).json({
+        message: 'Custom email content not found for this template.',
+      })
+    } catch (err: any) {
+      logger.error(err.message)
+      return response.status(500).send({
+        message: 'Could get custom email content.',
+      })
+    }
+  }
+}

--- a/locksmith/src/controllers/v2/customEmailController.ts
+++ b/locksmith/src/controllers/v2/customEmailController.ts
@@ -31,12 +31,11 @@ export class CustomEmailController {
         },
         {
           returning: true,
-          conflictFields: ['lockAddress'],
+          conflictFields: ['id'],
         }
       )
-      return response.status(200).send(customEmail?.content)
+      return response.status(200).send(customEmail)
     } catch (err: any) {
-      console.log(err)
       logger.error(err.message)
       return response.status(500).send({
         message: 'Could not save custom email content.',
@@ -59,7 +58,7 @@ export class CustomEmailController {
       })
 
       if (customEmail) {
-        return response.status(200).send(customEmail?.content)
+        return response.status(200).send(customEmail)
       }
       return response.status(404).json({
         message: 'Custom email content not found for this template.',
@@ -67,7 +66,7 @@ export class CustomEmailController {
     } catch (err: any) {
       logger.error(err.message)
       return response.status(500).send({
-        message: 'Could get custom email content.',
+        message: 'Could not get custom email content.',
       })
     }
   }

--- a/locksmith/src/models/customEmailContent.ts
+++ b/locksmith/src/models/customEmailContent.ts
@@ -22,11 +22,9 @@ CustomEmailContent.init(
       autoIncrement: true,
       primaryKey: true,
       type: DataTypes.INTEGER,
-      unique: 'id_unique',
     },
     lockAddress: {
       type: DataTypes.STRING,
-      unique: 'id_unique',
       allowNull: false,
     },
     network: {
@@ -35,9 +33,11 @@ CustomEmailContent.init(
     },
     template: {
       type: DataTypes.STRING,
+      allowNull: false,
     },
     content: {
       type: DataTypes.STRING,
+      allowNull: false,
       defaultValue: '',
     },
     createdAt: {

--- a/locksmith/src/models/customEmailContent.ts
+++ b/locksmith/src/models/customEmailContent.ts
@@ -36,7 +36,7 @@ CustomEmailContent.init(
       allowNull: false,
     },
     content: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       defaultValue: '',
     },

--- a/locksmith/src/models/customEmailContent.ts
+++ b/locksmith/src/models/customEmailContent.ts
@@ -1,0 +1,56 @@
+import type { InferAttributes, InferCreationAttributes } from 'sequelize'
+import { Model, DataTypes, CreationOptional } from 'sequelize'
+import { sequelize } from './sequelize'
+
+export class CustomEmailContent extends Model<
+  InferAttributes<CustomEmailContent>,
+  InferCreationAttributes<CustomEmailContent>
+> {
+  declare id: CreationOptional<number>
+  declare lockAddress: string
+  declare network: number
+  declare template: string
+  declare content?: string
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
+}
+
+CustomEmailContent.init(
+  {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+      unique: 'id_unique',
+    },
+    lockAddress: {
+      type: DataTypes.STRING,
+      unique: 'id_unique',
+      allowNull: false,
+    },
+    network: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    template: {
+      type: DataTypes.STRING,
+    },
+    content: {
+      type: DataTypes.STRING,
+      defaultValue: '',
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'CustomEmailContents',
+  }
+)

--- a/locksmith/src/routes/index.ts
+++ b/locksmith/src/routes/index.ts
@@ -27,6 +27,7 @@ import imagesRouter from './v2/images'
 import transferRouter from './v2/transfer'
 import receiptRouter from './v2/receipt'
 import receiptBaseRouter from './v2/receiptBase'
+import emailRouter from './v2/email'
 import config from '../config/config'
 
 const router = express.Router({ mergeParams: true })
@@ -72,6 +73,7 @@ router.use('/v2/claim', claimV2Router)
 router.use('/v2/transfer', transferRouter)
 router.use('/v2/receipts', receiptRouter)
 router.use('/v2/receipts-base', receiptBaseRouter)
+router.use('/v2/email', emailRouter)
 
 router.use('/', (_, res) => {
   res.send('<a href="https://unlock-protocol.com/">Unlock Protocol</a>')

--- a/locksmith/src/routes/v2/email.ts
+++ b/locksmith/src/routes/v2/email.ts
@@ -1,0 +1,28 @@
+import express from 'express'
+import { CustomEmailController } from '../../controllers/v2/customEmailController'
+import { authenticatedMiddleware } from '../../utils/middlewares/auth'
+import { lockManagerMiddleware } from '../../utils/middlewares/lockManager'
+
+const router = express.Router({ mergeParams: true })
+
+const customEmailController = new CustomEmailController()
+
+router.post(
+  '/:network/locks/:lockAddress/custom/:template',
+  authenticatedMiddleware,
+  lockManagerMiddleware,
+  (req, res) => {
+    customEmailController.saveCustomContent(req, res)
+  }
+)
+
+router.get(
+  '/:network/locks/:lockAddress/custom/:template',
+  authenticatedMiddleware,
+  lockManagerMiddleware,
+  (req, res) => {
+    customEmailController.getCustomContent(req, res)
+  }
+)
+
+export default router

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -399,6 +399,14 @@ components:
       schema:
         type: string
 
+    TemplateId:
+      in: path
+      name: template
+      required: true
+      description: Template id for email
+      schema:
+        type: string
+
   responses:
     200.GenericSuccess:
       description: 'Successfully completed the request.'
@@ -2057,6 +2065,92 @@ paths:
 
         500:
           description: Failed to update or create supplier details.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - 'message'
+                properties:
+                  message:
+                    type: string
+        401:
+          $ref: '#/components/responses/401.NotAuthenticated'
+
+  /v2/email/{network}/locks/{lockAddress}/custom/{template}:
+    get:
+      operationId: getCustomEmailContent
+      security:
+        - User: []
+      description: Get custom email content for a specific template and lock details
+      parameters:
+        - $ref: '#/components/parameters/Network'
+        - $ref: '#/components/parameters/LockAddress'
+        - $ref: '#/components/parameters/TemplateId'
+
+      responses:
+        200:
+          description: Successfully get custom template content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lockAddress:
+                    type: string
+                  network:
+                    type: number
+                  template:
+                    type: string
+                  content:
+                    type: string
+
+        500:
+          description: Could not get custom email content.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - 'message'
+                properties:
+                  message:
+                    type: string
+        401:
+          $ref: '#/components/responses/401.NotAuthenticated'
+
+        404:
+          description: Custom email content not found for this template.
+
+    post:
+      operationId: saveCustomEmailContent
+      security:
+        - User: []
+      description: Save custom email content for a specif lock.
+      parameters:
+        - $ref: '#/components/parameters/Network'
+        - $ref: '#/components/parameters/LockAddress'
+        - $ref: '#/components/parameters/TemplateId'
+
+      responses:
+        200:
+          description: Custom email content successfully saved.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lockAddress:
+                    type: string
+                  network:
+                    type: number
+                  template:
+                    type: string
+                  content:
+                    type: string
+
+        500:
+          description: Could not save custom email content.
           content:
             application/json:
               schema:


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Add news endpoints to save/get custom email content that will be added to the current email template we already have. 

- [x] endpoint to `save/get` custom email content
- [x] test for controllers
- [x] add definition in `openapi` file

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

