### PR TITLE
feat(unlock-app) - handle no image

### DIFF
--- a/packages/ui/lib/components/ImageUpload/ImageUpload.stories.tsx
+++ b/packages/ui/lib/components/ImageUpload/ImageUpload.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof meta>
 
 export const Primary = {
   args: {
-    preview: '',
+    preview: '/images/image_upload.png',
     description:
       'Upload an image or select an external URL. Recommend using a square of at least 300x300 pixels.',
   },

--- a/packages/ui/lib/components/ImageUpload/ImageUpload.stories.tsx
+++ b/packages/ui/lib/components/ImageUpload/ImageUpload.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof meta>
 
 export const Primary = {
   args: {
-    preview: '/images/image_upload.png',
+    preview: '',
     description:
       'Upload an image or select an external URL. Recommend using a square of at least 300x300 pixels.',
   },

--- a/packages/ui/lib/components/ImageUpload/ImageUpload.tsx
+++ b/packages/ui/lib/components/ImageUpload/ImageUpload.tsx
@@ -48,13 +48,16 @@ export const ImageUpload = ({
             />
           </div>
         )}
-        {!isUploading && (
-          <img
-            className="object-cover w-full h-full rounded-xl"
-            src={preview}
-            alt="NFT"
-          />
-        )}
+        {!isUploading &&
+          (preview ? (
+            <img
+              className="object-cover w-full h-full rounded-xl"
+              src={preview}
+              alt="NFT"
+            />
+          ) : (
+            <div className="text-xs">No image selected</div>
+          ))}
       </div>
       <Tab.Group>
         <div className="grid gap-4">

--- a/packages/ui/lib/components/ImageUpload/ImageUpload.tsx
+++ b/packages/ui/lib/components/ImageUpload/ImageUpload.tsx
@@ -3,13 +3,7 @@ import { Button } from '../Button/Button'
 import { Tab } from '@headlessui/react'
 import { CgSpinner as SpinnerIcon } from 'react-icons/cg'
 import { Input } from '../Form'
-
-interface ImageUploadProps {
-  preview: string
-  isUploading?: boolean
-  onChange: (fileOrFileUrl: File[] | string) => Promise<unknown> | unknown
-  description?: string
-}
+import { classed } from '@tw-classed/react'
 
 const tabs = [
   {
@@ -21,12 +15,35 @@ const tabs = [
     name: 'Insert image URL',
   },
 ]
+
+const ImageUploadWrapper = classed.div('grid gap-6 p-2 bg-white rounded-xl', {
+  variants: {
+    size: {
+      sm: 'max-w-sm',
+      full: 'w-full',
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+})
+
+type ImageUploadWrapperProps = React.ComponentProps<
+  typeof ImageUploadWrapper
+> & {
+  preview: string
+  isUploading?: boolean
+  onChange: (fileOrFileUrl: File[] | string) => Promise<unknown> | unknown
+  description?: string
+}
+
 export const ImageUpload = ({
   onChange,
   preview,
   isUploading,
   description,
-}: ImageUploadProps) => {
+  size,
+}: ImageUploadWrapperProps) => {
   const { getInputProps, getRootProps } = useDropzone({
     accept: {
       'image/png': ['.png'],
@@ -37,7 +54,7 @@ export const ImageUpload = ({
     onDropAccepted: onChange,
   })
   return (
-    <div className="grid max-w-sm gap-6 p-2 bg-white rounded-xl">
+    <ImageUploadWrapper size={size}>
       <div className="flex flex-col items-center justify-center p-1 border border-dashed rounded-lg aspect-1">
         {isUploading && (
           <div className="flex flex-col items-center justify-center h-full">
@@ -107,6 +124,6 @@ export const ImageUpload = ({
           </Tab.Panels>
         </div>
       </Tab.Group>
-    </div>
+    </ImageUploadWrapper>
   )
 }

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -175,6 +175,7 @@ export const Form = ({ onSubmit }: FormProps) => {
               <div className="grid grid-1.5">
                 <span>Illustration</span>
                 <ImageUpload
+                  size="full"
                   description="This illustration will be used for the NFT tickets. Use 512 by 512 pixels for best results."
                   isUploading={isUploading}
                   preview={metadataImage!}

--- a/unlock-app/src/components/interface/locks/metadata/DetailForm.tsx
+++ b/unlock-app/src/components/interface/locks/metadata/DetailForm.tsx
@@ -54,7 +54,7 @@ export function DetailForm({ disabled }: Props) {
             description="This will appear as each NFT's image on OpenSea on other marketplaces. Use 512 by 512 pixels for best results."
             isUploading={isUploading}
             preview={image!}
-            onChange={async (fileOrFileUrl) => {
+            onChange={async (fileOrFileUrl: any) => {
               if (typeof fileOrFileUrl === 'string') {
                 setValue('image', fileOrFileUrl)
               } else {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Handle when image is not selected 

**Full size**
<img width="449" alt="Screenshot 2023-03-21 at 20 21 58" src="https://user-images.githubusercontent.com/20865711/226731629-aa63a55b-ea2b-4437-b95b-b90e881ed41b.png">

**Full size**
<img width="450" alt="Screenshot 2023-03-21 at 20 27 58" src="https://user-images.githubusercontent.com/20865711/226732978-4883485f-2930-4356-9a05-0ba167ee9c91.png">

**SM size**
<img width="450" alt="Screenshot 2023-03-21 at 20 28 03" src="https://user-images.githubusercontent.com/20865711/226732982-f056e5e4-7e02-4cf0-8d40-e2faaf1c7f43.png">

**Full size in form** 

<img width="450" alt="Screenshot 2023-03-21 at 20 30 31" src="https://user-images.githubusercontent.com/20865711/226733445-a00bebd7-de7b-4bcc-ba19-68e69ce852fd.png">

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

