### PR TITLE
feat(locksmith) - allow null values lock settings

### DIFF
--- a/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
+++ b/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
@@ -205,4 +205,25 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(getSettingResponse.body.slug).toBe(undefined)
     expect(getSettingResponse.body.emailSender).toBe(undefined)
   })
+
+  it('should save null values for settings', async () => {
+    expect.assertions(4)
+
+    const { loginResponse } = await loginRandomUser(app)
+    // save settings
+    const saveSettingResponse = await request(app)
+      .post(`/v2/lock-settings/${network}/locks/${lockSettingMock.lockAddress}`)
+      .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
+      .send({
+        replyTo: null,
+        creditCardPrice: null,
+        emailSender: null,
+      })
+
+    const response = saveSettingResponse.body
+    expect(saveSettingResponse.status).toBe(200)
+    expect(response.replyTo).toBe(null)
+    expect(response.creditCardPrice).toBe(null)
+    expect(response.emailSender).toBe(null)
+  })
 })

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -15,18 +15,18 @@ const LockSettingSchema = z.object({
       description:
         'Set the email address that will appear on the Reply-To: field.',
     })
-    .optional(),
+    .nullish(),
   creditCardPrice: z
     .number({
       description: 'Credit card default price to use on checkout.',
     })
-    .optional(),
+    .nullish(),
   emailSender: z
     .string({
       description:
         'Custom name used as the email sender. This is the name that most email clients will show to readers.',
     })
-    .optional(),
+    .nullish(),
   slug: z
     .string({
       description: 'Slug that will be used to retrieve the lock',

--- a/locksmith/src/models/lockSetting.ts
+++ b/locksmith/src/models/lockSetting.ts
@@ -9,9 +9,9 @@ export class LockSetting extends Model<
   declare lockAddress: string
   declare network: number
   declare sendEmail: boolean
-  declare replyTo?: string
-  declare creditCardPrice?: number
-  declare emailSender?: string
+  declare replyTo?: string | null
+  declare creditCardPrice?: number | null
+  declare emailSender?: string | null
   declare slug?: string
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -374,6 +374,28 @@ components:
         type:
           type: string
 
+    LockSettings:
+      type: object
+      nullable: false
+      properties:
+        lockAddress:
+          type: string
+        network:
+          type: number
+        sendEmail:
+          type: boolean
+        slug:
+          type: string
+        replyTo:
+          type: string
+          nullable: true
+        creditCardPrice:
+          type: number
+          nullable: true
+        emailSender:
+          type: string
+          nullable: true
+
   parameters:
     Network:
       in: path
@@ -2482,22 +2504,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  sendEmail:
-                    type: boolean
-                  replyTo:
-                    type: string
-                  creditCardPrice:
-                    type: number
-                  slug:
-                    type: string
-                  lockAddress:
-                    type: string
-                  network:
-                    type: number
-                  emailSender:
-                    type: string
+                $ref: '#/components/schemas/LockSettings'
 
   /v2/lock-settings/{network}/locks/{lockAddress}:
     get:
@@ -2513,22 +2520,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  sendEmail:
-                    type: boolean
-                  replyTo:
-                    type: string
-                  creditCardPrice:
-                    type: number
-                  slug:
-                    type: string
-                  lockAddress:
-                    type: string
-                  network:
-                    type: number
-                  emailSender:
-                    type: string
+                $ref: '#/components/schemas/LockSettings'
 
         404:
           description: Setting not found
@@ -2564,22 +2556,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                sendEmail:
-                  type: boolean
-                replyTo:
-                  type: string
-                creditCardPrice:
-                  type: number
-                slug:
-                  type: string
-                lockAddress:
-                  type: string
-                network:
-                  type: number
-                emailSender:
-                  type: string
+              $ref: '#/components/schemas/LockSettings'
 
       responses:
         200:


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- allow `null` value for lock settings
- refactor `openapi` with schema object for lock settings 

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

