### PR TITLE
feat(unlock-app): Show renewal input even if lock is not erc20

### DIFF
--- a/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
+++ b/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
@@ -123,7 +123,7 @@ export const LocksForm = ({
       await Promise.allSettled(promises)
     }
     getRecurringCb()
-  }, [])
+  }, [getIsRecurringPossible, locks, lockRecurring])
 
   const reset = () => {
     setLockAddress('')
@@ -379,8 +379,6 @@ export const LocksForm = ({
     setRecurring(locks[lockAddress]?.recurringPayments ?? '')
   }, [lockAddress, locks])
 
-  const { isRecurringPossible } = lockRecurring[lockAddress] ?? {}
-
   return (
     <div className="flex flex-col gap-2">
       {addLockMutation?.isLoading && (
@@ -445,44 +443,42 @@ export const LocksForm = ({
               </div>
               <div className="flex flex-col gap-1">
                 <div className="flex flex-col gap-1">
-                  {isRecurringPossible && (
-                    <>
-                      <span className="flex items-center justify-between">
-                        <span className="px-1 text-sm">Number of renewals</span>
-                        <ToggleSwitch
-                          title="Unlimited"
-                          enabled={recurringUnlimited}
-                          setEnabled={(enabled: boolean) => {
-                            setRecurringUnlimited(enabled)
-                            const recurringPayments = enabled ? 'forever' : ''
-                            setRecurring(recurringPayments)
-                            onRecurringChange({
-                              recurringPayments,
-                            })
-                          }}
-                        />
-                      </span>
-                      <Input
-                        size="small"
-                        onChange={(e) => {
-                          setRecurring(e?.target.value)
-                          onRecurringChange({
-                            recurringPayments: e?.target?.value ?? '',
-                          })
-                        }}
-                        value={recurring}
-                        disabled={recurringUnlimited}
-                      />
-                    </>
-                  )}
+                  <span className="flex items-center justify-between">
+                    <span className="px-1 text-sm">Number of renewals</span>
+                    <ToggleSwitch
+                      title="Unlimited"
+                      enabled={recurringUnlimited}
+                      setEnabled={(enabled: boolean) => {
+                        setRecurringUnlimited(enabled)
+                        const recurringPayments = enabled ? 'forever' : ''
+                        setRecurring(recurringPayments)
+                        onRecurringChange({
+                          recurringPayments,
+                        })
+                      }}
+                    />
+                  </span>
+                  <Input
+                    size="small"
+                    onChange={(e) => {
+                      setRecurring(e?.target.value)
+                      onRecurringChange({
+                        recurringPayments: e?.target?.value ?? '',
+                      })
+                    }}
+                    value={recurring}
+                    disabled={recurringUnlimited}
+                  />
                   <span className="mb-4 text-xs text-gray-600">
                     This only applies to locks which have been enable for
-                    recurring payments.{' '}
+                    recurring payments. For native currency locks, this will
+                    only allow renewals for credit card based memberships if
+                    set.
                     <a
                       className="underline"
                       target="_blank"
                       href="https://unlock-protocol.com/guides/recurring-memberships/"
-                      rel="noreferrer"
+                      rel="noreferrer noopener"
                     >
                       Learn more
                     </a>


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Allow people to set renewal for native locks too. This will be ignored for non-erc20 crypto payment option.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

