### PR TITLE
fix(unlock-app): remove .enable on providers call by default and using it only for WalletConnect an…

### DIFF
--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -72,7 +72,15 @@ export function useAuthenticate(options: AuthenticateProps = {}) {
     const walletConnectProvider = new WalletConnectProvider({
       rpc: rpcForWalletConnect(config),
     })
-    return authenticate(walletConnectProvider)
+    const connectedAccount = await walletConnectProvider
+      .enable()
+      .catch((error) => {
+        console.error(error)
+        return undefined
+      })
+    if (connectedAccount) {
+      return authenticate(walletConnectProvider)
+    }
   }
 
   const handleCoinbaseWalletProvider = async () => {
@@ -81,8 +89,19 @@ export function useAuthenticate(options: AuthenticateProps = {}) {
       appLogoUrl: '/static/images/svg/default-lock-logo.svg',
     })
 
-    const ethereum = walletLink.makeWeb3Provider(config.networks[1].provider, 1)
-    return authenticate(ethereum)
+    const walletLinkProvider = walletLink.makeWeb3Provider(
+      config.networks[1].provider,
+      1
+    )
+    const connectedAccount = await walletLinkProvider
+      .enable()
+      .catch((error) => {
+        console.error(error)
+        return undefined
+      })
+    if (connectedAccount) {
+      return authenticate(walletLinkProvider)
+    }
   }
 
   const walletHandlers: {

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -165,13 +165,6 @@ export const useProvider = (config: any) => {
     if (provider instanceof ethers.providers.Provider) {
       auth = await resetProvider(provider)
     } else {
-      if (provider.enable) {
-        try {
-          await provider.enable()
-        } catch {
-          console.error('Please check your wallet and try again to connect.')
-        }
-      }
       const ethersProvider = new ethers.providers.Web3Provider(provider)
 
       if (provider.on) {


### PR DESCRIPTION
# Description

`.enable` has been deprecated even though it is still used by WalletConnect and WalletLink.  I removed from the "default" path and just added it to both of these.

# Issues

Fixes #11374


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

