### PR TITLE
fix(locksmith): getRequestURL does not work properly due to proxy

### DIFF
--- a/locksmith/src/app.ts
+++ b/locksmith/src/app.ts
@@ -10,6 +10,9 @@ import router from './routes'
 
 const app = express()
 
+// Enable proxy support
+app.enable('trust proxy')
+
 // Enable extended query parser
 app.set('query parser', 'extended')
 

--- a/locksmith/src/utils/normalizer.ts
+++ b/locksmith/src/utils/normalizer.ts
@@ -23,12 +23,16 @@ export const getValidNumber = (value: string | number): number | undefined => {
 }
 
 export const url = (value: string) => {
-  const trimmed = value.trim()
+  const trimmed = value.toLowerCase().trim()
   return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
 }
 
 export const getRequestURL = (req: Request) => {
-  return new URL(req.path, `${req.protocol}://${req.get('host')}`)
+  const requestURL = new URL(
+    req.originalUrl,
+    `${req.protocol}://${req.get('host')}`
+  )
+  return requestURL
 }
 
 export default {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Protocol is incorrect because application runs behind a proxy. This option enables express to find the correct req.protocol from heroku proxy (http instead of https)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

