### PR TITLE
fix: Add separate reset event for reseting checkout modal on close

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
@@ -123,6 +123,10 @@ interface BackEvent {
   type: CheckoutPage | 'BACK'
 }
 
+interface ResetEvent {
+  type: 'RESET_CHECKOUT'
+}
+
 export type CheckoutMachineEvents =
   | SelectLockEvent
   | SelectQuantityEvent
@@ -138,6 +142,7 @@ export type CheckoutMachineEvents =
   | RenewedEvent
   | UnlockAccountEvent
   | UpdatePaywallConfigEvent
+  | ResetEvent
   | DisconnectEvent
   | BackEvent
 
@@ -249,6 +254,10 @@ export const checkoutMachine = createMachine(
       },
       SUBMIT_DATA: {
         actions: ['submitData'],
+      },
+      RESET_CHECKOUT: {
+        target: 'SELECT',
+        actions: ['disconnect'],
       },
     },
     states: {

--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.typegen.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.typegen.ts
@@ -15,7 +15,7 @@ export interface Typegen0 {
   eventsCausingActions: {
     confirmMint: 'CONFIRM_MINT'
     confirmRenew: 'CONFIRM_RENEW'
-    disconnect: 'DISCONNECT'
+    disconnect: 'DISCONNECT' | 'RESET_CHECKOUT'
     selectLock: 'SELECT_LOCK'
     selectPaymentMethod: 'SELECT_PAYMENT_METHOD'
     selectQuantity: 'SELECT_QUANTITY'

--- a/unlock-app/src/components/interface/checkout/main/index.tsx
+++ b/unlock-app/src/components/interface/checkout/main/index.tsx
@@ -70,7 +70,7 @@ export function Checkout({
   const onClose = useCallback(
     (params: Record<string, string> = {}) => {
       // Reset the Paywall State!
-      checkoutService.send('DISCONNECT')
+      checkoutService.send('RESET_CHECKOUT')
       if (handleClose) {
         handleClose(params)
       } else if (redirectURI) {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

