### PR TITLE
fix(unlock-app): We should not fail when the user is connected to a network on which u…

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -28,7 +28,7 @@ export const useProvider = (config: any) => {
   const [openConnectModal, setOpenConnectModal] = useState(false)
   const [loading, setLoading] = useState(false)
   const [walletService, setWalletService] = useState<any>()
-  const [network, setNetwork] = useState<string | undefined>(undefined)
+  const [network, setNetwork] = useState<number | undefined>(undefined)
   const [account, setAccount] = useState<string | undefined>(undefined)
   const [email, setEmail] = useState<string | undefined>(undefined)
   const [isUnlockAccount, setIsUnlockAccount] = useState<boolean>(false)

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -50,7 +50,13 @@ export const useProvider = (config: any) => {
 
   const createWalletService = async (provider: any) => {
     const _walletService = new WalletService(config.networks)
-    const _network = await _walletService.connect(provider)
+    let _network = 1 // default
+    try {
+      _network = await _walletService.connect(provider)
+    } catch (error) {
+      console.log(error)
+    }
+
     const _account = await _walletService.getAccount()
     return {
       walletService: _walletService,

--- a/yarn.lock
+++ b/yarn.lock
@@ -27753,7 +27753,7 @@ __metadata:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 7a45a5a606a1e651c891467a693552b5237f8e90410f9c9daad4621ff0693d1c92b69aa35fc30eccf7c3b92ee724f15fc297e054086cfb312717ef01f48d2290
+  checksum: 71abe7f31555f169a47510675596f79193c8f55e4beeb4e6efa06c22d41988fa9c747d5e398af7f8401cca22c08ffb7a6d57b03d764c14858513c9eba23b53b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

We should not fail when the user is connected to a network on which Unlock is not deployed.
The app will ask the user to switch network when they want/need to send a transaction.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

