### PR TITLE
fix(smart-contracts): use safe.celo.org as default service for multisig on Celo

### DIFF
--- a/smart-contracts/scripts/multisig/submitTx.js
+++ b/smart-contracts/scripts/multisig/submitTx.js
@@ -20,8 +20,7 @@ const safeServiceURLs = {
   137: 'https://safe-transaction-polygon.safe.global/',
   42161: 'https://safe-transaction-arbitrum.safe.global',
   43114: 'https://safe-transaction-avalanche.safe.global/',
-  42220:
-    'https://safe-transaction-celo.safe.global/',
+  42220: 'http://mainnet-tx-svc.celo-safe-prod.celo-networks-dev.org/',
   // mumbai isnt supported by Safe Global, you need to run Safe infrastructure locally
   80001: 'http://localhost:8000/cgw/',
 }


### PR DESCRIPTION
# Description

This replace the Safe transaction service URL with the correct one for using safe.celo.org

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

