### PR TITLE
feat(locksmith) - add receipt links for transaction wedlocks

### DIFF
--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -69,6 +69,7 @@ vi.mock('../../src/operations/userMetadataOperations', async () => {
       }),
   }
 })
+
 describe('Wedlocks operations', () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -93,6 +94,7 @@ describe('Wedlocks operations', () => {
       })
       await notifyNewKeyToWedlocks(
         {
+          transactionsHash: ['0x'],
           lock: {
             address: lockAddress,
             name: lockName,
@@ -102,14 +104,20 @@ describe('Wedlocks operations', () => {
         },
         network
       )
-      const transferUrl = `${[
+
+      const baseAppUrl =
         process.env.UNLOCK_ENV !== 'prod'
           ? 'https://staging-app.unlock-protocol.com'
-          : 'https://app.unlock-protocol.com',
-      ]}/transfer?lockAddress=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&keyId=&network=${network}`
+          : 'https://app.unlock-protocol.com'
+
+      const keychainUrl = `${baseAppUrl}/keychain`
+
+      const transferUrl = `${baseAppUrl}/transfer?lockAddress=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&keyId=&network=${network}`
+
+      const transactionReceiptUrl = `${baseAppUrl}/receipts?address=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&network=${network}&hash=0x`
 
       expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
-        body: `{"template":"keyMined0x95de5F777A3e283bFf0c47374998E10D8A2183C7","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"lockAddress":"0x95de5F777A3e283bFf0c47374998E10D8A2183C7","lockName":"Alice in Wonderland","keychainUrl":"https://app.unlock-protocol.com/keychain","keyId":"","network":"Mumbai (Polygon)","transferUrl":"${transferUrl}"},"attachments":[]}`,
+        body: `{"template":"keyMined0x95de5F777A3e283bFf0c47374998E10D8A2183C7","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"lockAddress":"0x95de5F777A3e283bFf0c47374998E10D8A2183C7","lockName":"Alice in Wonderland","keyId":"","network":"Mumbai (Polygon)","keychainUrl":"${keychainUrl}","transactionReceiptUrl":"${transactionReceiptUrl}","transferUrl":"${transferUrl}"},"attachments":[]}`,
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       })

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -10,6 +10,7 @@ import { vi, expect } from 'vitest'
 import app from '../app'
 import request from 'supertest'
 import { loginRandomUser } from '../test-helpers/utils'
+import config from '../../src/config/config'
 
 const lockAddressMock = '0x8D33b257bce083eE0c7504C7635D1840b3858AFD'
 const network = 80001
@@ -105,16 +106,11 @@ describe('Wedlocks operations', () => {
         network
       )
 
-      const baseAppUrl =
-        process.env.UNLOCK_ENV !== 'prod'
-          ? 'https://staging-app.unlock-protocol.com'
-          : 'https://app.unlock-protocol.com'
+      const keychainUrl = `${config.unlockApp}/keychain`
 
-      const keychainUrl = `${baseAppUrl}/keychain`
+      const transferUrl = `${config.unlockApp}/transfer?lockAddress=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&keyId=&network=${network}`
 
-      const transferUrl = `${baseAppUrl}/transfer?lockAddress=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&keyId=&network=${network}`
-
-      const transactionReceiptUrl = `${baseAppUrl}/receipts?address=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&network=${network}&hash=0x`
+      const transactionReceiptUrl = `${config.unlockApp}/receipts?address=0x95de5F777A3e283bFf0c47374998E10D8A2183C7&network=${network}&hash=0x`
 
       expect(fetch).toHaveBeenCalledWith('http://localhost:1337', {
         body: `{"template":"keyMined0x95de5F777A3e283bFf0c47374998E10D8A2183C7","failoverTemplate":"keyMined","recipient":"julien@unlock-protocol.com","params":{"lockAddress":"0x95de5F777A3e283bFf0c47374998E10D8A2183C7","lockName":"Alice in Wonderland","keyId":"","network":"Mumbai (Polygon)","keychainUrl":"${keychainUrl}","transactionReceiptUrl":"${transactionReceiptUrl}","transferUrl":"${transferUrl}"},"attachments":[]}`,

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -43,7 +43,7 @@ type Attachment = {
   path: string
   filename: string
 }
-
+// TODO: replace with SubgraphKey schema
 interface Key {
   lock: {
     address: string
@@ -53,6 +53,7 @@ interface Key {
   tokenId?: string
   owner: string
   keyId?: string
+  transactionsHash?: string[]
 }
 
 interface SendEmailProps {
@@ -431,6 +432,13 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
   const withLockImage = (customContent || '')?.length > 0
   const lockImage = `${config.services.locksmith}/lock/${lockAddress}/icon`
 
+  const [transactionsHash] = key?.transactionsHash ?? []
+
+  const keychainUrl = `${config.unlockApp}/keychain`
+  const transactionReceiptUrl = transactionsHash
+    ? `${config.unlockApp}/receipts?address=${lockAddress}&network=${network}&hash=${transactionsHash}`
+    : undefined
+
   await sendEmail({
     network: network!,
     template: templates[0],
@@ -440,13 +448,15 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
     params: {
       lockAddress: key.lock.address ?? '',
       lockName: key.lock.name,
-      keychainUrl: 'https://app.unlock-protocol.com/keychain',
       keyId: tokenId ?? '',
       network: networks[network!]?.name ?? '',
-      openSeaUrl,
-      transferUrl: transferUrl.toString(),
       customContent,
       lockImage: withLockImage ? lockImage : undefined, // add custom image only when custom content is present
+      // urls
+      keychainUrl,
+      transactionReceiptUrl,
+      transferUrl: transferUrl.toString(),
+      openSeaUrl,
       // add event details props
       eventName: eventDetail?.eventName,
       eventDate: eventDetail?.eventDate,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
pass `transaction receipts URL` as a parameter when we send emails. 
This PR requires https://github.com/unlock-protocol/unlock/pull/11953 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

