### PR TITLE
fix(smart-contracts): cast uint160 safely in UnlockSwapPurchaser

### DIFF
--- a/smart-contracts/contracts/utils/UnlockSwapPurchaser.sol
+++ b/smart-contracts/contracts/utils/UnlockSwapPurchaser.sol
@@ -8,7 +8,21 @@ import "../interfaces/IPermit2.sol";
 import "../interfaces/IPublicLock.sol";
 import "../interfaces/IUnlock.sol";
 
+library SafeCast160 {
+  error UnsafeCast();
+
+  /// @notice Safely casts uint256 to uint160
+  /// @param value The uint256 to be cast
+  function toUint160(uint256 value) internal pure returns (uint160) {
+    if (value > type(uint160).max) revert UnsafeCast();
+    return uint160(value);
+  }
+}
+
 contract UnlockSwapPurchaser {
+  // make sure we dont exceed type uint160 when casting
+  using SafeCast160 for uint256;
+
   // Unlock address on current chain
   address public unlockAddress;
 
@@ -133,7 +147,7 @@ contract UnlockSwapPurchaser {
     IPermit2(permit2).approve(
       srcToken,
       uniswapRouter,
-      uint160(amountInMax),
+      amountInMax.toUint160(),
       uint48(block.timestamp + 60) // expires after 1min
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30474,7 +30474,7 @@ __metadata:
     yargs-parser: ^16.1.0
   bin:
     gluegun: bin/gluegun
-  checksum: 71abe7f31555f169a47510675596f79193c8f55e4beeb4e6efa06c22d41988fa9c747d5e398af7f8401cca22c08ffb7a6d57b03d764c14858513c9eba23b53b8
+  checksum: 7a45a5a606a1e651c891467a693552b5237f8e90410f9c9daad4621ff0693d1c92b69aa35fc30eccf7c3b92ee724f15fc297e054086cfb312717ef01f48d2290
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This adds a safety mechanism to prevent overflow when casting uint160 to uint256 in UnlockSwapPurchaser

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #11874
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
