### PR TITLE
fix(unlock-app): EthPass button only shown if user is logged in

### DIFF
--- a/packages/networks/src/networks/goerli.ts
+++ b/packages/networks/src/networks/goerli.ts
@@ -43,7 +43,7 @@ export const goerli: NetworkConfig = {
   startBlock: 7179039,
   previousDeploys: [],
   isTestNetwork: true,
-  maxFreeClaimCost: 10000,
+  maxFreeClaimCost: 100000,
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
     oracle: '0x25197CaCDE16500032EF4B35d60c6f7aEd4a38a5',

--- a/unlock-app/src/components/content/event/WalletlessRegistration.tsx
+++ b/unlock-app/src/components/content/event/WalletlessRegistration.tsx
@@ -133,7 +133,7 @@ export const WalletlessRegistration = ({
               status: transactionStatus,
               transactionHash: claimResult.hash,
             }}
-            account={claimResult.owner}
+            owner={claimResult.owner}
             lockName={''}
             lockAddress={lockAddress}
             network={network}

--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -25,7 +25,7 @@ import type { Transaction } from './checkoutMachine'
 interface MintingScreenProps {
   lockName: string
   mint: Transaction
-  account: string
+  owner: string
   lockAddress: string
   network: number
 }
@@ -33,17 +33,18 @@ interface MintingScreenProps {
 export const MintingScreen = ({
   lockName,
   mint,
-  account,
+  owner,
   lockAddress,
   network,
 }: MintingScreenProps) => {
   const web3Service = useWeb3Service()
   const config = useConfig()
+  const { account } = useAuth()
 
   const { data: tokenId } = useQuery(
-    ['userTokenId', mint, account, lockAddress, network, web3Service],
+    ['userTokenId', mint, owner, lockAddress, network, web3Service],
     async () => {
-      return web3Service.getTokenIdForOwner(lockAddress, account!, network)
+      return web3Service.getTokenIdForOwner(lockAddress, owner!, network)
     },
     {
       enabled: mint?.status === 'FINISHED',
@@ -102,7 +103,7 @@ export const MintingScreen = ({
           <Icon icon={ExternalLinkIcon} size="small" />
         </a>
       )}
-      {hasTokenId && isEthPassSupported(network) && (
+      {hasTokenId && account === owner && isEthPassSupported(network) && (
         <ul className="grid grid-cols-2 gap-3 pt-4">
           {!isIOS && (
             <li className="">
@@ -249,7 +250,7 @@ export function Minting({
       <main className="h-full px-6 py-2 overflow-auto">
         <MintingScreen
           mint={mint!}
-          account={account!}
+          owner={account!} // TODO: are we minting for someone else?
           lockAddress={lock!.address}
           lockName={lock!.name}
           network={lock!.network}


### PR DESCRIPTION
# Description

EthPass requires a user signer from the `owner` of the key. So we are not showing the EthPass buttons when the connected user is not the owner of the token.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

