### PR TITLE
refactor(unlock-js): Return fallback value on subgraph error

### DIFF
--- a/packages/unlock-js/src/subgraph/index.ts
+++ b/packages/unlock-js/src/subgraph/index.ts
@@ -52,12 +52,17 @@ export class SubgraphService {
       Object.values(this.networks).filter((item) => item.id !== 31337)
     const items = await Promise.all(
       networks.map(async (config) => {
-        const sdk = this.createSdk(config.id)
-        const results = await sdk.allLocks(variables)
-        return results.locks.map((item) => ({
-          ...item,
-          network: config.id,
-        }))
+        try {
+          const sdk = this.createSdk(config.id)
+          const results = await sdk.allLocks(variables)
+          return results.locks.map((item) => ({
+            ...item,
+            network: config.id,
+          }))
+        } catch (error) {
+          console.error(error)
+          return []
+        }
       })
     )
     return items.flat()
@@ -84,12 +89,17 @@ export class SubgraphService {
       Object.values(this.networks).filter((item) => item.id !== 31337)
     const items = await Promise.all(
       networks.map(async (config) => {
-        const sdk = this.createSdk(config.id)
-        const results = await sdk.allLocksWithKeys(variables)
-        return results.locks.map((item) => ({
-          ...item,
-          network: config.id,
-        }))
+        try {
+          const sdk = this.createSdk(config.id)
+          const results = await sdk.allLocksWithKeys(variables)
+          return results.locks.map((item) => ({
+            ...item,
+            network: config.id,
+          }))
+        } catch (error) {
+          console.error(error)
+          return []
+        }
       })
     )
     return items.flat()
@@ -124,12 +134,17 @@ export class SubgraphService {
 
     const items = await Promise.all(
       networks.map(async (config) => {
-        const sdk = this.createSdk(config.id)
-        const results = await sdk.AllKeys(variables)
-        return results.keys.map((item) => ({
-          ...item,
-          network: config.id,
-        }))
+        try {
+          const sdk = this.createSdk(config.id)
+          const results = await sdk.AllKeys(variables)
+          return results.keys.map((item) => ({
+            ...item,
+            network: config.id,
+          }))
+        } catch (error) {
+          console.error(error)
+          return []
+        }
       })
     )
 
@@ -155,12 +170,17 @@ export class SubgraphService {
 
     const items = await Promise.all(
       networks.map(async (config) => {
-        const sdk = this.createSdk(config.id)
-        const results = await sdk.AllReceipts(variables)
-        return results.receipts.map((item) => ({
-          ...item,
-          network: config.id,
-        }))
+        try {
+          const sdk = this.createSdk(config.id)
+          const results = await sdk.AllReceipts(variables)
+          return results.receipts.map((item) => ({
+            ...item,
+            network: config.id,
+          }))
+        } catch (error) {
+          console.error(error)
+          return []
+        }
       })
     )
     return items.flat()


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Opening as draft to discuss the solution with errors when querying multiple subgraphs. 

1. Provide fallback empty value and log an error.
2. Change the return object to { items: [], errors: [] } which will break the API but much better. 


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

