### PR TITLE
feature(unlock-app): improving formatting on the confirmation screen

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm.tsx
@@ -72,15 +72,35 @@ export function CreditCardPricingBreakdown({
       <div className="divide-y">
         <div className="flex justify-between w-full py-2 text-sm border-t border-gray-300">
           <span className="text-gray-600">Service Fee</span>
-          <div>${(unlockServiceFee / 100).toLocaleString()}</div>
+          <div>
+            $
+            {(unlockServiceFee / 100).toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2,
+            })}
+          </div>
         </div>
-        <div className="flex justify-between w-full py-2 text-sm">
-          <span className="text-gray-600"> Payment Processor </span>
-          <div>${(creditCardProcessingFee / 100).toLocaleString()}</div>
-        </div>
+        {!!creditCardProcessingFee && (
+          <div className="flex justify-between w-full py-2 text-sm">
+            <span className="text-gray-600"> Payment Processor </span>
+            <div>
+              $
+              {(creditCardProcessingFee / 100).toLocaleString(undefined, {
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 2,
+              })}
+            </div>
+          </div>
+        )}
         <div className="flex justify-between w-full py-2 text-sm border-t border-gray-300">
           <span className="text-gray-600"> Total </span>
-          <div className="font-bold">${(total / 100).toLocaleString()}</div>
+          <div className="font-bold">
+            $
+            {(total / 100).toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2,
+            })}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

This ensure we always show 2 decimals.


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

