### PR TITLE
fix(unlock-app): only lock managers are able to upload banners

### DIFF
--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -84,6 +84,10 @@ const CoverImageDrawer = ({
   handleClose,
 }: CoverImageDrawerProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const { isManager: isLockManager } = useLockManager({
+    lockAddress,
+    network,
+  })
 
   const { mutateAsync: uploadImage, isLoading: isUploading } = useImageUpload()
 
@@ -109,7 +113,7 @@ const CoverImageDrawer = ({
 
   return (
     <div className="relative inset-0 z-[1]">
-      {!isOpen && (
+      {isLockManager && (
         <Button
           className="absolute bottom-3 right-3 md:bottom-8 nd:right-9"
           variant="secondary"

--- a/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
@@ -82,7 +82,9 @@ export const Members = ({
         },
         queryKey: ['getSubgraphLock', lockAddress, network],
         onError: () => {
-          ToastHelper.error('Unable to fetch lock from subgraph')
+          ToastHelper.error(
+            `Unable to fetch lock ${lockAddress} from subgraph on network ${network}`
+          )
         },
       },
       {


### PR DESCRIPTION
# Description

Hiding the button when viewer is not a lock manager.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

