### PR TITLE
fix(smart-contracts): get correct nonce when submitting multisig tx

### DIFF
--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -21,7 +21,7 @@ const safeServiceURLs = {
   42161: 'https://safe-transaction-arbitrum.safe.global',
   43114: 'https://safe-transaction-avalanche.safe.global/',
   42220:
-    'https://transaction-service.gnosis-safe-staging.celo-networks-dev.org',
+    'https://safe-transaction-celo.safe.global/',
   // mumbai isnt supported by Safe Global, you need to run Safe infrastructure locally
   80001: 'http://localhost:8000/cgw/',
 }

--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -107,26 +107,24 @@ async function main({ safeAddress, tx, signer }) {
   )
   console.log(transactions)
 
+  const nonce = await safeService.getNextNonce(safeAddress)
   const txOptions = {
     origin: explainer,
-    // safeTxGas, // Optional
-    // baseGas, // Optional
-    // gasPrice, // Optional
-    // gasToken, // Optional
-    // refundReceiver, // Optional
-    // nonce // Optional
+    nonce // make sure we get the correct nonce, so we dont override
+          // txs that havent been executed yet
   }
 
   // create a MultiSend tx
   const safeTransaction = await safeSdk.createTransaction({
     safeTransactionData: transactions,
-    options: txOptions,
+    options: txOptions, 
   })
 
   // now send tx via Safe Global web service
   const safeTxHash = await safeSdk.getTransactionHash(safeTransaction)
   const senderSignature = await safeSdk.signTransactionHash(safeTxHash)
   // const nonce = await safeService.getNextNonce(safeAddress)
+  
   await safeService.proposeTransaction({
     safeAddress,
     safeTransactionData: safeTransaction.data,
@@ -135,8 +133,8 @@ async function main({ safeAddress, tx, signer }) {
     senderSignature: senderSignature.data,
   })
 
-  const { nonce } = await safeService.getTransaction(safeTxHash)
-  console.log(`Tx submitted to multisig with id: '${nonce}'`)
+  const { nonce: actualNonce } = await safeService.getTransaction(safeTxHash)
+  console.log(`Tx submitted to multisig with id: '${actualNonce}'`)
 
   if (process.env.RUN_MAINNET_FORK) {
       console.log(`Signing multisigs: ${nonce}`)


### PR DESCRIPTION
# Description

This PR make sure we get the correct nonce when submitting a tx on Safe Global multisig, so we dont override txs that havent been executed yet.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

