### PR TITLE
fix(smart-contracts): parse ProxyAdmin address directly from contract storage

### DIFF
--- a/smart-contracts/test/Lock/purchaseWithoutUnlock.js
+++ b/smart-contracts/test/Lock/purchaseWithoutUnlock.js
@@ -1,9 +1,8 @@
-const { ethers, network } = require('hardhat')
-const { Manifest } = require('@openzeppelin/upgrades-core')
+const { ethers } = require('hardhat')
 const ProxyAdmin = require('@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json')
 
 const createLockHash = require('../helpers/createLockCalldata')
-const { ADDRESS_ZERO, deployContracts } = require('../helpers')
+const { ADDRESS_ZERO, deployContracts, getProxyAdminAddress } = require('../helpers')
 
 const keyPrice = ethers.utils.parseEther('0.01')
 let pastImpl
@@ -34,15 +33,14 @@ contract('Lock / purchaseWithoutUnlock', () => {
     await broken.deployTransaction.wait()
     brokenImpl = broken.address
 
-    // parse OZ manifest to get proxyAdmin address
-    const manifestParser = await Manifest.forNetwork(network.provider)
-    const { admin } = await manifestParser.read()
+    // get proxyAdmin address
+    const proxyAdminAddress = await getProxyAdminAddress(unlock.address)
 
     // upgrade proxy to broken contract
     const [unlockOwner] = await ethers.getSigners()
     proxyAdmin = await ethers.getContractAt(
       ProxyAdmin.abi,
-      admin.address,
+      proxyAdminAddress,
       unlockOwner
     )
   })

--- a/smart-contracts/test/Lock/purchaseWithoutUnlock.js
+++ b/smart-contracts/test/Lock/purchaseWithoutUnlock.js
@@ -2,9 +2,8 @@ const { ethers, network } = require('hardhat')
 const { Manifest } = require('@openzeppelin/upgrades-core')
 const ProxyAdmin = require('@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol/ProxyAdmin.json')
 
-const deployContracts = require('../fixtures/deploy')
 const createLockHash = require('../helpers/createLockCalldata')
-const { ADDRESS_ZERO } = require('../helpers/constants')
+const { ADDRESS_ZERO, deployContracts } = require('../helpers')
 
 const keyPrice = ethers.utils.parseEther('0.01')
 let pastImpl
@@ -27,6 +26,8 @@ contract('Lock / purchaseWithoutUnlock', () => {
 
   // setup proxy admin etc
   before(async () => {
+    ;({ unlockEthers: unlock } = await deployContracts())
+
     // deploy a random contract to break Unlock implementation
     const BrokenUnlock = await ethers.getContractFactory('LockSerializer')
     const broken = await BrokenUnlock.deploy()
@@ -44,9 +45,6 @@ contract('Lock / purchaseWithoutUnlock', () => {
       admin.address,
       unlockOwner
     )
-
-    const deployments = await deployContracts()
-    unlock = deployments.unlockEthers
   })
 
   describe('purchase with a lock while Unlock is broken', () => {

--- a/smart-contracts/test/helpers/index.js
+++ b/smart-contracts/test/helpers/index.js
@@ -14,6 +14,7 @@ const uniswapV3 = require('./uniswapV3')
 const math = require('./math')
 const fork = require('./fork')
 const roles = require('./roles')
+const upgrades = require('./upgrades')
 
 module.exports = {
   deployContracts,
@@ -32,4 +33,5 @@ module.exports = {
   ...math,
   ...fork,
   ...roles,
+  ...upgrades,
 }

--- a/smart-contracts/test/helpers/upgrades.js
+++ b/smart-contracts/test/helpers/upgrades.js
@@ -1,0 +1,19 @@
+const { ethers } = require('hardhat')
+
+// as per OZ EIP1967 Proxy implementation, this is the keccak-256 hash 
+// of "eip1967.proxy.admin" subtracted by 1
+const ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+
+// get proxy admin address from storage 
+async function getProxyAdminAddress(contractAddress) {
+
+  const hex = await ethers.provider.getStorageAt(
+    contractAddress,
+    ADMIN_SLOT
+  )
+  return ethers.utils.hexStripZeros(hex)
+}
+
+module.exports = {
+ getProxyAdminAddress 
+}


### PR DESCRIPTION
# Description

This fixes a bug in `purchaseWithoutUnlock` test where OZ manifest parsing failes when trying to get the proxy admin address. Therefore this replaces the logic to parse ProxyAdmin address directly from contract storage 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

