### PR TITLE
feat(networks): export networks package as module

### DIFF
--- a/packages/networks/package.json
+++ b/packages/networks/package.json
@@ -2,13 +2,20 @@
   "name": "@unlock-protocol/networks",
   "version": "0.0.9",
   "main": "dist/index.js",
+  "module" : "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "description": "Unlock Protocol's contract addressess for various networks",
   "scripts": {
     "start": "tsc --watch",
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --resolve-plugins-relative-to ../eslint-config --ext .tsx,.ts,.js src/",
-    "build": "tsc",
+    "build": "tsup src/index.ts --dts --format esm,cjs",
     "clean": "rm -rf ./dist",
     "prepublish": "yarn build",
     "doc": "node ./bin/doc.js",
@@ -23,6 +30,7 @@
     "@unlock-protocol/tsconfig": "workspace:^",
     "@unlock-protocol/types": "workspace:^",
     "eslint": "8.35.0",
+    "tsup": "6.6.3",
     "typescript": "4.9.5"
   },
   "files": [

--- a/packages/networks/package.json
+++ b/packages/networks/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@unlock-protocol/networks",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "dist/index.js",
-  "module" : "dist/index.mjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14638,6 +14638,7 @@ __metadata:
     "@unlock-protocol/tsconfig": "workspace:^"
     "@unlock-protocol/types": "workspace:^"
     eslint: 8.35.0
+    tsup: 6.6.3
     typescript: 4.9.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

This adds tsup to build networks package so we can have both es6 module and require patterns.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

