### PR TITLE
fix(smart-contracts): prevent referrer fee from being sent to address zero

### DIFF
--- a/smart-contracts/contracts/mixins/MixinPurchase.sol
+++ b/smart-contracts/contracts/mixins/MixinPurchase.sol
@@ -86,21 +86,23 @@ contract MixinPurchase is
   @dev internal function to execute the payments to referrers if any is set
   */
   function _payReferrer(address _referrer) internal {
-    // get default value
-    uint basisPointsToPay = referrerFees[address(0)];
+    if(_referrer != address(0)) {
+      // get default value
+      uint basisPointsToPay = referrerFees[address(0)];
 
-    // get value for the referrer
-    if (referrerFees[_referrer] != 0) {
-      basisPointsToPay = referrerFees[_referrer];
-    }
+      // get value for the referrer
+      if (referrerFees[_referrer] != 0) {
+        basisPointsToPay = referrerFees[_referrer];
+      }
 
-    // pay the referrer if necessary
-    if (basisPointsToPay != 0) {
-      _transfer(
-        tokenAddress,
-        payable(_referrer),
-        (keyPrice * basisPointsToPay) / BASIS_POINTS_DEN
-      );
+      // pay the referrer if necessary
+      if (basisPointsToPay != 0) {
+        _transfer(
+          tokenAddress,
+          payable(_referrer),
+          (keyPrice * basisPointsToPay) / BASIS_POINTS_DEN
+        );
+      }
     }
   }
 


### PR DESCRIPTION
# Description

That prevents purchase tx from reverting when a general fee is set but no referrer is specified in the purchase call 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #10650
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

