### PR TITLE
fix(smart-contracts): tests for upgrading a lock from v12 to v13

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -166,9 +166,10 @@ contract MixinKeys is MixinErrors, MixinLockCore {
       // update unlock ref in this lock
       unlockProtocol = IUnlock(newUnlockAddress);
 
-      // update data version
-      schemaVersion = publicLockVersion();
     }
+    
+    // update data version
+    schemaVersion = publicLockVersion();
   }
 
   /**

--- a/smart-contracts/test/Lock/upgrades/v13.js
+++ b/smart-contracts/test/Lock/upgrades/v13.js
@@ -1,0 +1,203 @@
+const { ethers, upgrades } = require('hardhat')
+const {
+  ADDRESS_ZERO,
+  getContractFactoryFromSolFiles,
+  cleanupPastContracts,
+} = require('../../helpers')
+
+const keyPrice = ethers.utils.parseEther('0.01')
+const previousVersionNumber = 12
+const nextVersionNumber = 13
+
+describe('PublicLock upgrade v12 > v13', () => {
+  let lock
+  let PublicLockLatest
+  let PublicLockPast
+
+  after(async () => await cleanupPastContracts())
+
+  before(async function () {
+    // make sure mocha doesnt time out
+    this.timeout(200000)
+
+    PublicLockLatest = await ethers.getContractFactory(
+      'contracts/PublicLock.sol:PublicLock'
+    )
+
+    // get latest version number
+    const publicLockLatest = await PublicLockLatest.deploy()
+    await publicLockLatest.deployed()
+
+    // get previous version
+    PublicLockPast = await getContractFactoryFromSolFiles(
+      'PublicLock',
+      previousVersionNumber
+    )
+
+    // deploy a simple lock
+    const [, lockOwner] = await ethers.getSigners()
+    const duration = 60 * 60 * 24 * 30 // 30 days
+    const args = [
+      lockOwner.address,
+      duration,
+      ADDRESS_ZERO,
+      keyPrice,
+      130,
+      'A neat upgradeable lock!',
+    ]
+
+    lock = await upgrades.deployProxy(PublicLockPast, args)
+    await lock.deployed()
+
+    // set many keys
+    await lock.connect(lockOwner).updateLockConfig(
+      duration,
+      20,
+      3
+    )
+  })
+
+  it('past version has correct version number', async () => {
+    assert.equal(await lock.publicLockVersion(), previousVersionNumber)
+  })
+
+  describe('perform upgrade', async () => {
+    let buyers
+    let tokenIds
+    let expirationTimestamps
+    let totalSupplyBefore
+
+    before(async () => {
+      // buy some keys
+      const signers = await ethers.getSigners()
+      buyers = signers.slice(1, 10)
+
+      // purchase many keys
+      const tx = await lock.purchase(
+        [],
+        buyers.map((keyOwner) => keyOwner.address),
+        buyers.map(() => ADDRESS_ZERO),
+        buyers.map(() => ADDRESS_ZERO),
+        buyers.map(() => []),
+        {
+          value: keyPrice.mul(buyers.length),
+        }
+      )
+      const { events } = await tx.wait()
+      tokenIds = events
+        .filter((v) => v.event === 'Transfer')
+        .map(({ args }) => args.tokenId)
+
+      expirationTimestamps = await Promise.all(
+        tokenIds.map((tokenId) => lock.keyExpirationTimestampFor(tokenId))
+      )
+
+      // make sure record is proper before upgrade
+      assert.equal(await lock.publicLockVersion(), previousVersionNumber)
+      assert.equal(await lock.ownerOf(tokenIds[0]), buyers[0].address)
+      assert.equal(await lock.balanceOf(buyers[0].address), 1)
+
+      totalSupplyBefore = await lock.totalSupply()
+
+      // deploy new implementation
+      lock = await upgrades.upgradeProxy(lock.address, PublicLockLatest, {
+        unsafeSkipStorageCheck: true, // UNSECURE - but we need the flag as we are resizing the `__gap`
+      })
+
+      // make sure ownership is preserved
+      assert.equal(await lock.ownerOf(tokenIds[0]), buyers[0].address)
+    })
+
+    it('upgraded successfully ', async () => {
+      assert.equal(await lock.publicLockVersion(), nextVersionNumber)
+    })
+
+    it('totalSupply is preserved', async () => {
+      assert.equal(
+        totalSupplyBefore.toNumber(),
+        (await lock.totalSupply()).toNumber()
+      )
+    })
+
+    it('schemaVersion is not set correctly before migration', async () => {
+      assert.equal(
+        (await lock.schemaVersion()).toNumber(),
+        previousVersionNumber
+      )
+    })
+
+    describe('data migration', () => {
+      before(async () => {
+        await lock.migrate('0x')
+      })
+
+      it('schemaVersion has been updated', async () => {
+        assert.equal(await lock.schemaVersion(), await lock.publicLockVersion())
+      })
+
+      it('preserves all keys data', async () => {
+        const totalSupply = (await lock.totalSupply()).toNumber()
+        for (let i = 0; i < totalSupply; i++) {
+          const tokenId = i + 1
+          assert.equal(await lock.isValidKey(tokenId), true)
+          assert.equal(await lock.ownerOf(tokenId), buyers[i].address)
+          assert.equal(await lock.balanceOf(buyers[i].address), 1)
+          assert.equal(await lock.getHasValidKey(buyers[i].address), true)
+          assert.equal(
+            (await lock.keyExpirationTimestampFor(tokenId)).toNumber(),
+            expirationTimestamps[i].toNumber()
+          )
+        }
+      })
+
+      it('purchase should now work ', async () => {
+        const tx = await lock.connect(buyers[0]).purchase(
+          [],
+          buyers.map((k) => k.address),
+          buyers.map(() => ADDRESS_ZERO),
+          buyers.map(() => ADDRESS_ZERO),
+          buyers.map(() => []),
+          {
+            value: (keyPrice * buyers.length).toFixed(),
+          }
+        )
+        const { events } = await tx.wait()
+
+        const tokenIds = events
+          .filter((v) => v.event === 'Transfer')
+          .map(({ args }) => args.tokenId)
+
+        assert.equal(tokenIds.length, buyers.length)
+      })
+
+      it('grantKeys should now work ', async () => {
+        const tx = await lock.connect(buyers[0]).grantKeys(
+          buyers.map((k) => k.address),
+          buyers.map(() => Date.now()),
+          buyers.map(() => ADDRESS_ZERO)
+        )
+        const { events } = await tx.wait()
+        const tokenIds = events
+          .filter((v) => v.event === 'Transfer')
+          .map(({ args }) => args.tokenId)
+
+        assert.equal(tokenIds.length, buyers.length)
+      })
+
+      it('extend should now work ', async () => {
+        const tx = await lock
+          .connect(buyers[0])
+          .extend(0, tokenIds[0], ADDRESS_ZERO, [], {
+            value: keyPrice,
+          })
+        await tx.wait()
+        assert.equal(
+          (await lock.keyExpirationTimestampFor(tokenIds[0])).gt(
+            expirationTimestamps[0]
+          ),
+          true
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description

This adds a simple test for upgrading a lock from v12 to v13. This leads to to introduce two fixes : set `schemaVersion` properly and wrap the Unlock call to `protocolFee` in an effective try/catch (i.e. check first that the address is an actual contract)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

