### PR TITLE
feature(locksmith): introducing the ability to not convert when gas is fully subsidized

### DIFF
--- a/locksmith/src/utils/gasPrice.ts
+++ b/locksmith/src/utils/gasPrice.ts
@@ -18,6 +18,11 @@ export default class GasPrice {
 
   // Gas price denominated in cents
   async gasPriceUSD(network: number, gasCost: number): Promise<number> {
+    // Adding an excption for chains for which gas is fully subsidized
+    if (networks[network].fullySubsidizedGas) {
+      return 0
+    }
+
     const gasPrice = await this.gasPriceETH(network, gasCost)
     // Cost in currency
     let symbol = 'ETH'

--- a/locksmith/src/utils/keyPricer.ts
+++ b/locksmith/src/utils/keyPricer.ts
@@ -51,6 +51,10 @@ export default class KeyPricer {
       )
       throw new Error(`Missing currency`)
     }
+    // If key is free, no need to convert!
+    if (lock.keyPrice === '0') {
+      return 0
+    }
     const priceConversion = new PriceConversion()
     const usdPrice = await priceConversion.convertToUSD(
       symbol.toUpperCase(),

--- a/locksmith/src/utils/priceConversion.ts
+++ b/locksmith/src/utils/priceConversion.ts
@@ -17,7 +17,6 @@ export default class PriceConversion {
    */
   async convertToUSD(currency: string, lockPriceAmount: number) {
     const cached = cache[currency]
-
     let rate
     // Cache is valid for 5 minutes!
     if (cached && cached[0] > new Date().getTime() - 1000 * 60 * 5) {

--- a/packages/networks/src/networks/base-goerli.ts
+++ b/packages/networks/src/networks/base-goerli.ts
@@ -43,6 +43,7 @@ export const baseGoerli: NetworkConfig = {
   },
   startBlock: 2247300,
   isTestNetwork: true,
+  fullySubsidizedGas: true,
   maxFreeClaimCost: 10000,
 }
 

--- a/packages/networks/src/networks/goerli.ts
+++ b/packages/networks/src/networks/goerli.ts
@@ -43,6 +43,7 @@ export const goerli: NetworkConfig = {
   startBlock: 7179039,
   previousDeploys: [],
   isTestNetwork: true,
+  fullySubsidizedGas: true,
   maxFreeClaimCost: 100000,
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/packages/networks/src/networks/localhost.ts
+++ b/packages/networks/src/networks/localhost.ts
@@ -19,4 +19,5 @@ export const localhost: NetworkConfig = {
   serializerAddress: '0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1',
   description: 'Localhost network.',
   isTestNetwork: true,
+  fullySubsidizedGas: true,
 }

--- a/packages/networks/src/networks/mumbai.ts
+++ b/packages/networks/src/networks/mumbai.ts
@@ -39,6 +39,7 @@ export const mumbai: NetworkConfig = {
   url: 'https://mumbai.polygonscan.com/',
   faucet: 'https://faucet.polygon.technology/',
   isTestNetwork: true,
+  fullySubsidizedGas: true,
   maxFreeClaimCost: 500,
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/packages/networks/src/networks/palm.ts
+++ b/packages/networks/src/networks/palm.ts
@@ -1,6 +1,7 @@
 import { NetworkConfig } from '@unlock-protocol/types'
 
 export const palm: NetworkConfig = {
+  fullySubsidizedGas: true,
   publicProvider:
     'https://palm-mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
   provider: 'https://rpc.unlock-protocol.com/11297108109',

--- a/packages/types/src/types/unlockTypes.ts
+++ b/packages/types/src/types/unlockTypes.ts
@@ -123,6 +123,7 @@ export interface NetworkConfig {
   faucet?: string
   tokens?: Token[]
   hooks?: Partial<Record<HookName, Hook[]>>
+  fullySubsidizedGas?: boolean
 }
 
 export interface NetworkConfigs {

--- a/packages/unlock-js/src/abis.ts
+++ b/packages/unlock-js/src/abis.ts
@@ -1055,7 +1055,7 @@ const abis = {
         "function updateTransferFee(uint256 _transferFeeBasisPoints)",
         "function withdraw(address _tokenAddress,address _recipient,uint256 _amount)"
       ],
-      "bytecodeHash": "0x5b13a272434d7a229c5be2a3dc5d71ba0140f15ff7953c3212eff9d0675cc102"
+      "bytecodeHash": "0x363551a7e8051fe1a13a8430e2277433660616ebf20394bf1c7c7001f949e2d7"
     }
   },
   "Unlock": {


### PR DESCRIPTION
# Description

Some chains like Palm are fine with subsidizing gas fully.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

