### PR TITLE
fix(unlock-app): using the parent as the origin

### DIFF
--- a/unlock-app/src/components/interface/Authenticate.jsx
+++ b/unlock-app/src/components/interface/Authenticate.jsx
@@ -164,7 +164,7 @@ Authenticate.defaultProps = {
   optional: false,
   onCancel: null,
   embedded: false,
-  onAuthenticated: () => {},
+  onAuthenticated: () => { },
   providerAdapter: null,
 }
 

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -44,7 +44,7 @@ export interface MethodCallResult {
 
 // Taken from https://github.com/ethers-io/ethers.js/blob/master/src.ts/providers/web3-provider.ts
 export type AsyncSendable = {
-  parentOrigin: string
+  parentOrigin: () => string
   enable: () => void
   sendAsync?: (
     request: any,
@@ -115,6 +115,7 @@ export const useCheckoutCommunication = () => {
     undefined
   )
   const [user, setUser] = useState<string | undefined>(undefined)
+
   const parent = usePostmateParent({
     setConfig: (config: PaywallConfig) => {
       setPaywallConfig(config)
@@ -195,7 +196,10 @@ export const useCheckoutCommunication = () => {
 
   if (useDelegatedProvider && !providerAdapter) {
     setProviderAdapter({
-      parentOrigin: parent?.parentOrigin,
+      parentOrigin: () => {
+        // @ts-expect-error Property 'parentOrigin' does not exist on type 'ChildAPI'.ts(2339)
+        return parent?.parentOrigin
+      },
       enable: () => {
         return new Promise((resolve) => {
           enabled = resolve

--- a/unlock-app/src/hooks/useCheckoutCommunication.ts
+++ b/unlock-app/src/hooks/useCheckoutCommunication.ts
@@ -44,10 +44,8 @@ export interface MethodCallResult {
 
 // Taken from https://github.com/ethers-io/ethers.js/blob/master/src.ts/providers/web3-provider.ts
 export type AsyncSendable = {
+  parentOrigin: string
   enable: () => void
-  isMetaMask?: boolean
-  host?: string
-  path?: string
   sendAsync?: (
     request: any,
     callback: (error: any, response: any) => void
@@ -197,6 +195,7 @@ export const useCheckoutCommunication = () => {
 
   if (useDelegatedProvider && !providerAdapter) {
     setProviderAdapter({
+      parentOrigin: parent?.parentOrigin,
       enable: () => {
         return new Promise((resolve) => {
           enabled = resolve

--- a/unlock-app/src/hooks/useSIWE.tsx
+++ b/unlock-app/src/hooks/useSIWE.tsx
@@ -112,7 +112,6 @@ export const SIWEProvider = ({ children }: Props) => {
 
       let domain = window.location.host
       // If we are using the parent's provider, then we MUST use the parent's domain
-      console.log(provider?.provider?.parentOrigin)
       if (provider?.provider?.parentOrigin) {
         domain = new URL(provider.provider.parentOrigin).host
       }

--- a/unlock-app/src/hooks/useSIWE.tsx
+++ b/unlock-app/src/hooks/useSIWE.tsx
@@ -10,6 +10,7 @@ import {
   saveAccessToken,
 } from '~/utils/session'
 import { config } from '~/config/app'
+import ProviderContext from '~/contexts/ProviderContext'
 
 type Status = 'loading' | 'error' | 'success' | 'rejected' | 'idle'
 
@@ -46,6 +47,7 @@ interface Props {
 
 export const SIWEProvider = ({ children }: Props) => {
   const { connected, getWalletService, network } = useAuth()
+  const { provider } = useContext(ProviderContext)
   const { session, refetchSession } = useSession()
   const [status, setStatus] = useState<Status>('idle')
   const queryClient = useQueryClient()
@@ -90,7 +92,6 @@ export const SIWEProvider = ({ children }: Props) => {
         throw new Error('No wallet connected.')
       }
       const walletService = await getWalletService()
-
       const address = await walletService.signer.getAddress()
       const insideIframe = window !== window.parent
 
@@ -107,6 +108,13 @@ export const SIWEProvider = ({ children }: Props) => {
 
       if (parent.host !== window.location.host) {
         resources = [window.location.origin]
+      }
+
+      let domain = window.location.host
+      // If we are using the parent's provider, then we MUST use the parent's domain
+      console.log(provider?.provider?.parentOrigin)
+      if (provider?.provider?.parentOrigin) {
+        domain = new URL(provider.provider.parentOrigin).host
       }
 
       const siwe = new SiweMessage({

--- a/unlock-app/src/hooks/useSIWE.tsx
+++ b/unlock-app/src/hooks/useSIWE.tsx
@@ -113,11 +113,11 @@ export const SIWEProvider = ({ children }: Props) => {
       let domain = window.location.host
       // If we are using the parent's provider, then we MUST use the parent's domain
       if (provider?.provider?.parentOrigin) {
-        domain = new URL(provider.provider.parentOrigin).host
+        domain = new URL(provider.provider.parentOrigin()).host
       }
 
       const siwe = new SiweMessage({
-        domain: window.location.host, // parent.host,
+        domain,
         uri: parent.origin,
         address,
         chainId: network,


### PR DESCRIPTION
# Description

After much investigation I found that indeed we are sometimes (inconsistently but that's another issue) using the parent's injected provider and we need to use its domain for the SIWE message.


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
