### PR TITLE
feat(smart-contracts): more params to verify cli task

### DIFF
--- a/smart-contracts/tasks/verify.js
+++ b/smart-contracts/tasks/verify.js
@@ -21,23 +21,32 @@ const artifactsPath = path.resolve(
 
 task('verify-proxy', 'Deploy and verify the TransparentProxy used by locks')
   .addOptionalParam('publicLockAddress', 'the PublicLock template address')
+  .addOptionalParam('unlockAddress', 'the Unlock factory address')
+  .addOptionalParam('lockVersion', 'the version number of deployed lock')
   .addOptionalParam('proxyAdminAddress', "Unlock's ProxyAdmin contract address")
+  .addOptionalParam('calldata', 'calldata used for lock creation')
   .addOptionalParam(
     'transparentProxyAddress',
     'the address of TransparentProxy instance already deployed using this script'
   )
   .setAction(
     async ({
+      calldata,
+      lockVersion,
       publicLockAddress,
       proxyAdminAddress,
       transparentProxyAddress,
+      unlockAddress,
     }) => {
       // eslint-disable-next-line global-require
       const verifyProxy = require('../scripts/verify-proxy')
       await verifyProxy({
+        calldata,
+        lockVersion,
         publicLockAddress,
         proxyAdminAddress,
         transparentProxyAddress,
+        unlockAddress,
       })
     }
   )


### PR DESCRIPTION
# Description

Allow to pass creation calldata and lock version directly to the verify cli task, so we can verify existing deployed proxy (instead of redeploying one) -- see https://github.com/unlock-protocol/unlock/issues/12100#issuecomment-1580796764 for context

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
