### PR TITLE
fix(smart-contracts): `getBalance` test helper default to use ethersjs

### DIFF
--- a/smart-contracts/test/helpers/getTokenBalance.js
+++ b/smart-contracts/test/helpers/getTokenBalance.js
@@ -2,18 +2,26 @@ const { ethers } = require('hardhat')
 const BigNumber = require('bignumber.js')
 const { ADDRESS_ZERO } = require('./constants')
 
-const Erc20Token = artifacts.require(
-  '@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20'
-)
 
-module.exports = async function getTokenBalance(account, tokenAddress) {
+async function getBalance(account, tokenAddress) {
+  const balance  = await getBalanceEthers(account, tokenAddress)
+  return new BigNumber(balance.toString())
+}
+
+async function getBalanceEthers(account, tokenAddress) {
+  let balance
   // ETH balance
   if (!tokenAddress || tokenAddress === ADDRESS_ZERO) {
-    const balanceETH = await ethers.provider.getBalance(account)
-    return new BigNumber(balanceETH.toString())
+    balance = await ethers.provider.getBalance(account)
+  } else {
+    // erc20 balance
+    const token = await ethers.getContractAt('@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20', tokenAddress)
+    balance = await token.balanceOf(account)
   }
-  // erc20 balance
-  const token = await Erc20Token.at(tokenAddress)
-  const balance = await token.balanceOf(account)
-  return new BigNumber(balance.toString())
+  return balance
+}
+
+module.exports = {
+  getBalance,
+  getBalanceEthers,
 }

--- a/smart-contracts/test/helpers/index.js
+++ b/smart-contracts/test/helpers/index.js
@@ -15,8 +15,8 @@ const math = require('./math')
 const fork = require('./fork')
 
 module.exports = {
-  getBalance,
   deployContracts,
+  ...getBalance,
   ...lock,
   ...constants,
   ...deployLocks,


### PR DESCRIPTION
# Description

Add support for ethersjs `BigNumber` to the `getBalance` test helper

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

