### PR TITLE
feature(unlock-app): adding the ability to pass hidden metadata

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const MetadataInput = z.object({
-  type: z.enum(['text', 'date', 'color', 'email', 'url'], {
+  type: z.enum(['text', 'date', 'color', 'email', 'url', 'hidden'], {
     description:
       'The type field maps to a certain subset of HTML <input> types, which influences how the form renders. ',
   }),
@@ -18,6 +18,11 @@ export const MetadataInput = z.object({
   placeholder: z
     .string({
       description: 'Placeholder displayed to users.',
+    })
+    .optional(),
+  value: z
+    .string({
+      description: 'Value to use for hidden metadata inputs.',
     })
     .optional(),
   defaultValue: z

--- a/packages/ui/lib/components/Form/FieldLayout.tsx
+++ b/packages/ui/lib/components/Form/FieldLayout.tsx
@@ -12,6 +12,7 @@ export interface Props {
   description?: ReactNode
   children: ReactNode
   append?: ReactNode
+  hidden?: boolean
 }
 
 const SIZE_STYLES: SizeStyleProp = {
@@ -37,12 +38,17 @@ export function FieldLayout(props: Props) {
     append,
     required,
     optional,
+    hidden,
   } = props
   const labelSizeStyle = SIZE_STYLES[size!]
   const labelClass = twMerge('px-1', labelSizeStyle)
   const descriptionClass = twMerge('text-gray-600', TEXT_SIZE[size])
   const errorClass = twMerge('text-red-500', TEXT_SIZE[size])
   const successClass = twMerge('text-green-500', TEXT_SIZE[size])
+
+  if (hidden) {
+    return null
+  }
 
   function Message() {
     if (error) {

--- a/packages/ui/lib/components/Form/Input.tsx
+++ b/packages/ui/lib/components/Form/Input.tsx
@@ -94,6 +94,7 @@ export const Input = forwardRef(
         error={error}
         success={success}
         description={description}
+        hidden={inputProps.type === 'hidden'}
       >
         <div className="relative">
           {icon && (

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -209,7 +209,7 @@ export const MetadataInputs = ({
           )
         })
         .map((metadataInputItem) => {
-          const { name, defaultValue, placeholder, type, required } =
+          const { name, defaultValue, placeholder, type, required, value } =
             metadataInputItem ?? {}
           return (
             <Input
@@ -224,6 +224,7 @@ export const MetadataInputs = ({
               error={errors?.metadata?.[id]?.[name]?.message}
               {...register(`metadata.${id}.${name}`, {
                 required: required && `${name} is required`,
+                value,
               })}
             />
           )


### PR DESCRIPTION
# Description

This PR adds the ability to add a new type of metadata input called `hidden`. If this one is used, the implementer can pass an arbitrary value that gets saved as part of the owner's metadata and that the implemeter can then used to "map" owners with users in their own application.

Refs #12136

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
