### PR TITLE
feat(locksmith) - stripe account details + refactor

### DIFF
--- a/locksmith/src/controllers/lockController.ts
+++ b/locksmith/src/controllers/lockController.ts
@@ -43,15 +43,16 @@ export const connectStripe = async (req: Request, res: Response) => {
 
 export const stripeConnected = async (req: Request, res: Response) => {
   try {
-    const stripeConnected = await stripeOperations.getStripeConnectForLock(
-      Normalizer.ethereumAddress(req.params.lockAddress),
-      req.chain
-    )
+    const { stripeEnabled, stripeAccount: account } =
+      await stripeOperations.getStripeConnectForLock(
+        Normalizer.ethereumAddress(req.params.lockAddress),
+        req.chain
+      )
 
-    if (stripeConnected !== -1 && stripeConnected !== 0) {
-      return res.json({ connected: 1 })
+    if (stripeEnabled) {
+      return res.json({ connected: 1, account })
     }
-    return res.json({ connected: stripeConnected })
+    return res.json({ connected: 0, account })
   } catch (error) {
     logger.error(
       'Cannot verified if Stripe is connected: there was an error',

--- a/locksmith/src/controllers/lockController.ts
+++ b/locksmith/src/controllers/lockController.ts
@@ -52,7 +52,11 @@ export const stripeConnected = async (req: Request, res: Response) => {
     if (stripeEnabled) {
       return res.json({ connected: 1, account })
     }
-    return res.json({ connected: 0, account })
+
+    return res.json({
+      connected: account ? 0 : -1, // status is '0' when account is connected but not ready
+      account,
+    })
   } catch (error) {
     logger.error(
       'Cannot verified if Stripe is connected: there was an error',

--- a/locksmith/src/controllers/v2/purchaseController.ts
+++ b/locksmith/src/controllers/v2/purchaseController.ts
@@ -98,12 +98,10 @@ export const createPaymentIntent: RequestHandler = async (
     throw new Error('Lock is sold out.')
   }
 
-  const stripeConnectApiKey = await getStripeConnectForLock(
-    lockAddress,
-    network
-  )
+  const { stripeEnabled, stripeAccount: stripeConnectApiKey = '' } =
+    await getStripeConnectForLock(lockAddress, network)
 
-  if (stripeConnectApiKey == 0 || stripeConnectApiKey == -1) {
+  if (!stripeEnabled) {
     return response
       .status(400)
       .send({ message: 'Missing Stripe Connect integration' })

--- a/locksmith/src/operations/creditCardOperations.ts
+++ b/locksmith/src/operations/creditCardOperations.ts
@@ -18,19 +18,17 @@ export const getCreditCardEnabledStatus = async ({
 }: CreditCardStateProps): Promise<boolean> => {
   const fulfillmentDispatcher = new Dispatcher()
 
-  const [hasEnoughToPayForGas, stripeConnected, isAuthorizedForCreditCard] =
+  const [hasEnoughToPayForGas, { stripeEnabled }, isAuthorizedForCreditCard] =
     await Promise.all([
       fulfillmentDispatcher.hasFundsForTransaction(network),
       getStripeConnectForLock(lockAddress, network),
       AuthorizedLockOperations.hasAuthorization(lockAddress, network),
     ])
 
-  const hasStripeConfig = stripeConnected != 0 && stripeConnected != -1
-
   const creditCardEnabled =
     hasEnoughToPayForGas &&
     isAuthorizedForCreditCard &&
-    hasStripeConfig &&
+    stripeEnabled &&
     totalPriceInCents > MIN_PAYMENT_STRIPE_CREDIT_CARD // Let's check that the price is larger than 50cts
 
   return creditCardEnabled

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -263,7 +263,7 @@ export const getStripeConnectForLock = async (
   const account = await stripeConnection(stripeConnectLockDetails.stripeAccount)
 
   return {
-    stripeEnabled: account?.charges_enabled ?? false,
+    stripeEnabled: !!account?.charges_enabled,
     stripeAccount: stripeConnectLockDetails.stripeAccount,
   }
 }

--- a/locksmith/src/websub/helpers/renewFiatKey.ts
+++ b/locksmith/src/websub/helpers/renewFiatKey.ts
@@ -35,9 +35,16 @@ export async function renewFiatKey({
       lockAddress,
     }
 
-    const stripeAccount = await getStripeConnectForLock(lockAddress, network)
+    const { stripeEnabled, stripeAccount = '' } = await getStripeConnectForLock(
+      lockAddress,
+      network
+    )
 
-    if (stripeAccount === 0 || stripeAccount === -1) {
+    if (!stripeEnabled) {
+      throw new Error('Stripe connect is not enabled')
+    }
+
+    if (!stripeAccount) {
       throw new Error('No stripe connect account associated with the lock')
     }
 

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1772,6 +1772,17 @@ paths:
       responses:
         200:
           description: Successfully returns lock Stripe connection details.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - 'connected'
+                properties:
+                  account:
+                    type: string
+                  connected:
+                    type: number
 
   /v2/images/upload:
     post:

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1763,6 +1763,16 @@ paths:
         401:
           $ref: '#/components/responses/401.NotAuthenticated'
 
+  /lock/{lockAddress}/stripe-connected:
+    get:
+      operationId: getLockStripeConnectionDetails
+      description: Returns Stripe connection details
+      parameters:
+        - $ref: '#/components/parameters/LockAddress'
+      responses:
+        200:
+          description: Successfully returns lock Stripe connection details.
+
   /v2/images/upload:
     post:
       operationId: uploadImages

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1769,6 +1769,13 @@ paths:
       description: Returns Stripe connection details
       parameters:
         - $ref: '#/components/parameters/LockAddress'
+        - in: query
+          name: chain
+          required: true
+          schema:
+            type: number
+          description: Lock network
+
       responses:
         200:
           description: Successfully returns lock Stripe connection details.
@@ -1776,8 +1783,6 @@ paths:
             application/json:
               schema:
                 type: object
-                required:
-                  - 'connected'
                 properties:
                   account:
                     type: string


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Stripe refactors that includes:

- replace of using `0 | -1 | accountApi` for connected status and return instead return an object with `stripeEnaled` & `stripeAccount`, this will also simplify the login used with a more centric check  

-  endpoint `'/lock/:lockAddress/stripe-connected'` now returns also `account`, in the case `Stripe is connected but not ready to process charges.` we have also the details about the connected account to resume it from the FE.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
