### PR TITLE
fix(subgraph): Update owner after key cancellation

### DIFF
--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -205,6 +205,7 @@ export function handleCancelKey(event: CancelKeyEvent): void {
   const keyID = genKeyID(event.address, event.params.tokenId.toString())
   const key = Key.load(keyID)
   const fallbackTimestamp = event.block.timestamp
+  const lockContract = PublicLock.bind(event.address)
   if (key) {
     // Due to a bug in v11, we need to check the version of the lock and fallback to the timestamp since expiration can be for a different key
     const lock = Lock.load(key.lock)
@@ -217,6 +218,8 @@ export function handleCancelKey(event: CancelKeyEvent): void {
         Address.fromBytes(key.owner)
       )
     }
+    const owner = lockContract.ownerOf(key.tokenId)
+    key.owner = owner
     key.cancelled = true
     key.save()
   }

--- a/subgraph/tests/keys.test.ts
+++ b/subgraph/tests/keys.test.ts
@@ -355,7 +355,7 @@ describe('Cancel keys', () => {
     const newCancelKey = createCancelKeyEvent(BigInt.fromU32(tokenId))
     handleCancelKey(newCancelKey)
     assert.fieldEquals('Key', keyID, 'cancelled', 'true')
-
+    assert.fieldEquals('Key', keyID, 'owner', nullAddress)
     dataSourceMock.resetValues()
   })
 })

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -157,7 +157,7 @@ createMockedFunction(
   .returns([ethereum.Value.fromString('My lock v8')])
 
 createMockedFunction(
-    Address.fromString(lockAddressV8),
+  Address.fromString(lockAddressV8),
   'tokenAddress',
   'tokenAddress():(address)'
 )
@@ -205,3 +205,15 @@ createMockedFunction(
     ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(0)),
   ])
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(tokenId))])
+
+createMockedFunction(
+  Address.fromString(lockAddress),
+  'ownerOf',
+  'ownerOf(uint256):(address)'
+)
+  .withArgs([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(tokenId))])
+  .returns([
+    ethereum.Value.fromAddress(
+      Address.fromString('0x0000000000000000000000000000000000000000')
+    ),
+  ])


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Updates owner after key cancellation since we reset it to null address but this isn't reflected in the graph right now. 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

