### PR TITLE
feat(smart-contracts): task to submit template to multisig w/o setting as default

### DIFF
--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -65,7 +65,7 @@ async function main({ safeAddress, tx, signer }) {
   // create tx
   const safeSdk = await Safe.create({ ethAdapter, safeAddress })
 
-  const txs = !Array.isArray(tx) === [tx] || tx
+  const txs = !Array.isArray(tx) ? [tx] : tx
 
   const explainer = txs
     .map(

--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -3,6 +3,7 @@ const {
   getSafeAddress,
   getSafeVersion,
   submitTxOldMultisig,
+  confirmMultisigTx,
 } = require('./_helpers')
 
 const Safe = require('@safe-global/safe-core-sdk').default
@@ -138,6 +139,14 @@ async function main({ safeAddress, tx, signer }) {
 
   const { nonce } = await safeService.getTransaction(safeTxHash)
   console.log(`Tx submitted to multisig with id: '${nonce}'`)
+
+  if (process.env.RUN_MAINNET_FORK) {
+      console.log(`Signing multisigs: ${nonce}`)
+      await confirmMultisigTx({
+        transactionId: nonce,
+        multisigAddress: safeAddress,
+      })
+    }
 }
 
 module.exports = main

--- a/smart-contracts/scripts/upgrade/_helpers.js
+++ b/smart-contracts/scripts/upgrade/_helpers.js
@@ -1,0 +1,52 @@
+const { ethers, run } = require('hardhat')
+const fs = require('fs-extra')
+const path = require('path')
+
+const contractsPath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'contracts',
+  'past-versions'
+)
+
+const artifactsPath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'artifacts',
+  'contracts',
+  'past-versions'
+)
+
+async function copyAndBuildContractAtVersion(contractName, version) {
+  // need to copy .sol for older versions in contracts repo
+    const pastUnlockPath = require.resolve(
+      `@unlock-protocol/contracts/dist/Unlock/${contractName}V${version}.sol`
+    )
+    await fs.copy(
+      pastUnlockPath,
+      path.resolve(contractsPath, `${contractName}V${version}.sol`)
+    )
+
+    // re-compile contract
+    await run('compile')
+
+    // get factory using fully qualified path
+    const Contract = await ethers.getContractFactory(
+      `contracts/past-versions/${contractName}V${version}.sol:${contractName}`
+    )
+    return Contract
+}
+
+async function cleanupContractVersions() {
+    // delete .sol file
+    await fs.remove(contractsPath)
+    await fs.remove(artifactsPath)
+
+}
+
+module.exports = {
+  copyAndBuildContractAtVersion,
+  cleanupContractVersions
+}

--- a/smart-contracts/scripts/upgrade/prepare.js
+++ b/smart-contracts/scripts/upgrade/prepare.js
@@ -1,12 +1,30 @@
 const { ethers, upgrades } = require('hardhat')
 
+const {
+  copyAndBuildContractAtVersion,
+  cleanupContractVersions
+} = require('../upgrade/_helpers')
+
 // used to update contract implementation address in proxy admin using multisig
-async function main({ proxyAddress, contractName }) {
-  const Contract = await ethers.getContractFactory(contractName)
+async function main({ proxyAddress, contractName, contractVersion }) {
+
+  // need to fetch previous 
+  let Contract 
+  if (contractVersion) {
+    console.log(`Setting up version ${contractVersion} from package`)
+    Contract = await copyAndBuildContractAtVersion(contractName, contractVersion)
+  } else {
+    console.log(`Deploying development version of Unlock from local source code. Please pass a version number if you want to deploy from a stable release.`)
+    Contract = await ethers.getContractFactory('contracts/Unlock.sol:Unlock')
+  }
+
   const implementation = await upgrades.prepareUpgrade(proxyAddress, Contract)
 
   console.log(`${contractName} implementation deployed at: ${implementation}`)
 
+  if(contractVersion) {
+    await cleanupContractVersions()
+  }
   return implementation
 }
 

--- a/smart-contracts/scripts/upgrade/prepare.js
+++ b/smart-contracts/scripts/upgrade/prepare.js
@@ -1,4 +1,4 @@
-const { ethers, upgrades } = require('hardhat')
+const { ethers, run, upgrades } = require('hardhat')
 
 const {
   copyAndBuildContractAtVersion,
@@ -21,6 +21,10 @@ async function main({ proxyAddress, contractName, contractVersion }) {
   const implementation = await upgrades.prepareUpgrade(proxyAddress, Contract)
 
   console.log(`${contractName} implementation deployed at: ${implementation}`)
+
+  await run('verify:verify', {
+    address: implementation
+  })
 
   if(contractVersion) {
     await cleanupContractVersions()

--- a/smart-contracts/scripts/upgrade/propose.js
+++ b/smart-contracts/scripts/upgrade/propose.js
@@ -1,7 +1,8 @@
 const { ethers } = require('hardhat')
-const proxyABI = require('./ABIs/proxy.json')
+const { networks } = require('@unlock-protocol/networks')
 
-const { confirmMultisigTx, impersonate } = require('../../../test/helpers')
+const { abi: proxyABI } = require('../../test/helpers/ABIs/ProxyAdmin.json')
+const { confirmMultisigTx, impersonate } = require('../../test/helpers')
 
 const { submitTx, getOwners } = require('../multisig')
 
@@ -12,11 +13,14 @@ async function main({ proxyAddress, proxyAdminAddress, implementation }) {
   const isDev = chainId === 31337
   if (isDev) console.log('Dev mode ON')
 
+  const { multisig } = networks[chainId]
+
+
   // get proper credentials
-  const owners = await getOwners(chainId)
   let signer
   if (isDev) {
     // impersonate multisig owner
+    const owners = await getOwners(chainId)
     signer = await ethers.getSigner(owners[0])
     await impersonate(owners[0])
   } else {
@@ -25,19 +29,25 @@ async function main({ proxyAddress, proxyAdminAddress, implementation }) {
   console.log(`Signer: ${signer.address}`)
 
   // build upgrade tx
-  const { interface } = new ethers.Contract(proxyABI, proxyAddress)
-  const data = interface.encodeFunctionData('upgrade', [
-    proxyAddress,
-    implementation,
-  ])
+  const { interface } = await ethers.getContractAt(proxyABI, proxyAdminAddress)
+
+  const args = [
+      proxyAddress,
+      implementation,
+    ]
+  const data = interface.encodeFunctionData('upgrade', args)
 
   // submit proxy upgrade tx to proxyAdmin
   const transactionId = await submitTx({
+    safeAddress: multisig,
     tx: {
       contractAddress: proxyAdminAddress,
+      functionName: 'upgrade', // just for explainer
+      functionArgs: args, // just for explainer
       value: 0, // ETH value
       calldata: data,
     },
+    signer
   })
 
   // make sure it doesnt revert

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -29,7 +29,11 @@ task('upgrade', 'Upgrade an existing contract with a new implementation (no mult
 task('upgrade:prepare', 'Deploy the implementation of an upgreadable contract')
   .addParam('contract', 'The contract path')
   .addParam('proxy', 'The proxy contract address')
-  .setAction(async ({ contract, proxy }, { ethers, run }) => {
+  .addOptionalParam(
+    'contractVersion',
+    'If set, will fetch the contract version from contracts package'
+  )
+  .setAction(async ({ contract, proxy, contractVersion }, { ethers, run }) => {
     // first compile latest version
     await run('compile')
 
@@ -45,6 +49,7 @@ task('upgrade:prepare', 'Deploy the implementation of an upgreadable contract')
     await prepareUpgrade({
       proxyAddress: proxy,
       contractName,
+      contractVersion
     })
   })
 

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -108,7 +108,7 @@ task(
     'publicLockVersion',
     'Specify the template version to deploy (from contracts package)'
   )
-  .addOptionalFlag('addOnly', 'Only add the template without setting it as default')
+  .addFlag('addOnly', 'Only add the template without setting it as default')
   .setAction(async ({ publicLockAddress, publicLockVersion, addOnly }) => {
     // eslint-disable-next-line global-require
     const prepareLockUpgrade = require('../scripts/upgrade/submitLockVersion')

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -84,7 +84,6 @@ task('upgrade:import', 'Import a missing impl manifest from a proxy contract')
  */
 
 task('upgrade:propose', 'Send an upgrade implementation proposal to multisig')
-  .addParam('contract', 'The contract path')
   .addParam('proxyAddress', 'The proxy contract address')
   .addParam('implementation', 'The implementation contract path')
   .setAction(async ({ proxyAddress, implementation }, { network }) => {
@@ -111,8 +110,8 @@ task(
   .addFlag('addOnly', 'Only add the template without setting it as default')
   .setAction(async ({ publicLockAddress, publicLockVersion, addOnly }) => {
     // eslint-disable-next-line global-require
-    const prepareLockUpgrade = require('../scripts/upgrade/submitLockVersion')
-    await prepareLockUpgrade({ publicLockAddress, publicLockVersion, addOnly })
+    const submitLockVersion = require('../scripts/upgrade/submitLockVersion')
+    await submitLockVersion({ publicLockAddress, publicLockVersion, addOnly })
   })
 
 task(

--- a/smart-contracts/tasks/upgrade.js
+++ b/smart-contracts/tasks/upgrade.js
@@ -103,10 +103,11 @@ task(
     'publicLockVersion',
     'Specify the template version to deploy (from contracts package)'
   )
-  .setAction(async ({ publicLockAddress, publicLockVersion }) => {
+  .addOptionalFlag('addOnly', 'Only add the template without setting it as default')
+  .setAction(async ({ publicLockAddress, publicLockVersion, addOnly }) => {
     // eslint-disable-next-line global-require
     const prepareLockUpgrade = require('../scripts/upgrade/submitLockVersion')
-    await prepareLockUpgrade({ publicLockAddress, publicLockVersion })
+    await prepareLockUpgrade({ publicLockAddress, publicLockVersion, addOnly })
   })
 
 task(


### PR DESCRIPTION
# Description

This adds a way to submit a PublicLock template to a multisig with `addLockTemplate` w/o running `setLockTemplate`. The PR also contains a bunch of improvements and fixes to the `propose:upgrade` task, allowing to pick a specific version of a contract.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

