### PR TITLE
feat(smart-contracts): use solhint with `lint-staged` to lint contracts pre commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "start": "./scripts/start.sh",
     "nuke": "./scripts/nuke.sh",
     "lint": "yarn packages --parallel run lint",
+    "lint:contracts": "yarn workspace @unlock-protocol/smart-contracts lint:contracts --fix",
     "postinstall": "husky install"
   },
   "repository": {
@@ -79,9 +80,8 @@
   "homepage": "https://github.com/unlock-protocol/unlock#readme",
   "packageManager": "yarn@3.5.0",
   "lint-staged": {
-    "*.{js,ts,tsx}": [
-      "yarn run lint --fix"
-    ],
-    "*.{js,ts,tsx,sol,css,md}": "prettier --write"
+    "*.{js,ts,tsx}": "yarn run lint --fix",
+    "*.{js,ts,tsx,sol,css,md}": "prettier --write",
+    "*.{sol}": "yarn lint:contracts "
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
   "lint-staged": {
     "*.{js,ts,tsx}": "yarn run lint --fix",
     "*.{js,ts,tsx,sol,css,md}": "prettier --write",
-    "*.{sol}": "yarn lint:contracts "
+    "*.sol": "yarn lint:contracts "
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "homepage": "https://github.com/unlock-protocol/unlock#readme",
   "packageManager": "yarn@3.5.0",
   "lint-staged": {
-    "*.{js,ts,tsx,sol}": [
+    "*.{js,ts,tsx}": [
       "yarn run lint --fix"
     ],
     "*.{js,ts,tsx,sol,css,md}": "prettier --write"

--- a/smart-contracts/.eslintrc.js
+++ b/smart-contracts/.eslintrc.js
@@ -18,7 +18,6 @@ const rulesToIgnore = [
 
 module.exports = {
   extends: ['@unlock-protocol/eslint-config'],
-  plugins: ['mocha'],
   globals: {
     it: true,
     artifacts: true,


### PR DESCRIPTION
# Description

This removes the lint-staged `{sol}` rule from eslint and replace it with a new solhint rule to lint staged contracts files when commiting them

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
