### PR TITLE
fix(smart-contracts): allow create sample locks at version from cli

### DIFF
--- a/smart-contracts/scripts/deployments/lock.js
+++ b/smart-contracts/scripts/deployments/lock.js
@@ -27,7 +27,7 @@ async function main({
     serializedLock
 
   // eslint-disable-next-line no-console
-  console.log(`LOCK DEPLOY > creating a new lock '${name}'...`)
+  console.log(`LOCK DEPLOY > creating a new lock (${lockVersion ? 'latest' : `v${lockVersion}`}) '${name}'...`)
 
   let tx
   if (unlockVersion < 10) {

--- a/smart-contracts/tasks/lock.js
+++ b/smart-contracts/tasks/lock.js
@@ -49,16 +49,16 @@ task('lock:clone', 'Redeploy an identical lock')
   )
 
 task('lock:samples', 'Deploy a sample lock')
-  .addParam('unlockAddress', 'The Unlock contract address')
+  .addOptionalParam('unlockAddress', 'The Unlock contract address')
   .addOptionalParam('tokenAddress', 'The ERC20 token address')
   .addOptionalParam(
-    'unlockVersion',
-    'The Unlock version to use to deploy the contract'
+    'lockVersion',
+    'The PublicLock version to use when deploying the lock'
   )
-  .setAction(async ({ unlockAddress, unlockVersion }) => {
+  .setAction(async ({ unlockAddress, lockVersion }) => {
     // eslint-disable-next-line global-require
     const deploySampleLocks = require('../scripts/lock/samples')
-    await deploySampleLocks({ unlockAddress, unlockVersion })
+    await deploySampleLocks({ unlockAddress, lockVersion })
   })
 
 task('lock:create', 'Deploy a lock')


### PR DESCRIPTION
# Description

This adds a simpler approach when creating sample locks from hardhat cli by fetching unlock address directly from our networks package + allowing to pass a version number to create lock at specific version.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

