### PR TITLE
feat(locksmith) - utils to lowercase object keys

### DIFF
--- a/locksmith/__tests__/utils/object.test.ts
+++ b/locksmith/__tests__/utils/object.test.ts
@@ -12,7 +12,7 @@ describe('lowercaseObjectKeys', () => {
 
     const lowercased = lowercaseObjectKeys(obj)
 
-    // has all lowercase keys
+    // has all lowercased keys
     expect(lowercased).toHaveProperty('firstname')
     expect(lowercased).toHaveProperty('lastname')
     expect(lowercased).toHaveProperty('addressline1')

--- a/locksmith/__tests__/utils/object.test.ts
+++ b/locksmith/__tests__/utils/object.test.ts
@@ -1,0 +1,30 @@
+import { it, describe, expect } from 'vitest'
+import { lowercaseObjectKeys } from '../../src/utils/object'
+
+describe('lowercaseObjectKeys', () => {
+  it('should lowercase all object keys', () => {
+    expect.assertions(9)
+    const obj = {
+      FIRSTNAME: 'mario',
+      LASTNAME: 'rossi',
+      addressLine1: 'via portorico',
+    }
+
+    const lowercased = lowercaseObjectKeys(obj)
+
+    // has all lowercase keys
+    expect(lowercased).toHaveProperty('firstname')
+    expect(lowercased).toHaveProperty('lastname')
+    expect(lowercased).toHaveProperty('addressline1')
+
+    // has all values for lowercased keys
+    expect(lowercased.firstname).toBe('mario')
+    expect(lowercased.lastname).toBe('rossi')
+    expect(lowercased.addressline1).toBe('via portorico')
+
+    // does not have old keys
+    expect(lowercased).not.toHaveProperty('FIRSTNAME')
+    expect(lowercased).not.toHaveProperty('LASTNAME')
+    expect(lowercased).not.toHaveProperty('addressLine1')
+  })
+})

--- a/locksmith/src/utils/object.ts
+++ b/locksmith/src/utils/object.ts
@@ -2,3 +2,13 @@ export function objectWithoutKey(obj: Record<string, unknown>, key: string) {
   const { [key]: deletedKey, ...otherKeys } = obj
   return otherKeys
 }
+
+export function lowercaseObjectKeys(obj: Record<string, unknown> = {}) {
+  const newObject: Record<string, any> = {}
+
+  Object.keys(obj).forEach((key) => {
+    newObject[key.toLowerCase()] = obj[key]
+  })
+
+  return newObject
+}


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
-  utils to lowercase object keys that we will need inside `locksmith`

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
