### PR TITLE
chore(packages): moved babel-eslint to the right place

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@babel/core": "7.21.0",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
-    "babel-eslint": "10.1.0",
     "babel-plugin-polyfill-corejs2": "0.3.3",
     "typescript": "4.9.5"
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.56.0",
     "@typescript-eslint/parser": "5.56.0",
+    "babel-eslint": "10.1.0",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.3",
     "eslint-config-prettier": "8.8.0",

--- a/packages/unlock-assets/package.json
+++ b/packages/unlock-assets/package.json
@@ -46,7 +46,6 @@
     "@storybook/addon-links": "6.5.16",
     "@storybook/react": "6.5.16",
     "@svgr/cli": "6.5.1",
-    "babel-eslint": "10.1.0",
     "babel-loader": "9.1.2",
     "eslint": "8.35.0",
     "eslint-config-prettier": "8.6.0",

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -32,7 +32,6 @@
     "@unlock-protocol/hardhat-helpers": "workspace:^",
     "@unlock-protocol/hardhat-plugin": "workspace:^",
     "@unlock-protocol/networks": "workspace:./packages/networks",
-    "babel-eslint": "10.1.0",
     "babel-polyfill": "6.26.0",
     "babel-register": "6.26.0",
     "bignumber.js": "9.1.1",

--- a/unlock-protocol-com/package.json
+++ b/unlock-protocol-com/package.json
@@ -17,7 +17,6 @@
     "@unlock-protocol/unlock-assets": "workspace:./packages/unlock-assets",
     "@zeit/next-source-maps": "0.0.3",
     "apexcharts": "3.37.1",
-    "babel-eslint": "10.1.0",
     "babel-loader": "9.1.2",
     "babel-plugin-require-context-hook": "1.0.0",
     "babel-plugin-styled-components": "2.0.7",

--- a/wedlocks/package.json
+++ b/wedlocks/package.json
@@ -10,7 +10,6 @@
     "@babel/preset-env": "7.20.2",
     "@typescript-eslint/parser": "5.56.0",
     "@unlock-protocol/eslint-config": "workspace:./packages/eslint-config",
-    "babel-eslint": "10.1.0",
     "babel-loader": "9.1.2",
     "babel-plugin-wildcard": "7.0.0",
     "dotenv": "16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14346,6 +14346,7 @@ __metadata:
   dependencies:
     "@typescript-eslint/eslint-plugin": 5.56.0
     "@typescript-eslint/parser": 5.56.0
+    babel-eslint: 10.1.0
     eslint: 8.36.0
     eslint-config-next: 13.2.3
     eslint-config-prettier: 8.8.0
@@ -14582,7 +14583,6 @@ __metadata:
     "@unlock-protocol/hardhat-helpers": "workspace:^"
     "@unlock-protocol/hardhat-plugin": "workspace:^"
     "@unlock-protocol/networks": "workspace:./packages/networks"
-    babel-eslint: 10.1.0
     babel-polyfill: 6.26.0
     babel-register: 6.26.0
     bignumber.js: 9.1.1
@@ -14799,7 +14799,6 @@ __metadata:
     "@storybook/addon-links": 6.5.16
     "@storybook/react": 6.5.16
     "@svgr/cli": 6.5.1
-    babel-eslint: 10.1.0
     babel-loader: 9.1.2
     eslint: 8.35.0
     eslint-config-prettier: 8.6.0
@@ -14894,7 +14893,6 @@ __metadata:
     "@zeit/next-source-maps": 0.0.3
     apexcharts: 3.37.1
     autoprefixer: 10.4.13
-    babel-eslint: 10.1.0
     babel-loader: 9.1.2
     babel-plugin-require-context-hook: 1.0.0
     babel-plugin-styled-components: 2.0.7
@@ -14952,7 +14950,6 @@ __metadata:
     "@typescript-eslint/parser": 5.56.0
     "@unlock-protocol/eslint-config": "workspace:./packages/eslint-config"
     "@vitest/coverage-c8": 0.28.3
-    babel-eslint: 10.1.0
     babel-loader: 9.1.2
     babel-plugin-wildcard: 7.0.0
     dotenv: 16.0.3
@@ -50518,7 +50515,6 @@ __metadata:
     "@babel/core": 7.21.0
     "@typescript-eslint/eslint-plugin": 5.54.0
     "@typescript-eslint/parser": 5.54.0
-    babel-eslint: 10.1.0
     babel-plugin-polyfill-corejs2: 0.3.3
     eslint: 8.35.0
     eslint-plugin-prettier: latest


### PR DESCRIPTION
# Description

I realized we used `babel-eslint` in many places... but the place where we needed it !

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

