### PR TITLE
fix(locksmith): showing only "ready" Stripe accounts

### DIFF
--- a/locksmith/src/controllers/v2/stripeController.ts
+++ b/locksmith/src/controllers/v2/stripeController.ts
@@ -69,6 +69,7 @@ export const getConnectionsForManager = async (req: Request, res: Response) => {
   ).filter((connection) => !!connection)
 
   return res.json({
+    // @ts-expect-error Property 'lock' | 'chain' | 'stripeAccount' does not exist on type 'false | StripeConnectLock'.
     result: activeStripeAccounts.map(({ lock, chain, stripeAccount }) => ({
       lock,
       chain,

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -209,15 +209,20 @@ export const getStripeConnectForLock = async (lock: string, chain: number) => {
     return -1
   }
 
-  const account = await stripe.accounts.retrieve(
+  const isReady = await stripeConnectionReady(
     stripeConnectLockDetails.stripeAccount
   )
 
-  if (account.charges_enabled) {
+  if (isReady) {
     return stripeConnectLockDetails.stripeAccount
   }
 
   return 0
+}
+
+export const stripeConnectionReady = async (stripeAccount: string) => {
+  const account = await stripe.accounts.retrieve(stripeAccount)
+  return account.charges_enabled
 }
 
 export default {


### PR DESCRIPTION
# Description

When connecting a lock via credit card, we let the select the same Stripe account as a connect one from before.
Let's only show the ones which are connected.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

