### PR TITLE
feature(paywall): loadCheckoutModal yields a promise of {hash, lock} when closed

### DIFF
--- a/packages/paywall/README.md
+++ b/packages/paywall/README.md
@@ -40,5 +40,7 @@ const provider = window.ethereum
 const paywall = new Paywall(paywallConfig, networkConfigs, provider)
 
 // Loads the checkout UI
-paywall.loadCheckoutModal()
+const response = await paywall.loadCheckoutModal()
+
+// response is set when the modal is closed. response may include hash (the transaction hash) and lock (the address of the lock to which the transaction was sent)
 ```

--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/unlock.latest.umd.js",
   "module": "./dist/unlock.latest.es.js",
   "exports": {


### PR DESCRIPTION
# Description

`loadCheckoutModal` now yields a promise of `hash` and `lock` when closed.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #https://github.com/unlock-protocol/unlock/issues/11956

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
