### PR TITLE
feat(unlock-app) - fix lock loading error

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
@@ -57,7 +57,7 @@ export const Members = ({
 
   const [
     { isLoading, data: members = [] },
-    { isLoading: isLockLoading, data: lock },
+    { isLoading: isLockLoading, data: lock, isError: hasLockLoadingError },
     { isLoading: isLoadingSettings, data: { data: lockSettings = {} } = {} },
   ] = useQueries({
     queries: [
@@ -116,6 +116,16 @@ export const Members = ({
           ))}
         </Placeholder.Root>
       </>
+    )
+  }
+
+  if (hasLockLoadingError) {
+    return (
+      <ImageBar
+        alt="Fetch error"
+        src="/images/illustrations/no-member.svg"
+        description={<span>Unable to fetch lock members from subgraph.</span>}
+      />
     )
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
Subgraph have some timeout and errors that cause the members list to not shows.
In this case out UI shows the same banner in the case we lock have no items.
A new banner is added to cover this specific case 

**Error** 
<img width="1380" alt="Screenshot 2023-06-14 at 12 08 49" src="https://github.com/unlock-protocol/unlock/assets/20865711/d51368a3-0ff4-4102-bb28-b98a37fb7374">

**Fix** 
<img width="1318" alt="Screenshot 2023-06-14 at 12 13 45" src="https://github.com/unlock-protocol/unlock/assets/20865711/3f6f50f5-9339-47a5-947d-5b496c590b61">


**Error from query** 
```
{
	"errors": [
		{
			"message": "service is overloaded and can not run the query right now. Please try again in a few minutes"
		}
	]
}
```

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
