### PR TITLE
feat(locksmith) - add credit card price on settings

### DIFF
--- a/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
+++ b/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
@@ -12,6 +12,7 @@ const lockSettingMock = {
   lockAddress: '0xF3850C690BFF6c1E343D2449bBbbb00b0E934f7b',
   network,
   sendEmail: true,
+  creditCardPrice: 0.04,
   replyTo: 'example@gmail.com',
   createdAt: '2023-03-24T15:40:54.509Z',
   updatedAt: '2023-03-24T15:40:54.509Z',
@@ -117,7 +118,7 @@ describe('LockSettings v2 endpoints for lock', () => {
   })
 
   it('should correctly save settings when user is lockManager', async () => {
-    expect.assertions(3)
+    expect.assertions(4)
 
     const { loginResponse } = await loginRandomUser(app)
     const saveSettingResponse = await request(app)
@@ -131,11 +132,12 @@ describe('LockSettings v2 endpoints for lock', () => {
     const response = saveSettingResponse.body
     expect(saveSettingResponse.status).toBe(200)
     expect(response.sendEmail).toBe(false)
+    expect(response.creditCardPrice).toBe(null)
     expect(response.replyTo).toBe('example@gmail.com')
   })
 
   it('should save and retrieve setting when user is lockManager', async () => {
-    expect.assertions(7)
+    expect.assertions(9)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -146,12 +148,14 @@ describe('LockSettings v2 endpoints for lock', () => {
       .send({
         sendEmail: false,
         replyTo: 'example@gmail.com',
+        creditCardPrice: 0.04,
       })
 
     const response = saveSettingResponse.body
     expect(saveSettingResponse.status).toBe(200)
     expect(response.sendEmail).toBe(false)
     expect(response.replyTo).toBe('example@gmail.com')
+    expect(response.creditCardPrice).toBe(0.04)
 
     // retrieve settings
     const getSettingResponse = await request(app)
@@ -160,14 +164,17 @@ describe('LockSettings v2 endpoints for lock', () => {
 
     expect(getSettingResponse.status).toBe(200)
     expect(getSettingResponse.body.sendEmail).toBe(false)
-    expect(getSettingResponse.body.replyTo).toBe('example@gmail.com')
+    expect(getSettingResponse.body.replyTo).toBe(lockSettingMock.replyTo)
     expect(getSettingResponse.body.lockAddress).toBe(
       lockSettingMock.lockAddress
+    )
+    expect(getSettingResponse.body.creditCardPrice).toBe(
+      lockSettingMock.creditCardPrice
     )
   })
 
   it('should retrieve default settings for a lock', async () => {
-    expect.assertions(3)
+    expect.assertions(4)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -180,5 +187,6 @@ describe('LockSettings v2 endpoints for lock', () => {
       DEFAULT_LOCK_SETTINGS.sendEmail
     )
     expect(getSettingResponse.body.replyTo).toBe(undefined)
+    expect(getSettingResponse.body.creditCardPrice).toBe(undefined)
   })
 })

--- a/locksmith/migrations/20230424180440-add-credit-card-price-to-lock-settings.js
+++ b/locksmith/migrations/20230424180440-add-credit-card-price-to-lock-settings.js
@@ -1,0 +1,17 @@
+'use strict'
+const table = 'LockSettings'
+/** @type {import('sequelize-cli').Migration} */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(table, 'creditCardPrice', {
+      type: Sequelize.FLOAT,
+      allowNull: true,
+      defaultValue: null,
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(table, 'creditCardPrice')
+  },
+}

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -16,6 +16,11 @@ const LockSettingSchema = z.object({
         'Set the email address that will appear on the Reply-To: field.',
     })
     .optional(),
+  creditCardPrice: z
+    .number({
+      description: 'Credit card default price to use on checkout,',
+    })
+    .optional(),
 })
 
 export type LockSettingProps = z.infer<typeof LockSettingSchema>
@@ -23,6 +28,7 @@ export type LockSettingProps = z.infer<typeof LockSettingSchema>
 export const DEFAULT_LOCK_SETTINGS: LockSettingProps = {
   sendEmail: true,
   replyTo: undefined,
+  creditCardPrice: undefined,
 }
 
 export const updateSettings: RequestHandler = async (
@@ -42,6 +48,7 @@ export const updateSettings: RequestHandler = async (
     })
     return response.status(200).send(settings)
   } catch (err: any) {
+    console.log('errore', err)
     logger.error(err.message)
     return response.status(500).send({
       message: 'Could not save setting, please try again.',

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -18,7 +18,7 @@ const LockSettingSchema = z.object({
     .optional(),
   creditCardPrice: z
     .number({
-      description: 'Credit card default price to use on checkout,',
+      description: 'Credit card default price to use on checkout.',
     })
     .optional(),
 })

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -48,7 +48,6 @@ export const updateSettings: RequestHandler = async (
     })
     return response.status(200).send(settings)
   } catch (err: any) {
-    console.log('errore', err)
     logger.error(err.message)
     return response.status(500).send({
       message: 'Could not save setting, please try again.',

--- a/locksmith/src/models/lockSetting.ts
+++ b/locksmith/src/models/lockSetting.ts
@@ -10,6 +10,7 @@ export class LockSetting extends Model<
   declare network: number
   declare sendEmail: boolean
   declare replyTo?: string
+  declare creditCardPrice?: number
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 }
@@ -28,6 +29,11 @@ LockSetting.init(
     sendEmail: {
       type: DataTypes.BOOLEAN,
       defaultValue: true,
+    },
+    creditCardPrice: {
+      type: DataTypes.FLOAT,
+      allowNull: true,
+      defaultValue: null,
     },
     replyTo: {
       type: DataTypes.STRING,

--- a/locksmith/src/operations/lockSettingOperations.ts
+++ b/locksmith/src/operations/lockSettingOperations.ts
@@ -18,6 +18,7 @@ export async function saveSettings({
   network,
   sendEmail,
   replyTo,
+  creditCardPrice,
 }: SendEmailProps & LockSettingProps) {
   return await LockSetting.upsert(
     {
@@ -25,6 +26,7 @@ export async function saveSettings({
       network,
       sendEmail,
       replyTo,
+      creditCardPrice,
     },
     {
       returning: true,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

As part of https://github.com/unlock-protocol/unlock/issues/10583, we add a new settings parameter that allows setting a credit card price for a specific lock 



<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

