### PR TITLE
fix(ui): adding QueryClient inside of AddressComponent

### DIFF
--- a/packages/ui/lib/components/Form/AddressInput.tsx
+++ b/packages/ui/lib/components/Form/AddressInput.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios'
 import {
   InputHTMLAttributes,
   ForwardedRef,
@@ -10,8 +11,35 @@ import { forwardRef } from 'react'
 import { FaWallet, FaSpinner } from 'react-icons/fa'
 import { IconBaseProps } from 'react-icons'
 import { isAddressOrEns, minifyAddress } from '../../utils'
-import { useMutation } from '@tanstack/react-query'
+import {
+  useMutation,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
+
 import { Input } from './Input'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 10,
+      refetchInterval: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchIntervalInBackground: false,
+      retry: (failureCount, error) => {
+        if (error instanceof AxiosError) {
+          return ![400, 401, 403, 404].includes(error.response?.status || 0)
+        }
+        if (failureCount > 3) {
+          return false
+        }
+        return true
+      },
+    },
+  },
+})
+
 export interface Props
   extends Omit<
     InputHTMLAttributes<HTMLInputElement>,
@@ -32,6 +60,105 @@ const WalletIcon = (props: IconBaseProps) => (
 const LoadingIcon = (props: IconBaseProps) => (
   <FaSpinner {...props} className="fill-gray-500" />
 )
+
+export const WrappedAddressInput = ({
+  size = 'medium',
+  value,
+  defaultValue,
+  className,
+  description,
+  label,
+  withIcon = true,
+  isTruncated = false, // address not truncated by default
+  onChange,
+  onResolveName,
+  ...inputProps
+}: Props) => {
+  const [error, setError] = useState<any>('')
+  const [success, setSuccess] = useState('')
+  const [address, setAddress] = useState<string>(value as string)
+
+  const onReset = () => {
+    setError('')
+    setSuccess('')
+  }
+
+  const resolveNameMutation = useMutation(onResolveName, {
+    onMutate: () => {
+      onReset() // restore state when typing
+    },
+  })
+
+  const handleResolver = async (address: string) => {
+    try {
+      const res: any = await resolveNameMutation.mutateAsync(address)
+      if (res) {
+        const isError = res?.type === 'error'
+
+        setError(isError ? `It's not a valid ens name or address` : '') // set error when is error
+
+        if (res && (res?.type || '')?.length > 0) {
+          if (res.type === 'address') {
+            setSuccess(res.name)
+          }
+
+          if (res.type === 'name') {
+            setSuccess(res.address)
+          }
+        }
+        return res.address
+      }
+      return ''
+    } catch (err) {
+      onReset()
+      setError(`It's not a valid ens name or address`)
+      return ''
+    }
+  }
+
+  useEffect(() => {
+    if (
+      (typeof defaultValue === 'string' && defaultValue.length === 0) ||
+      (typeof value === 'string' && value === '')
+    ) {
+      setAddress('')
+      onReset()
+    }
+  }, [defaultValue, value])
+
+  return (
+    <Input
+      {...inputProps}
+      type="address"
+      value={address}
+      label={label}
+      error={error}
+      success={isTruncated ? minifyAddress(success) : success}
+      description={description}
+      iconClass={resolveNameMutation.isLoading ? 'animate-spin' : ''}
+      icon={resolveNameMutation.isLoading ? LoadingIcon : WalletIcon}
+      onChange={async (e) => {
+        const value: string = e.target.value
+        await resolveNameMutation.reset() // reset mutation
+        setAddress(value)
+
+        if (isAddressOrEns(value)) {
+          try {
+            const res = await handleResolver(value)
+            if (typeof onChange === 'function' && res) {
+              onChange(res)
+            }
+          } catch (_err) {}
+        } else {
+          setError(`It's not a valid ens name or address`)
+          if (typeof onChange === 'function') {
+            onChange(value as any)
+          }
+        }
+      }}
+    />
+  )
+}
 
 /**
  * Primary Input component for React Hook Form
@@ -57,92 +184,10 @@ export const AddressInput = forwardRef(
       onResolveName,
       ...inputProps
     } = props
-
-    const [error, setError] = useState<any>('')
-    const [success, setSuccess] = useState('')
-    const [address, setAddress] = useState<string>(value as string)
-
-    const onReset = () => {
-      setError('')
-      setSuccess('')
-    }
-
-    const resolveNameMutation = useMutation(onResolveName, {
-      onMutate: () => {
-        onReset() // restore state when typing
-      },
-    })
-
-    const handleResolver = async (address: string) => {
-      try {
-        const res: any = await resolveNameMutation.mutateAsync(address)
-        if (res) {
-          const isError = res?.type === 'error'
-
-          setError(isError ? `It's not a valid ens name or address` : '') // set error when is error
-
-          if (res && (res?.type || '')?.length > 0) {
-            if (res.type === 'address') {
-              setSuccess(res.name)
-            }
-
-            if (res.type === 'name') {
-              setSuccess(res.address)
-            }
-          }
-          return res.address
-        }
-        return ''
-      } catch (err) {
-        onReset()
-        setError(`It's not a valid ens name or address`)
-        return ''
-      }
-    }
-
-    useEffect(() => {
-      if (
-        (typeof defaultValue === 'string' && defaultValue.length === 0) ||
-        (typeof value === 'string' && value === '')
-      ) {
-        setAddress('')
-        onReset()
-      }
-    }, [defaultValue, value])
-
     return (
-      <>
-        <Input
-          {...inputProps}
-          type="address"
-          value={address}
-          label={label}
-          error={error}
-          success={isTruncated ? minifyAddress(success) : success}
-          description={description}
-          iconClass={resolveNameMutation.isLoading ? 'animate-spin' : ''}
-          icon={resolveNameMutation.isLoading ? LoadingIcon : WalletIcon}
-          onChange={async (e) => {
-            const value: string = e.target.value
-            await resolveNameMutation.reset() // reset mutation
-            setAddress(value)
-
-            if (isAddressOrEns(value)) {
-              try {
-                const res = await handleResolver(value)
-                if (typeof onChange === 'function' && res) {
-                  onChange(res)
-                }
-              } catch (_err) {}
-            } else {
-              setError(`It's not a valid ens name or address`)
-              if (typeof onChange === 'function') {
-                onChange(value as any)
-              }
-            }
-          }}
-        />
-      </>
+      <QueryClientProvider client={queryClient}>
+        <WrappedAddressInput {...props} />
+      </QueryClientProvider>
     )
   }
 )

--- a/unlock-app/src/config/queryClient.ts
+++ b/unlock-app/src/config/queryClient.ts
@@ -14,9 +14,7 @@ export const queryClient = new QueryClient({
           return false
         }
         if (error instanceof AxiosError) {
-          return ![400, 401, 403, 404, 500].includes(
-            error.response?.status || 0
-          )
+          return ![400, 401, 403, 404].includes(error.response?.status || 0)
         }
         return true
       },


### PR DESCRIPTION
# Description

This should remove the need to downgrade.
I am surprised the library can't use the provider from `_app`, but I think it is cleaner this way anyway because it won't expect other apps to have a provider set


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

