### PR TITLE
feat(locksmith) - add checkoutConfigId to lockSettings

### DIFF
--- a/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
+++ b/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
@@ -8,7 +8,6 @@ const network = 4
 const lockAddress = '0x62ccb13a72e6f991de53b9b7ac42885151588cd2'
 const lockAddress2 = '0x060D07E7cCcD390B6F93B4D318E9FF203250D9be'
 const lockSettingMock = {
-  id: 4,
   lockAddress: '0xF3850C690BFF6c1E343D2449bBbbb00b0E934f7b',
   network,
   sendEmail: true,
@@ -16,6 +15,7 @@ const lockSettingMock = {
   emailSender: 'Custom Sender',
   slug: 'slug-test',
   replyTo: 'example@gmail.com',
+  checkoutConfigId: 'f549d936-24e6-49e0-9acb',
   createdAt: '2023-03-24T15:40:54.509Z',
   updatedAt: '2023-03-24T15:40:54.509Z',
 }
@@ -120,7 +120,7 @@ describe('LockSettings v2 endpoints for lock', () => {
   })
 
   it('should correctly save settings when user is lockManager', async () => {
-    expect.assertions(6)
+    expect.assertions(7)
 
     const { loginResponse } = await loginRandomUser(app)
     const saveSettingResponse = await request(app)
@@ -131,6 +131,7 @@ describe('LockSettings v2 endpoints for lock', () => {
         replyTo: 'example@gmail.com',
         slug: 'slug-demo',
         emailSender: 'Example',
+        checkoutConfigId: 'f549d936-24e6-49e0-9acb',
       })
 
     const response = saveSettingResponse.body
@@ -140,10 +141,11 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(response.replyTo).toBe('example@gmail.com')
     expect(response.slug).toBe('slug-demo')
     expect(response.emailSender).toBe('Example')
+    expect(response.checkoutConfigId).toBe('f549d936-24e6-49e0-9acb')
   })
 
   it('should save and retrieve setting when user is lockManager', async () => {
-    expect.assertions(13)
+    expect.assertions(15)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -157,6 +159,7 @@ describe('LockSettings v2 endpoints for lock', () => {
         creditCardPrice: 0.04,
         slug: 'slug-test',
         emailSender: 'Custom Sender',
+        checkoutConfigId: 'f549d936-24e6-49e0-9acb',
       })
 
     const response = saveSettingResponse.body
@@ -166,6 +169,7 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(response.creditCardPrice).toBe(0.04)
     expect(response.slug).toBe('slug-test')
     expect(response.emailSender).toBe('Custom Sender')
+    expect(response.checkoutConfigId).toBe('f549d936-24e6-49e0-9acb')
 
     // retrieve settings
     const getSettingResponse = await request(app)
@@ -185,10 +189,13 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(getSettingResponse.body.emailSender).toBe(
       lockSettingMock.emailSender
     )
+    expect(getSettingResponse.body.checkoutConfigId).toBe(
+      lockSettingMock.checkoutConfigId
+    )
   })
 
   it('should retrieve default settings for a lock', async () => {
-    expect.assertions(6)
+    expect.assertions(7)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -204,10 +211,11 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(getSettingResponse.body.creditCardPrice).toBe(undefined)
     expect(getSettingResponse.body.slug).toBe(undefined)
     expect(getSettingResponse.body.emailSender).toBe(undefined)
+    expect(getSettingResponse.body.checkoutConfigId).toBe(undefined)
   })
 
   it('should save null values for settings', async () => {
-    expect.assertions(4)
+    expect.assertions(5)
 
     const { loginResponse } = await loginRandomUser(app)
     // save settings
@@ -218,6 +226,7 @@ describe('LockSettings v2 endpoints for lock', () => {
         replyTo: null,
         creditCardPrice: null,
         emailSender: null,
+        checkoutConfigId: null,
       })
 
     const response = saveSettingResponse.body
@@ -225,5 +234,6 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(response.replyTo).toBe(null)
     expect(response.creditCardPrice).toBe(null)
     expect(response.emailSender).toBe(null)
+    expect(response.checkoutConfigId).toBe(null)
   })
 })

--- a/locksmith/migrations/20230529130600-add-checkout-config-id-to-lock-settings.js
+++ b/locksmith/migrations/20230529130600-add-checkout-config-id-to-lock-settings.js
@@ -1,0 +1,17 @@
+'use strict'
+const table = 'LockSettings'
+/** @type {import('sequelize-cli').Migration} */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(table, 'checkoutConfigId', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      defaultValue: null,
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(table, 'checkoutConfigId')
+  },
+}

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -34,7 +34,7 @@ const LockSettingSchema = z.object({
     .optional(),
   checkoutConfigId: z
     .string({
-      description: 'Checkout config URL assigned to the lock.',
+      description: 'Checkout config URL id.',
     })
     .nullish(),
 })

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -32,6 +32,11 @@ const LockSettingSchema = z.object({
       description: 'Slug that will be used to retrieve the lock',
     })
     .optional(),
+  checkoutConfigId: z
+    .string({
+      description: 'Checkout config URL assigned to the lock.',
+    })
+    .nullish(),
 })
 
 export type LockSettingProps = z.infer<typeof LockSettingSchema>
@@ -42,6 +47,7 @@ export const DEFAULT_LOCK_SETTINGS: LockSettingProps = {
   creditCardPrice: undefined,
   emailSender: undefined,
   slug: undefined,
+  checkoutConfigId: undefined,
 }
 
 export const updateSettings: RequestHandler = async (

--- a/locksmith/src/models/lockSetting.ts
+++ b/locksmith/src/models/lockSetting.ts
@@ -13,6 +13,7 @@ export class LockSetting extends Model<
   declare creditCardPrice?: number | null
   declare emailSender?: string | null
   declare slug?: string
+  declare checkoutConfigId?: string | null
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 }
@@ -50,6 +51,11 @@ LockSetting.init(
       type: DataTypes.STRING,
       allowNull: true,
       unique: true,
+      defaultValue: null,
+    },
+    checkoutConfigId: {
+      type: DataTypes.STRING,
+      allowNull: true,
       defaultValue: null,
     },
     createdAt: {

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -395,6 +395,9 @@ components:
         emailSender:
           type: string
           nullable: true
+        checkoutConfigId:
+          type: string
+          nullable: true
 
   parameters:
     Network:


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
As part of https://github.com/unlock-protocol/unlock/issues/11019 
We need to add the checkout config URL id as part of the lock settings.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
