### PR TITLE
fix(keychain): Remove use of window.open and use static image url

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -130,10 +130,6 @@ export function Minting({
 
   const stepItems = useCheckoutSteps(checkoutService)
 
-  const tokenImage = `${config.services.storage.host}/lock/${
-    lock!.address
-  }/icon?id=${tokenId}`
-
   const hasTokenId = !!tokenId
 
   return (
@@ -195,10 +191,9 @@ export function Minting({
                     network={lock!.network}
                     lockAddress={lock!.address}
                     tokenId={tokenId}
-                    image={tokenImage}
                     name={lock!.name}
                     handlePassUrl={(url: string) => {
-                      window.open(url, '_')
+                      window.location.assign(url)
                     }}
                   >
                     Add to Google Wallet
@@ -225,10 +220,9 @@ export function Minting({
                     network={lock!.network}
                     lockAddress={lock!.address}
                     tokenId={tokenId}
-                    image={tokenImage}
                     name={lock!.name}
                     handlePassUrl={(url: string) => {
-                      window.open(url, '_')
+                      window.location.assign(url)
                     }}
                   >
                     Add to Apple Wallet

--- a/unlock-app/src/components/interface/checkout/main/Returning.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Returning.tsx
@@ -89,10 +89,6 @@ export function Returning({
     }
   )
 
-  const tokenImage = `${config.services.storage.host}/lock/${
-    lock!.address
-  }/icon?id=${tokenId}`
-
   return (
     <Fragment>
       <Stepper position={2} service={checkoutService} items={stepItems} />
@@ -137,10 +133,9 @@ export function Returning({
                     network={lock!.network}
                     lockAddress={lock!.address}
                     tokenId={tokenId}
-                    image={tokenImage}
                     name={lock!.name}
                     handlePassUrl={(url: string) => {
-                      window.open(url, '_')
+                      window.location.assign(url)
                     }}
                   >
                     Add to Google Wallet
@@ -167,10 +162,9 @@ export function Returning({
                     network={lock!.network}
                     lockAddress={lock!.address}
                     tokenId={tokenId}
-                    image={tokenImage}
                     name={lock!.name}
                     handlePassUrl={(url: string) => {
-                      window.open(url, '_')
+                      window.location.assign(url)
                     }}
                   >
                     Add to Apple Wallet

--- a/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
+++ b/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
@@ -4,6 +4,7 @@ import { createWalletPass, Platform } from '../../../services/ethpass'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import { WalletService } from '@unlock-protocol/unlock-js'
+import { config as AppConfig } from '~/config/app'
 
 const addToPhoneWallet = async (
   walletService: WalletService,
@@ -74,7 +75,6 @@ interface AddToWalletProps {
   network: number
   lockAddress: string
   tokenId: string
-  image: string
   platform: Platform
   handlePassUrl: (url: string) => void
   disabled?: boolean
@@ -92,14 +92,13 @@ export const AddToDeviceWallet = ({
   lockAddress,
   tokenId,
   network,
-  image,
   name,
   handlePassUrl,
   platform,
   ...rest
 }: AddToWalletProps) => {
   const { getWalletService } = useAuth()
-
+  const image = `${AppConfig.services.storage.host}/image/${network}/${lockAddress}/${tokenId}`
   const handleClick = async () => {
     const generate = async () => {
       const walletService = await getWalletService()

--- a/unlock-app/src/components/interface/keychain/Key.tsx
+++ b/unlock-app/src/components/interface/keychain/Key.tsx
@@ -327,10 +327,9 @@ function Key({ ownedKey, account, network }: Props) {
                             network={network}
                             lockAddress={lock.address}
                             tokenId={tokenId}
-                            image={metadata.image}
                             name={metadata.name}
                             handlePassUrl={(url: string) => {
-                              window.open(url, '_')
+                              window.location.assign(url)
                             }}
                           >
                             <Image
@@ -353,12 +352,11 @@ function Key({ ownedKey, account, network }: Props) {
                             network={network}
                             lockAddress={lock.address}
                             tokenId={tokenId}
-                            image={metadata.image}
                             name={metadata.name}
                             handlePassUrl={(url: string) => {
                               if (isIOS) {
                                 // Download
-                                window.open(url, '_')
+                                window.location.assign(url)
                               } else if (setPassUrl) {
                                 // Show the modal
                                 setPassUrl(url)


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Browser blocks pop up because we do some fetching and generation before opening the window. 
Replaced it with windows.location.assign to avoid this. 

Uses static locksmith url for image instead of passing it as a prop.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

