### PR TITLE
fix(unlock-js): prevent versions higher than 12 when creating a lock from "old" Unlock on mainnet

### DIFF
--- a/packages/unlock-js/src/Unlock/v11/createLock.js
+++ b/packages/unlock-js/src/Unlock/v11/createLock.js
@@ -32,8 +32,12 @@ async function _getKeyPrice(lock, provider) {
 export default async function (lock, transactionOptions = {}, callback) {
   const unlockContract = await this.getUnlockContract()
 
-  const lockVersion =
-    lock.publicLockVersion || (await unlockContract.publicLockLatestVersion())
+  const publicLockLatestVersion =
+    unlockContract.getAddress() === '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
+      ? 12
+      : await unlockContract.publicLockLatestVersion()
+
+  const lockVersion = lock.publicLockVersion || publicLockLatestVersion
 
   let { maxNumberOfKeys, expirationDuration } = lock
   if (maxNumberOfKeys === UNLIMITED_KEYS_COUNT) {

--- a/packages/unlock-js/src/Unlock/v11/createLock.js
+++ b/packages/unlock-js/src/Unlock/v11/createLock.js
@@ -32,7 +32,9 @@ async function _getKeyPrice(lock, provider) {
 export default async function (lock, transactionOptions = {}, callback) {
   const unlockContract = await this.getUnlockContract()
 
+  // prevent "old" Unlock on mainnet from deploying versions higher than 12
   const publicLockLatestVersion =
+    this.networkId === 1 &&
     unlockContract.getAddress() === '0x3d5409CcE1d45233dE1D4eBDEe74b8E004abDD13'
       ? 12
       : await unlockContract.publicLockLatestVersion()


### PR DESCRIPTION
# Description

This introduces a fix to prevent the "old" Unlock mainnet to deploy locks with versions higher than 12.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

