### PR TITLE
fix(paywall): not calling enable if it is not defined

### DIFF
--- a/packages/paywall/README.md
+++ b/packages/paywall/README.md
@@ -1,11 +1,13 @@
 # The paywall
 
-The paywall is an application which can be added to any website to check if a visitor is a member.
+The paywall is an application that can be added to any website to check if a visitor is a member.
 It also offers the ability to open a "checkout" UI which lets the user purchase a key to any of the locks configured for that page.
 
-## Module
+## CDN version
 
-A npm module `@unlock-protocol/paywall` is offered for convenience to export and easily add an Unlock paywall to any site without "hotloading" the code from the unlock servers.
+You can also [load the library from our CDN](https://paywall.unlock-protocol.com/static/unlock.latest.min.js) and embed it in your applications.
+
+[See details in our docs](https://docs.unlock-protocol.com/tools/paywall).
 
 ### The Paywall Object
 
@@ -14,22 +16,29 @@ The `@unlock-protocol/paywall` module exports an object called `Paywall` that ma
 Usage is simple:
 
 ```javascript
-import { Paywall } from '@unlock-protocol/paywall';
+import { Paywall } from '@unlock-protocol/paywall'
 
 // See https://docs.unlock-protocol.com/getting-started/locking-page#configure-the-paywall
-const paywallConfig = {};
+const paywallConfig = {}
 
 // Configure networks to use
+// You can also use @unlock-protocol/networks for convenience...
 const networkConfigs = {
   1: {
     provider: 'HTTP PROVIDER',
   },
   100: {
-    // configuration for xdai... etc
+    // configuration for gnosis chain... etc
   },
   // etc
 }
 
-new Paywall(paywallConfig, networkConfigs);
-// from this point onward, it behaves exactly as if you had loaded the script in the <head> of your page.
+// Pass a provider. You can also use a provider from a library such as Magic.link or privy.io
+// If no provider is set, the library uses window.ethereum
+const provider = window.ethereum
+
+const paywall = new Paywall(paywallConfig, networkConfigs, provider)
+
+// Loads the checkout UI
+paywall.loadCheckoutModal()
 ```

--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/unlock.latest.umd.js",
   "module": "./dist/unlock.latest.es.js",
   "exports": {

--- a/packages/paywall/src/utils/enableInjectedProvider.ts
+++ b/packages/paywall/src/utils/enableInjectedProvider.ts
@@ -36,5 +36,7 @@ export const enableInjectedProvider = async (provider: Enabler | undefined) => {
 
   // resolves if provider is already enabled or if user allows provider to enable
   // rejects if user does not allow
-  await provider.enable()
+  if (provider.enable) {
+    await provider.enable()
+  }
 }


### PR DESCRIPTION
# Description

A minor fix to only call `.enable` on the provider if it is defined.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

