### PR TITLE
fix(unlock-app): do not show an error message

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -149,9 +149,8 @@ export const useProvider = (config: any) => {
       }
     } catch (error: any) {
       if (error.message.startsWith('Missing config')) {
-        ToastHelper.error(
-          `Unlock is currently not deployed on this network. Please switch network and refresh the page: ${error.message}`
-        )
+        // We actually do not care :D
+        // The user will be promped to switch networks when they perform a transaction
       } else if (error.message.includes('could not detect network')) {
         ToastHelper.error(
           'We could not detect the network to which your wallet is connected. Please try another wallet. (This issue happens often with the Frame Wallet)' // TODO: remove when Frame is fixed


### PR DESCRIPTION
# Description

We do not show an error message if the user is connected to a network that we are not supporting since we will ask the user to switch networks when it is time for them to send a transaction.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

