### PR TITLE
fix(unlock-app) : unlimited memberships can still be soulbound

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingTerms.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingTerms.tsx
@@ -45,9 +45,9 @@ export const SettingTerms = ({
           network={network}
           isManager={isManager}
           disabled={!isManager}
+          unlimitedDuration={unlimitedDuration}
         />
       ),
-      active: !unlimitedDuration,
     },
     {
       label: 'Duration',

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
@@ -11,6 +11,7 @@ interface UpdateTransferFeeProps {
   network: number
   isManager: boolean
   disabled: boolean
+  unlimitedDuration: boolean
 }
 
 interface FormProps {
@@ -22,6 +23,7 @@ export const UpdateTransferFee = ({
   network,
   isManager,
   disabled,
+  unlimitedDuration,
 }: UpdateTransferFeeProps) => {
   const web3Service = useWeb3Service()
   const { getWalletService } = useAuth()
@@ -107,7 +109,7 @@ export const UpdateTransferFee = ({
         }
         disabled={disabledInput}
       />
-      {allowTransfer && (
+      {allowTransfer && !unlimitedDuration && (
         <>
           <Input
             label="Transfer fee (%)"


### PR DESCRIPTION
# Description

Fixing a bug where unlimited memberships could not be made soulbound.
They just can't have fees on transfers...


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

