### PR TITLE
fix(unlock-app): fix ts reference error for uniswap types

### DIFF
--- a/unlock-app/tsconfig.json
+++ b/unlock-app/tsconfig.json
@@ -24,7 +24,10 @@
     "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@uniswap/smart-order-router": [
+        "../packages/unlock-js/node_modules/@uniswap/smart-order-router",
+      ]
     }
   },
   "include": ["./src/**/*"]


### PR DESCRIPTION
# Description

Fix for ts error that can find uniswap js lib types in monorepo -- see https://github.com/microsoft/TypeScript/issues/42873 for more context


```
./src/hooks/useUniswapRoutes.ts:25:14
Type error: The inferred type of 'useUniswapRoutes' cannot be named without a reference to '@unlock-protocol/unlock-js/node_modules/@uniswap/smart-order-router'. This is likely not portable. A type annotation is necessary.

  23 | }
  24 | 
> 25 | export const useUniswapRoutes = ({
     |              ^
  26 |   routes,
  27 |   enabled = true,
  28 | }: UniswapRoutesOption) => {
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
