### PR TITLE
feature(subgraph): adding createdAt to keys

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -50,6 +50,8 @@ type Key @entity {
   tokenURI: String
   "Block key was created"
   createdAtBlock: BigInt!
+  "Timestamp of the block in which the key was created"
+  createdAt: BigInt!
   "Invoked by a Lock manager to expire the user's key and perform a refund and cancellation of the key"
   cancelled: Boolean
   "list of transaction hashes for purchase/extensions of a specific token"

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -39,6 +39,7 @@ function newKey(event: TransferEvent): void {
   key.lock = event.address.toHexString()
   key.tokenId = event.params.tokenId
   key.owner = event.params.to
+  key.createdAt = event.block.timestamp
   key.createdAtBlock = event.block.number
   key.cancelled = false
 

--- a/subgraph/tests/keys.test.ts
+++ b/subgraph/tests/keys.test.ts
@@ -66,6 +66,7 @@ describe('Key transfers (v8)', () => {
     assert.fieldEquals('Key', keyIDV8, 'tokenURI', `${tokenURI}`)
     assert.fieldEquals('Key', keyIDV8, 'expiration', `${expiration}`)
     assert.fieldEquals('Key', keyIDV8, 'createdAtBlock', '1')
+    assert.fieldEquals('Key', keyIDV8, 'createdAt', '1')
   })
 
   afterAll(() => {


### PR DESCRIPTION
# Description

This is so we can add this to the key metadata and use it in certificates.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

