### PR TITLE
feat(unlock-app) - fix modal closes when creating an account

### DIFF
--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -402,12 +402,7 @@ export const EventDetails = ({ lockAddress, network }: EventDetailsProps) => {
 
   const { isEvent } = getLockTypeByMetadata(metadata)
 
-  if (
-    isMetadataLoading ||
-    isHasValidKeyLoading ||
-    isLoadingSettings ||
-    isLoadingEventLocks
-  ) {
+  if (isMetadataLoading || isLoadingSettings || isLoadingEventLocks) {
     return (
       <Placeholder.Root>
         <Placeholder.Card size="lg" />
@@ -515,7 +510,12 @@ export const EventDetails = ({ lockAddress, network }: EventDetailsProps) => {
   const coverImage = eventData.ticket?.event_cover_image
 
   const RegistrationCard = () => {
-    if (isClaimableLoading || isLockLoading || isLoadingSettings) {
+    if (
+      isClaimableLoading ||
+      isLockLoading ||
+      isLoadingSettings ||
+      isHasValidKeyLoading
+    ) {
       return <Placeholder.Card size="md" />
     }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

`isLoadingEventLocks` is one of the props used to show the placeholder for the event page, when a new account is created this will cause a re-render of the placeholder, with the eventual closing of the checkout modal (because is placed after the placeholder).

This is now moved only when needed to avoid this issue 

**Issue** 

https://github.com/unlock-protocol/unlock/assets/20865711/47dfbef8-7b86-4505-9261-0b52e569071b

**Fix** 

https://github.com/unlock-protocol/unlock/assets/20865711/177a323c-8882-4bd4-9e47-0e454a3b3624






<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
