### PR TITLE
fix(unlock-app): Inline the card check

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
@@ -245,6 +245,7 @@ export const checkoutMachine = createMachine(
       CAPTCHA: 'CAPTCHA',
       PASSWORD: 'PASSWORD',
       PROMO: 'PROMO',
+      CARD: 'CARD',
       UPDATE_PAYWALL_CONFIG: {
         target: 'SELECT',
         actions: ['updatePaywallConfig'],
@@ -487,7 +488,9 @@ export const checkoutMachine = createMachine(
             {
               target: 'CARD',
               actions: ['selectPaymentMethod'],
-              cond: 'isCardPayment',
+              cond: (_, event) => {
+                return ['card', 'universal_card'].includes(event.payment.method)
+              },
             },
             {
               actions: ['selectPaymentMethod'],

--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.typegen.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.typegen.ts
@@ -29,7 +29,7 @@ export interface Typegen0 {
   }
   eventsCausingDelays: {}
   eventsCausingGuards: {
-    isCardPayment: 'BACK' | 'SELECT_PAYMENT_METHOD'
+    isCardPayment: 'BACK'
     requireCaptcha: 'BACK' | 'SELECT_RECIPIENTS' | 'SIGN_MESSAGE'
     requireMessageToSign: 'BACK' | 'SELECT_LOCK' | 'SELECT_RECIPIENTS'
     requirePassword: 'BACK' | 'SELECT_RECIPIENTS' | 'SIGN_MESSAGE'


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Looks like xstate doesn't like non-inline check 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

