### PR TITLE
fix(unlock-app): stripe onramp not visible in iframe

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -126,6 +126,7 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
   // Universal card is enabled if credit card is not enabled by the lock manager and the lock is USDC
   const USDC = networkConfig?.tokens?.find((t: any) => t.symbol === 'USDC')
   const universalCardEnabled =
+    window.top === window &&
     !enableCreditCard &&
     networkConfig.universalCard?.cardPurchaserAddress &&
     lock.currencyContractAddress?.toLowerCase()?.trim() ===


### PR DESCRIPTION
# Description

Prompted by the Stripe team, we're not loading inside an iframe.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
