### PR TITLE
fix(unlock-js): USDC fix on Polygon

### DIFF
--- a/packages/unlock-js/src/CardPurchaser.ts
+++ b/packages/unlock-js/src/CardPurchaser.ts
@@ -104,6 +104,7 @@ export class CardPurchaser {
       expiration: now + 60 * 60, // 1 hour!
     }
 
+    // @ts-expect-error Property '_signTypedData' does not exist on type 'Signer'.ts(2339)
     const signature = await signer._signTypedData(
       domain,
       PurchaseTypes,

--- a/packages/unlock-js/src/erc20.ts
+++ b/packages/unlock-js/src/erc20.ts
@@ -113,6 +113,14 @@ interface TransferAuthorizationMessage {
   nonce: string
 }
 
+/**
+ * Computes the domain separator for a given ERC20 contract
+ * Note: some contracts may not have `version()` or `name()` implemented correctly.
+ * @param chainId
+ * @param erc20ContractAddress
+ * @param provider
+ * @returns
+ */
 const getDomain = async (
   chainId: number,
   erc20ContractAddress: string,
@@ -127,11 +135,19 @@ const getDomain = async (
     console.error(
       `We could not retrieve the version of ${erc20ContractAddress} using the version() method. Defaulting to ${version}`
     )
-    console.error(error)
   }
 
   const name = await contract.name()
 
+  // On Polygon, the typehash is ... different.
+  if (chainId === 137) {
+    return {
+      name,
+      version,
+      salt: ethers.utils.zeroPad(ethers.utils.arrayify(137), 32),
+      verifyingContract: ethers.utils.getAddress(erc20ContractAddress),
+    }
+  }
   return {
     name,
     version,


### PR DESCRIPTION
# Description

On Polygon, USDC uses a different domain separator!
Like always thank you @Amxx !

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

