### PR TITLE
fix(unlock-app) removing the prompt to switch network when loading the page to manage…

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -306,7 +306,7 @@ const NotManagerBanner = () => {
 }
 
 export const ManageLockPage = () => {
-  const { network: walletNetwork, changeNetwork, account: owner } = useAuth()
+  const { account: owner } = useAuth()
   const { query } = useRouter()
   const [loading, setLoading] = useState(false)
   const [network, setNetwork] = useState<string>(
@@ -319,28 +319,14 @@ export const ManageLockPage = () => {
 
   const lockNetwork = network ? parseInt(network as string) : undefined
 
-  // let's force to switch network based on the lockAddress
-  const switchToCurrentNetwork = async () => {
-    if (!lockNetwork) return
-    const differentNetwork = walletNetwork != parseInt(`${lockNetwork}`)
-
-    if (differentNetwork) {
-      await changeNetwork(parseInt(`${network}`))
-    }
-  }
-
   const withoutParams = !lockAddress && !lockNetwork
 
   const { isManager, isLoading: isLoadingLockManager } = useLockManager({
     lockAddress,
-    network: walletNetwork!,
+    network: lockNetwork!,
   })
 
   const showNotManagerBanner = !isLoadingLockManager && !isManager
-
-  useEffect(() => {
-    switchToCurrentNetwork()
-  }, [])
 
   const [filters, setFilters] = useState({
     query: '',
@@ -348,10 +334,6 @@ export const ManageLockPage = () => {
     expiration: ExpirationStatus.ALL,
   })
   const [page, setPage] = useState(1)
-
-  if (!walletNetwork) {
-    return <ConnectWalletModal isOpen={true} setIsOpen={() => void 0} />
-  }
 
   const toggleAirdropKeys = () => {
     setAirdropKeys(!airdropKeys)


### PR DESCRIPTION
# Description

We don't need to worry about the user's network until they perform a transaction.
This will be merged once @searchableguy adds the ability to check the network before sending transactions!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

