### PR TITLE
feat(unlock-app) - support for boolean for emails + test

### DIFF
--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -12,7 +12,7 @@ import remarkHtml from 'remark-html'
 import * as emailOperations from './emailOperations'
 
 type Params = {
-  [key: string]: string | number | undefined
+  [key: string]: string | number | undefined | boolean
   keyId: string
   keychainUrl?: string
   lockName: string

--- a/packages/email-templates/src/__tests__/templates/keyExpiring.test.ts
+++ b/packages/email-templates/src/__tests__/templates/keyExpiring.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import keyExpiring from '../../templates/keyExpiring'
+import { prepareAll } from '../../templates/prepare'
+import { expect, it, describe } from 'vitest'
+import { asHtml } from '../utils'
+
+const DETAILS = {
+  keyId: '1337',
+  lockName: 'Ethereal NYC 202',
+  keychainUrl: 'https://app.unlock-protocol.com/keychain',
+  network: 'Polygon',
+}
+describe('keyExpiring', () => {
+  it('should have the right subject', () => {
+    expect.assertions(1)
+    expect(
+      prepareAll(keyExpiring).subject({
+        ...DETAILS,
+      })
+    ).toBe(`Your "Ethereal NYC 202" membership is about to expire!`)
+  })
+
+  it('should correct text when isRenewable', () => {
+    expect.assertions(1)
+
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewable: true,
+    })
+
+    expect(asHtml(content).textContent).toContain(
+      `You can renew this membership from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+
+  it('should not show text when is not isRenewable', () => {
+    expect.assertions(1)
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewable: false,
+    })
+
+    expect(asHtml(content).textContent).not.toContain(
+      `You can renew this membership from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+
+  it('should correct text when isAutoRenewable', () => {
+    expect.assertions(1)
+
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isAutoRenewable: true,
+      currency: 'STR',
+    })
+
+    expect(asHtml(content).textContent).toContain(
+      `This membership will automatically renew, since your balance of STR is enough. You can cancel this renewal from the Unlock Keychain.`
+    )
+  })
+
+  it('should not show text when is not isAutoRenewable', () => {
+    expect.assertions(1)
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isAutoRenewable: false,
+      currency: 'STR',
+    })
+
+    expect(asHtml(content).textContent).not.toContain(
+      `This membership will automatically renew, since your balance of STR is enough. You can cancel this renewal from the Unlock Keychain`
+    )
+  })
+
+  it('should correct text when isRenewableIfRePurchased', () => {
+    expect.assertions(1)
+
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewableIfRePurchased: true,
+    })
+
+    expect(asHtml(content).textContent).toContain(
+      `This membership will not automatically renew because the membership contract terms have changed. You can approve the new terms from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+
+  it('should not show text when is not isRenewableIfRePurchased', () => {
+    expect.assertions(1)
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewableIfRePurchased: false,
+    })
+
+    expect(asHtml(content).textContent).not.toContain(
+      `This membership will not automatically renew because the membership contract terms have changed. You can approve the new terms from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+
+  it('should correct text when isRenewableIfReApproved', () => {
+    expect.assertions(1)
+
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewableIfReApproved: true,
+      currency: 'STR',
+    })
+
+    expect(asHtml(content).textContent).toContain(
+      `This membership will not automatically renew because you have not approved enough STR. You can approve renewals from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+
+  it('should not show text when is not isRenewableIfReApproved', () => {
+    expect.assertions(1)
+    const content = prepareAll(keyExpiring).html({
+      ...DETAILS,
+      isRenewableIfReApproved: false,
+      currency: 'STR',
+    })
+
+    expect(asHtml(content).textContent).not.toContain(
+      `This membership will not automatically renew because you have not approved enough STR. You can approve renewals from the Unlock Keychain so you don't lose any benefit.`
+    )
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Add test for `keyMined` template + support for `boolean` for `sendEmail` 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

