### PR TITLE
feat(unlock-app) - correctly check network for picker

### DIFF
--- a/unlock-app/src/components/interface/Picker/index.tsx
+++ b/unlock-app/src/components/interface/Picker/index.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query'
 import { config } from '~/config/app'
 import { subgraph } from '~/config/subgraph'
 import { LockImage } from '../locks/Manage/elements/LockPicker'
-import LoadingIcon from '../Loading'
 import Link from 'next/link'
 import { ethers } from 'ethers'
 import { ToastHelper } from '~/components/helpers/toast.helper'
@@ -126,6 +125,7 @@ export function Picker({
       ? tokenUrl(lockAddress, state.keyId)
       : ''
 
+  const showLocks = state.network && collect.lockAddress && lockExists
   return (
     <div className="grid gap-4">
       {collect.network && (
@@ -141,34 +141,32 @@ export function Picker({
           description="Select the network your lock is on."
         />
       )}
-      {state.network &&
-        collect.lockAddress &&
-        (lockExists || isLoadingLocks ? (
-          isLoadingLocks ? (
-            <Placeholder.Line size="xl" />
-          ) : (
-            <Select
-              key={state.network}
-              label="Lock"
-              options={locksOptions}
-              defaultValue={lockAddress}
-              onChange={(lockAddress: any) => {
-                handleOnChange(lockAddress)
-              }}
-              customOption={customOption}
-              description="Select the lock you want to use."
-            />
-          )
+      {showLocks ? (
+        isLoadingLocks ? (
+          <Placeholder.Line size="xl" />
         ) : (
-          <div>
-            You have not deployed locks on this network yet.{' '}
-            <Link href="/locks/create">
-              <span className="font-medium underline cursor-pointer">
-                Deploy one now
-              </span>
-            </Link>
-          </div>
-        ))}
+          <Select
+            key={state.network}
+            label="Lock"
+            options={locksOptions}
+            defaultValue={lockAddress}
+            onChange={(lockAddress: any) => {
+              handleOnChange(lockAddress)
+            }}
+            customOption={customOption}
+            description="Select the lock you want to use."
+          />
+        )
+      ) : (
+        <div>
+          You have not deployed locks on this network yet.{' '}
+          <Link href="/locks/create">
+            <span className="font-medium underline cursor-pointer">
+              Deploy one now
+            </span>
+          </Link>
+        </div>
+      )}
       {state.lockAddress && lockExists && collect.key && (
         <Input
           className="w-full"

--- a/unlock-app/src/components/interface/Picker/index.tsx
+++ b/unlock-app/src/components/interface/Picker/index.tsx
@@ -10,6 +10,7 @@ import { ethers } from 'ethers'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import networks from '@unlock-protocol/networks'
 import { FiExternalLink as ExternalLinkIcon } from 'react-icons/fi'
+import { Placeholder } from '@unlock-protocol/ui'
 
 export interface PickerState {
   network?: number
@@ -45,7 +46,7 @@ export function Picker({
     keyId,
   })
 
-  const { data: locks, isInitialLoading } = useQuery(
+  const { data: locks, isLoading: isLoadingLocks } = useQuery(
     ['locks', userAddress, network],
     async () => {
       const locks = await subgraph.locks(
@@ -89,10 +90,6 @@ export function Picker({
   }, [state.network, locks])
 
   const lockExists = locksOptions.length > 0
-
-  if (isInitialLoading) {
-    return <LoadingIcon />
-  }
 
   const onChangeFn = (lockAddress: string) => {
     setState((state) => ({
@@ -146,18 +143,22 @@ export function Picker({
       )}
       {state.network &&
         collect.lockAddress &&
-        (lockExists ? (
-          <Select
-            key={state.network}
-            label="Lock"
-            options={locksOptions}
-            defaultValue={lockAddress}
-            onChange={(lockAddress: any) => {
-              handleOnChange(lockAddress)
-            }}
-            customOption={customOption}
-            description="Select the lock you want to use."
-          />
+        (lockExists || isLoadingLocks ? (
+          isLoadingLocks ? (
+            <Placeholder.Line size="xl" />
+          ) : (
+            <Select
+              key={state.network}
+              label="Lock"
+              options={locksOptions}
+              defaultValue={lockAddress}
+              onChange={(lockAddress: any) => {
+                handleOnChange(lockAddress)
+              }}
+              customOption={customOption}
+              description="Select the lock you want to use."
+            />
+          )
         ) : (
           <div>
             You have not deployed locks on this network yet.{' '}

--- a/unlock-app/src/components/interface/Picker/index.tsx
+++ b/unlock-app/src/components/interface/Picker/index.tsx
@@ -46,14 +46,19 @@ export function Picker({
   })
 
   const { data: locks, isInitialLoading } = useQuery(
-    ['locks', userAddress],
+    ['locks', userAddress, network],
     async () => {
-      const locks = await subgraph.locks({
-        first: 100,
-        where: {
-          lockManagers_contains: [userAddress.toLowerCase()],
+      const locks = await subgraph.locks(
+        {
+          first: 100,
+          where: {
+            lockManagers_contains: [userAddress.toLowerCase()],
+          },
         },
-      })
+        {
+          networks: [network],
+        }
+      )
       return locks
     }
   )

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -354,17 +354,9 @@ export const ManageLockPage = () => {
             <div className="w-1/2">
               <Picker
                 userAddress={owner!}
-                network={Number(network)}
-                lockAddress={lockAddress}
-                collect={{
-                  network: true,
-                  lockAddress: true,
-                }}
                 onChange={({ lockAddress, network }) => {
-                  if (lockAddress) {
+                  if (lockAddress && network) {
                     setLockAddress(lockAddress)
-                  }
-                  if (network) {
                     setNetwork(`${network}`)
                   }
                 }}

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -309,7 +309,8 @@ export const ManageLockPage = () => {
 
   const lockNetwork = network ? parseInt(network as string) : undefined
 
-  const withoutParams = !lockAddress && !lockNetwork
+  const withoutParams =
+    !query?.lockAddress && !query.network && !(lockAddress && network)
 
   const { isManager, isLoading: isLoadingLockManager } = useLockManager({
     lockAddress,
@@ -333,13 +334,6 @@ export const ManageLockPage = () => {
     setAirdropKeys(!airdropKeys)
   }
 
-  const onLockPick = (lockAddress?: string, network?: string | number) => {
-    if (lockAddress && network) {
-      setLockAddress(lockAddress)
-      setNetwork(`${network}`)
-    }
-  }
-
   const LockSelection = () => {
     const resetLockSelection = () => {
       setLockAddress('')
@@ -355,13 +349,24 @@ export const ManageLockPage = () => {
         {withoutParams ? (
           <>
             <h2 className="mb-2 text-lg font-bold text-brand-ui-primary">
-              Select a lock to start manage it
+              Select a lock to start manage it s
             </h2>
             <div className="w-1/2">
               <Picker
                 userAddress={owner!}
-                onChange={(state) => {
-                  onLockPick(state.lockAddress, state.network)
+                network={Number(network)}
+                lockAddress={lockAddress}
+                collect={{
+                  network: true,
+                  lockAddress: true,
+                }}
+                onChange={({ lockAddress, network }) => {
+                  if (lockAddress) {
+                    setLockAddress(lockAddress)
+                  }
+                  if (network) {
+                    setNetwork(`${network}`)
+                  }
                 }}
               />
             </div>

--- a/unlock-app/src/components/interface/locks/metadata/index.tsx
+++ b/unlock-app/src/components/interface/locks/metadata/index.tsx
@@ -230,8 +230,8 @@ export function UpdateMetadataForm({ lockAddress, network, keyId }: Props) {
           </div>
           <Picker
             userAddress={account!}
-            lockAddress={lockAddress}
-            network={network}
+            lockAddress={selected.lockAddress}
+            network={selected.network}
             keyId={keyId}
             collect={{
               lockAddress: true,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
On `Picker`, we load all the network and it take forever (some issue on Base that slows everything) 
let's only load the locks for the selected network: 

**Issue** 

https://user-images.githubusercontent.com/20865711/232126453-fa44e79b-3253-4827-9253-216341c48bfb.mov


**Base issue** 

<img width="567" alt="Screenshot 2023-04-14 at 19 52 34" src="https://user-images.githubusercontent.com/20865711/232126705-2501a22a-0d48-4117-84c1-4b8520f3e323.png">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

