### PR TITLE
fix(smart-contracts): remove unused `receive` function from Unlock contract

### DIFF
--- a/smart-contracts/contracts/Unlock.sol
+++ b/smart-contracts/contracts/Unlock.sol
@@ -686,7 +686,4 @@ contract Unlock is UnlockInitializable, UnlockOwnable {
       }
     }
   }
-
-  // required to withdraw WETH
-  receive() external payable {}
 }


### PR DESCRIPTION
# Description

This removes the `receive` fallback function from Unlock as we dont currently need it. Thanks to @abdulhakim-altunkaya  for finding this ! (see #11510)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

