### PR TITLE
feat(ui) - detail component more flexible

### DIFF
--- a/packages/ui/lib/components/Detail/Detail.tsx
+++ b/packages/ui/lib/components/Detail/Detail.tsx
@@ -2,8 +2,10 @@ import { Tooltip } from '../Tooltip/Tooltip'
 import { Size, SizeStyleProp } from '~/types'
 import { Placeholder } from '../Placeholder'
 import { classed } from '@tw-classed/react'
+import { BaseHTMLAttributes } from 'react'
 
-export interface DetailProps {
+export interface DetailProps
+  extends Omit<BaseHTMLAttributes<HTMLInputElement>, 'size' | 'children'> {
   label: React.ReactNode
   children?: React.ReactNode
   loading?: boolean
@@ -12,7 +14,24 @@ export interface DetailProps {
   valueSize?: Size
   truncate?: boolean
   tooltip?: boolean
+  justify?: boolean
 }
+
+const Wrapper = classed.div('flex gap-1', {
+  variants: {
+    inline: {
+      false: 'flex-col',
+      true: 'md:items-center',
+    },
+    justify: {
+      true: 'justify-between',
+    },
+  },
+  defaultVariants: {
+    inline: false,
+    justify: true,
+  },
+})
 
 const Label = classed.span('relative text-gray-700', {
   variants: {
@@ -54,6 +73,8 @@ export const Detail = ({
   inline = false,
   truncate = false,
   tooltip = false,
+  justify = true,
+  className,
 }: DetailProps) => {
   const SizeMapping: SizeStyleProp = {
     tiny: 'sm',
@@ -65,10 +86,8 @@ export const Detail = ({
   const placeHolderSize = SizeMapping?.[valueSize] ?? 'md'
 
   return (
-    <div className={`flex ${inline ? 'justify-between' : 'flex-col gap-1'}`}>
-      <div className="flex items-center gap-1">
-        <Label size={labelSize}>{label}</Label>
-      </div>
+    <Wrapper inline={inline} justify={justify} className={className}>
+      <Label size={labelSize}>{label}</Label>
       {loading ? (
         <Placeholder.Line
           size={placeHolderSize as any}
@@ -78,21 +97,24 @@ export const Detail = ({
             maxWidth: '150px',
           }}
         />
-      ) : typeof label === 'string' && tooltip ? (
-        <Tooltip tip={children} label={label} side="bottom">
+      ) : (
+        children &&
+        (typeof label === 'string' && tooltip ? (
+          <Tooltip tip={children} label={label} side="bottom">
+            <div className="flex items-center gap-2 text-right">
+              <Value truncate={truncate} size={valueSize}>
+                {children}
+              </Value>
+            </div>
+          </Tooltip>
+        ) : (
           <div className="flex items-center gap-2 text-right">
             <Value truncate={truncate} size={valueSize}>
-              {children ?? '-'}
+              {children}
             </Value>
           </div>
-        </Tooltip>
-      ) : (
-        <div className="flex items-center gap-2 text-right">
-          <Value truncate={truncate} size={valueSize}>
-            {children ?? '-'}
-          </Value>
-        </div>
+        ))
       )}
-    </div>
+    </Wrapper>
   )
 }

--- a/packages/ui/lib/components/Detail/Detail.tsx
+++ b/packages/ui/lib/components/Detail/Detail.tsx
@@ -5,7 +5,7 @@ import { classed } from '@tw-classed/react'
 import { BaseHTMLAttributes } from 'react'
 
 export interface DetailProps
-  extends Pick<BaseHTMLAttributes<HTMLInputElement>, 'className'> {
+  extends Pick<BaseHTMLAttributes<HTMLDivElement>, 'className'> {
   label: React.ReactNode
   children?: React.ReactNode
   loading?: boolean

--- a/packages/ui/lib/components/Detail/Detail.tsx
+++ b/packages/ui/lib/components/Detail/Detail.tsx
@@ -5,7 +5,7 @@ import { classed } from '@tw-classed/react'
 import { BaseHTMLAttributes } from 'react'
 
 export interface DetailProps
-  extends Omit<BaseHTMLAttributes<HTMLInputElement>, 'size' | 'children'> {
+  extends Pick<BaseHTMLAttributes<HTMLInputElement>, 'className'> {
   label: React.ReactNode
   children?: React.ReactNode
   loading?: boolean


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- [x] Show children only when present
- [x] Make wrapper more flexible and use `@tw-classed` for it
- [x] add support for custom `className`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

