### PR TITLE
feat(locksmith) - remove 404 for receipts-base

### DIFF
--- a/locksmith/src/controllers/v2/receiptBaseController.ts
+++ b/locksmith/src/controllers/v2/receiptBaseController.ts
@@ -30,9 +30,8 @@ export class ReceiptBaseController {
     )
 
     if (!receipt) {
-      return response.status(404).json({
-        message: 'No supplier found with the provided parameters.',
-      })
+      // no returning content
+      return response.sendStatus(204)
     }
 
     return response.status(200).json({

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -2123,7 +2123,7 @@ paths:
                     type: string
 
         204:
-          description: No supplier found with the provided parameters
+          description: No receipts found
 
         500:
           description: Failed to retrieve supplier details.

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -2122,6 +2122,9 @@ paths:
                   country:
                     type: string
 
+        204:
+          description: No supplier found with the provided parameters
+
         500:
           description: Failed to retrieve supplier details.
           content:


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
By returning `404` when we don't have a value for `/v2/receipts-base/{network}/{lockAddress}` endpoint, an error is visible on the FE.

Let's return instead `204` when no content if returned to avoid showing error modal 

**Issue** 

<img width="400" alt="Screenshot 2023-05-18 at 16 58 29" src="https://github.com/unlock-protocol/unlock/assets/20865711/81769656-2ca2-4831-9976-a0f41d07e9c4">

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

