### PR TITLE
fix(locksmith): lock managers and key owners can generate QR code

### DIFF
--- a/locksmith/src/controllers/v2/ticketsController.tsx
+++ b/locksmith/src/controllers/v2/ticketsController.tsx
@@ -34,6 +34,7 @@ export class TicketsController {
     )
     response.status(200).send({ payload, signature })
   }
+
   /**
    * This will mark a ticket as check-in, this operation is only allowed for a lock verifier of a lock manager
    * @param {Request} request

--- a/locksmith/src/routes/v2/ticket.ts
+++ b/locksmith/src/routes/v2/ticket.ts
@@ -5,13 +5,11 @@ import {
   generateTicket,
 } from '../../controllers/v2/ticketsController'
 import { keyOwnerMiddleware } from '../../utils/middlewares/keyOwnerMiddleware'
-import {
-  authenticatedMiddleware,
-  applicationOnlyMiddleware,
-} from '../../utils/middlewares/auth'
+import { authenticatedMiddleware } from '../../utils/middlewares/auth'
 import { isVerifierMiddleware } from '../../utils/middlewares/isVerifierMiddleware'
 import { Web3Service } from '@unlock-protocol/unlock-js'
 import { lockManagerMiddleware } from './../../utils/middlewares/lockManager'
+import { lockManagerOrKeyOwnerMiddleware } from '../../utils/middlewares/lockManagerOrKeyOwner'
 
 const router = express.Router({ mergeParams: true })
 
@@ -48,8 +46,7 @@ router.post(
 router.get(
   '/:network/:lockAddress/:keyId/qr',
   authenticatedMiddleware,
-  applicationOnlyMiddleware,
-  lockManagerMiddleware,
+  lockManagerOrKeyOwnerMiddleware,
   (req, res) => {
     ticketsController.getQrCode(req, res)
   }

--- a/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
+++ b/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
@@ -1,0 +1,46 @@
+import { RequestHandler } from 'express'
+import networks from '@unlock-protocol/networks'
+import { Web3Service } from '@unlock-protocol/unlock-js'
+import Normalizer from '../normalizer'
+
+export const lockManagerOrKeyOwnerMiddleware: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  const lockAddress = Normalizer.ethereumAddress(req.params.lockAddress)
+  const network = Number(req.params.network)
+  const userAddress = Normalizer.ethereumAddress(req.user!.walletAddress!)
+  const tokenId = req.params.keyId.toLowerCase()
+
+  if (!lockAddress) {
+    return res.status(404).send({
+      message: 'Missing lock Address',
+    })
+  }
+
+  if (!network) {
+    return res.status(404).send({
+      message: 'Missing network',
+    })
+  }
+
+  const web3Service = new Web3Service(networks)
+
+  const isLockManager = await web3Service.isLockManager(
+    lockAddress,
+    userAddress,
+    network
+  )
+
+  const keyOwner = Normalizer.ethereumAddress(
+    await web3Service.ownerOf(lockAddress, tokenId, network)
+  )
+
+  if (!isLockManager && keyOwner !== userAddress) {
+    return res.status(401).send({
+      message: `${userAddress} is not a lock manager or the key owner of ${tokenId} for ${lockAddress} on ${network}`,
+    })
+  }
+  return next()
+}

--- a/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
+++ b/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
@@ -10,7 +10,7 @@ export const lockManagerOrKeyOwnerMiddleware: RequestHandler = async (
 ) => {
   const lockAddress = Normalizer.ethereumAddress(req.params.lockAddress)
   const network = Number(req.params.network)
-  const userAddress = Normalizer.ethereumAddress(req.user!.walletAddress!)
+  const userAddress = req.user!.walletAddress
   const tokenId = req.params.keyId.toLowerCase()
 
   if (!lockAddress) {

--- a/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
+++ b/locksmith/src/utils/middlewares/lockManagerOrKeyOwner.ts
@@ -27,17 +27,12 @@ export const lockManagerOrKeyOwnerMiddleware: RequestHandler = async (
 
   const web3Service = new Web3Service(networks)
 
-  const isLockManager = await web3Service.isLockManager(
-    lockAddress,
-    userAddress,
-    network
-  )
+  const [isLockManager, keyOwner] = await Promise.all([
+    web3Service.isLockManager(lockAddress, userAddress, network),
+    web3Service.ownerOf(lockAddress, tokenId, network),
+  ])
 
-  const keyOwner = Normalizer.ethereumAddress(
-    await web3Service.ownerOf(lockAddress, tokenId, network)
-  )
-
-  if (!isLockManager && keyOwner !== userAddress) {
+  if (!isLockManager && Normalizer.ethereumAddress(keyOwner) !== userAddress) {
     return res.status(401).send({
       message: `${userAddress} is not a lock manager or the key owner of ${tokenId} for ${lockAddress} on ${network}`,
     })

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -949,7 +949,7 @@ paths:
     get:
       operationId: ticketQRCode
       security:
-        - Application: ['lockManager']
+        - User: ['user', 'lockManager']
       description: Get QR code for the key.
       parameters:
         - $ref: '#/components/parameters/Network'


### PR DESCRIPTION
# Description

A key owner and the lock manager should both be able to generate a QR code.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

