### PR TITLE
feat(ui) - header nav hide burgher on mobile with no items

### DIFF
--- a/packages/ui/lib/components/HeaderNav/HeaderNav.tsx
+++ b/packages/ui/lib/components/HeaderNav/HeaderNav.tsx
@@ -416,19 +416,24 @@ export const HeaderNav = ({
     }
   }, [menuExpanded])
 
+  const hasSections = menuSections?.length > 0
+
   return (
     <div className={`relative ${menuExpanded ? 'fixed top-0' : ''}`}>
       <div className="flex items-center justify-between w-full h-24 gap-2">
         <div className="flex items-center gap-8">
           <div>
             <div className="flex items-center gap-2">
-              <div className="block lg:hidden">
-                <Icon
-                  size={30}
-                  icon={menuExpanded ? CloseIcon : MenuIcon}
-                  onClick={() => setMenuExpanded(!menuExpanded)}
-                />
-              </div>
+              {/* no need to show burgher menu if there is no items */}
+              {hasSections && (
+                <div className="block lg:hidden">
+                  <Icon
+                    size={30}
+                    icon={menuExpanded ? CloseIcon : MenuIcon}
+                    onClick={() => setMenuExpanded(!menuExpanded)}
+                  />
+                </div>
+              )}
               <Link href={logoUrl}>
                 <div
                   className={`grid items-center gap-1 divide-x md:gap-2 ${


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

There is no need to show the bugher menu when the navbar does not have items 

**Issue**

<img width="500" alt="Screenshot 2023-05-31 at 12 56 36" src="https://github.com/unlock-protocol/unlock/assets/20865711/a6f93c8a-6c7b-4e4c-8c75-80067695be25">

**Fix**

<img width="500" alt="Screenshot 2023-05-31 at 12 55 27" src="https://github.com/unlock-protocol/unlock/assets/20865711/61fd83f0-9104-4242-adbe-ef28524640f6">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
