### PR TITLE
feat(smart-contracts): add `getAdmin` helper in Unlock

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -655,15 +655,9 @@ contract Unlock is UnlockInitializable, UnlockOwnable {
     return globalTokenSymbol;
   }
 
-  /**
-   * Returns the ProxyAdmin contract address that manage upgrades for 
-   * the current Unlock contract.
-   */
+  // for doc, see IUnlock.sol
   function getAdmin() public view returns (address) {
-      // as per OZ EIP1967 Proxy implementation, this is the keccak-256 hash 
-      // of "eip1967.proxy.admin" subtracted by 1
       bytes32 _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
-
       return StorageSlot.getAddressSlot(_ADMIN_SLOT).value;
   }
 

--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -655,6 +655,18 @@ contract Unlock is UnlockInitializable, UnlockOwnable {
     return globalTokenSymbol;
   }
 
+  /**
+   * Returns the ProxyAdmin contract address that manage upgrades for 
+   * the current Unlock contract.
+   */
+  function getAdmin() public view returns (address) {
+      // as per OZ EIP1967 Proxy implementation, this is the keccak-256 hash 
+      // of "eip1967.proxy.admin" subtracted by 1
+      bytes32 _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+      return StorageSlot.getAddressSlot(_ADMIN_SLOT).value;
+  }
+
   // for doc, see IUnlock.sol
   function postLockUpgrade() public {
     // check if lock hasnot already been deployed here and version is correct

--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -325,6 +325,16 @@ interface IUnlock {
    */
   function protocolFee() external view returns (uint);
 
+  
+  /**
+   * Returns the ProxyAdmin contract address that manage upgrades for 
+   * the current Unlock contract.
+   * @dev this reads the address directly from storage, at the slot `_ADMIN_SLOT` 
+   * defined by Open Zeppelin's EIP1967 Proxy implementation which corresponds
+   * to the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1
+   */
+   function getAdmin() external view returns (address);
+
   /**
    * Call executed by a lock after its version upgrade triggred by `upgradeLock`
    * - PublicLock v12 > v13 (mainnet): migrate an existing Lock to another instance 

--- a/smart-contracts/test/Unlock/getAdmin.js
+++ b/smart-contracts/test/Unlock/getAdmin.js
@@ -1,0 +1,25 @@
+const { upgrades } = require('hardhat')
+const { deployContracts, getProxyAdminAddress } = require('../helpers')
+
+contract('Unlock / getAdmin', () => {
+  it('fetched correctly the proxy admin address', async () => {
+    const { unlock } = await deployContracts()
+    const admin = await unlock.getAdmin()
+    
+    // get instance from OZ plugin 
+    const proxyAdmin = await upgrades.admin.getInstance()
+    assert.equal(proxyAdmin.address, admin)
+    
+    // make sure it matches with address from storage 
+    assert.equal(
+      (await getProxyAdminAddress(unlock.address)).toLowerCase(), 
+      admin.toLowerCase()
+    )
+
+    // change unlock proxyAdmin
+    const newProxyAdmin = await upgrades.deployProxyAdmin()
+    await proxyAdmin.changeProxyAdmin(unlock.address, newProxyAdmin)
+    assert.equal(await unlock.getAdmin(), newProxyAdmin)
+
+  })
+})


### PR DESCRIPTION
# Description

This adds a helper in Unlock to get the address of the ProxyAdmin contract that manages the current Unlock instance 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

