### PR TITLE
fix(locksmith): returning partial results when we paginate

### DIFF
--- a/locksmith/src/controllers/v2/grantKeysController.ts
+++ b/locksmith/src/controllers/v2/grantKeysController.ts
@@ -86,7 +86,7 @@ export class GrantKeysController {
       )
       return
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       response.status(500).send({
         error: 'There was an error granting keys. Please try again.',
       })

--- a/locksmith/src/controllers/v2/keyController.ts
+++ b/locksmith/src/controllers/v2/keyController.ts
@@ -46,7 +46,7 @@ export default class KeyController {
     } catch (error) {
       logger.error(error.message)
       return response.status(500).send({
-        message: 'Keys list could not be retrived.',
+        message: 'Keys list could not be retrieved.',
       })
     }
   }

--- a/locksmith/src/controllers/v2/verifierController.ts
+++ b/locksmith/src/controllers/v2/verifierController.ts
@@ -26,7 +26,7 @@ export default class VerifierController {
     } catch (error) {
       logger.error(error.message)
       return response.status(500).send({
-        message: 'Verifier list could not be retrived.',
+        message: 'Verifier list could not be retrieved.',
       })
     }
   }

--- a/locksmith/src/graphql/datasource/keysByQuery.ts
+++ b/locksmith/src/graphql/datasource/keysByQuery.ts
@@ -3,6 +3,7 @@ import networks from '@unlock-protocol/networks'
 import gql from 'graphql-tag'
 import { DocumentNode } from 'graphql'
 import { getValidNumber } from '../../utils/normalizer'
+import logger from '../../logger'
 
 export type KeyFilter = 'all' | 'active' | 'expired' | 'tokenId'
 const keyholdersByTokedIdQuery = gql`
@@ -193,14 +194,14 @@ export class keysByQuery extends GraphQLDataSource {
 
           getForNextPage = nextPageKeys?.length === first
         } catch (error) {
-          console.error(error)
+          logger.error(error)
           getForNextPage = false // When we have an error, we stop paginating, results will be partial
         }
       }
 
       return locks
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       return []
     }
   }

--- a/locksmith/src/graphql/datasource/keysByQuery.ts
+++ b/locksmith/src/graphql/datasource/keysByQuery.ts
@@ -159,6 +159,8 @@ export class keysByQuery extends GraphQLDataSource {
 
       const getData = async (getFromPage = page) => {
         const skip = parseInt(`${getFromPage}`, 10) * first
+        // The Graph does not support skipping more than 5000
+        // https://thegraph.com/docs/en/querying/graphql-api/#pagination
         return await this.query(query, {
           variables: {
             addresses,
@@ -180,20 +182,25 @@ export class keysByQuery extends GraphQLDataSource {
       // get next page keys and add it to the list until the length is equal to MAX_ITEMS
       while (getForNextPage) {
         page = page + 1
+        try {
+          const {
+            data: {
+              locks: [{ keys: nextPageKeys = [] }],
+            },
+          } = (await getData()) ?? {}
 
-        const {
-          data: {
-            locks: [{ keys: nextPageKeys = [] }],
-          },
-        } = (await getData()) ?? {}
+          keysList?.push(...(nextPageKeys ?? []))
 
-        keysList?.push(...(nextPageKeys ?? []))
-
-        getForNextPage = nextPageKeys?.length === first
+          getForNextPage = nextPageKeys?.length === first
+        } catch (error) {
+          console.error(error)
+          getForNextPage = false // When we have an error, we stop paginating, results will be partial
+        }
       }
 
       return locks
     } catch (error) {
+      console.error(error)
       return []
     }
   }

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -6,6 +6,7 @@ import { UserReference } from '../models/userReference'
 import { StripeCustomer } from '../models/stripeCustomer'
 import Sequelize from 'sequelize'
 import config from '../config/config'
+import logger from '../logger'
 
 const { Op } = Sequelize
 
@@ -59,7 +60,7 @@ export const saveStripeCustomerIdForAddress = async (
       StripeCustomerId: stripeCustomerId,
     })
   } catch (error) {
-    console.error(error)
+    logger.error(error)
     return false
   }
 }

--- a/locksmith/src/websub/helpers/renewKey.ts
+++ b/locksmith/src/websub/helpers/renewKey.ts
@@ -105,7 +105,7 @@ export const isWorthRenewing = async (
       gasRefund: gasRefund.toNumber(),
     }
   } catch (error) {
-    console.error(error)
+    logger.error(error)
     return {
       shouldRenew: false,
       error: error.message,


### PR DESCRIPTION
# Description

I realized loading members for locks with more than 5000 keys.
When debugging I found that The Graph does not allow the "Skip" param to be larger than 5000.
I am adding that partial fix to return "partial" results, but I really want to understand _why_ we are loading _all_ the results when in practice the front-end would only show 20 anyway.

Any idea @kalidiagne @searchableguy ?

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

