### PR TITLE
feat(locksmith) - use custom credit card price for purchase when is set

### DIFF
--- a/locksmith/__tests__/operations/pricingOperations.test.ts
+++ b/locksmith/__tests__/operations/pricingOperations.test.ts
@@ -12,6 +12,11 @@ const decimals = 18
 const currencyContractAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
 const keyPrice = 40000
 
+const recipients = [
+  '0x6f59999AE79Bc593549918179454A47980a800E5',
+  '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+]
+
 // eslint-disable-next-line
 var mockWeb3Service = {
   providerForNetwork: vi.fn(),
@@ -260,6 +265,22 @@ describe('pricingOperations', () => {
       expect(pricing?.symbol).toBe('$')
       expect(pricing?.amountInUSD).toBe(55.32)
       expect(pricing?.amountInCents).toBe(5532)
+    })
+
+    it('returns pricing when "creditCardPrice" is set in lockSettings for recipients', async () => {
+      expect.assertions(4)
+
+      const pricing = await pricingOperations.getPricingFromSettings({
+        lockAddress,
+        network,
+        recipients,
+      })
+
+      expect(pricing?.decimals).toBe(18)
+      expect(pricing?.symbol).toBe('$')
+      // total for the 2 recipients
+      expect(pricing?.amountInUSD).toBe(110.64)
+      expect(pricing?.amountInCents).toBe(11064)
     })
   })
 })

--- a/locksmith/__tests__/operations/pricingOperations.test.ts
+++ b/locksmith/__tests__/operations/pricingOperations.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as pricingOperations from '../../src/operations/pricingOperations'
+import { DEFAULT_LOCK_SETTINGS } from '../../src/controllers/v2/lockSettingController'
+import { ethers } from 'ethers'
 
 const lockAddress = '0x551c6ecdf819Dc90c5287971072B4651119accD3'
 const lockAddressErc20 = '0x8D33b257bce083eE0c7504C7635D1840b3858AFD'
+const lockAddressWithSettings = '0xbd55144a3a30907e080595cabf652bc079728b2f'
+const lockAddressWithoutSettings = '0x0ddf835dc0c326c4a677a807b21af1d7a521f275'
 const network = 5
 const decimals = 18
 const currencyContractAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
@@ -25,6 +29,7 @@ var mockWeb3Service = {
       tokenAddress: vi.fn(() => currencyContractAddress),
     }
   }),
+  purchasePriceFor: vi.fn(() => keyPrice),
 }
 
 vi.mock('@unlock-protocol/unlock-js', () => ({
@@ -35,6 +40,21 @@ vi.mock('@unlock-protocol/unlock-js', () => ({
     return 6
   },
 }))
+
+vi.mock('../../src/operations/lockSettingOperations', () => {
+  return {
+    getSettings: vi.fn(({ lockAddress: lock }) => {
+      if ([lockAddress, lockAddressWithSettings].includes(lock)) {
+        return Promise.resolve({
+          sendEmail: true,
+          creditCardPrice: 5532, // 55.32$ in basis points
+        })
+      }
+
+      return Promise.resolve(DEFAULT_LOCK_SETTINGS)
+    }),
+  }
+})
 
 describe('pricingOperations', () => {
   beforeEach(() => {
@@ -144,6 +164,102 @@ describe('pricingOperations', () => {
       expect(pricing.symbol).toBe('ETH')
       expect(pricing.amountInUSD).toBe(0.04)
       expect(pricing.amountInCents).toBe(4)
+    })
+
+    it('returns usd pricing with "creditCard" settings price', async () => {
+      expect.assertions(5)
+
+      const pricing = await pricingOperations.getDefaultUsdPricing({
+        lockAddress: lockAddressWithSettings,
+        network,
+      })
+
+      expect(pricing.amount).toBe(1)
+      expect(pricing.amountInCents).toBe(5532)
+      expect(pricing.amountInUSD).toBe(55.32)
+      expect(pricing.decimals).toBe(18)
+      expect(pricing.symbol).toBe('$')
+    })
+
+    it('returns default usd pricing when "creditCard" settings price is not set', async () => {
+      expect.assertions(4)
+
+      const pricing = await pricingOperations.getDefaultUsdPricing({
+        lockAddress: lockAddressWithoutSettings,
+        network,
+      })
+
+      expect(pricing.decimals).toBe(6)
+      expect(pricing.symbol).toBe('ETH')
+      expect(pricing.amountInUSD).toBe(0.04)
+      expect(pricing.amountInCents).toBe(4)
+    })
+  })
+
+  describe('getUsdPricingForRecipient', () => {
+    it('returns default usd pricing when "creditCard" settings price is not set', async () => {
+      expect.assertions(4)
+      const userAddress = await ethers.Wallet.createRandom().getAddress()
+      const referrer = await ethers.Wallet.createRandom().getAddress()
+
+      const pricing = await pricingOperations.getUsdPricingForRecipient({
+        lockAddress: lockAddressWithoutSettings,
+        network,
+        userAddress,
+        data: '0x',
+        referrer,
+      })
+      expect(pricing.address).toBe(userAddress)
+      expect(pricing.price.symbol).toBe('ETH')
+      expect(pricing.price.amountInUSD).toBe(0.04)
+      expect(pricing.price.amountInCents).toBe(4)
+    })
+
+    it('returns usd pricing with "creditCard" settings price', async () => {
+      expect.assertions(6)
+      const userAddress = await ethers.Wallet.createRandom().getAddress()
+      const referrer = await ethers.Wallet.createRandom().getAddress()
+
+      const pricing = await pricingOperations.getUsdPricingForRecipient({
+        lockAddress: lockAddressWithSettings,
+        network,
+        userAddress,
+        data: '0x',
+        referrer,
+      })
+      expect(pricing.address).toBe(userAddress)
+      expect(pricing.price.decimals).toBe(18)
+      expect(pricing.price.symbol).toBe('$')
+      expect(pricing.price.amountInUSD).toBe(55.32)
+      expect(pricing.price.amountInCents).toBe(5532)
+      expect(pricing.price.amount).toBe(1)
+    })
+  })
+
+  describe('getPricingFromSettings', () => {
+    it('returns null when pricing when "creditCardPrice" is not set in lockSettings', async () => {
+      expect.assertions(1)
+
+      const pricing = await pricingOperations.getPricingFromSettings({
+        lockAddress: lockAddressErc20,
+        network,
+      })
+
+      expect(pricing).toBe(null)
+    })
+
+    it('returns pricing when "creditCardPrice" is set in lockSettings', async () => {
+      expect.assertions(4)
+
+      const pricing = await pricingOperations.getPricingFromSettings({
+        lockAddress,
+        network,
+      })
+
+      expect(pricing?.decimals).toBe(18)
+      expect(pricing?.symbol).toBe('$')
+      expect(pricing?.amountInUSD).toBe(55.32)
+      expect(pricing?.amountInCents).toBe(5532)
     })
   })
 })

--- a/locksmith/__tests__/utils/pricing.test.ts
+++ b/locksmith/__tests__/utils/pricing.test.ts
@@ -1,0 +1,236 @@
+import { expect, describe, beforeEach, it, vi } from 'vitest'
+import {
+  createPricingForPurchase,
+  getKeyPricingInUSD,
+} from '../../src/utils/pricing'
+import { DEFAULT_LOCK_SETTINGS } from '../../src/controllers/v2/lockSettingController'
+
+const recipients = [
+  '0x6f59999AE79Bc593549918179454A47980a800E5',
+  '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+]
+const data = ['0x', '0x']
+
+const lockAddressWithSettings = '0xbd55144a3a30907e080595cabf652bc079728b2f'
+const currencyContractAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
+
+const lockAddress = '0x551c6ecdf819Dc90c5287971072B4651119accD3'
+const network = 5
+const keyPrice = 9000000000000000
+const gasPrice = 12.4
+vi.mock('../../src/operations/lockSettingOperations', () => {
+  return {
+    getSettings: vi.fn(({ lockAddress: lock }) => {
+      if ([lockAddressWithSettings].includes(lock)) {
+        return Promise.resolve({
+          sendEmail: true,
+          creditCardPrice: 5532, // 55.32$ in basis points
+        })
+      }
+
+      return Promise.resolve(DEFAULT_LOCK_SETTINGS)
+    }),
+  }
+})
+
+vi.mock('../../src/utils/gasPrice', async () => {
+  const actual: any = await vi.importActual('../../src/utils/gasPrice')
+  return {
+    ...actual,
+    gasPriceUSD: vi.fn(() => gasPrice),
+  }
+})
+
+vi.mock('../../src/utils/gasPrice', () => {
+  const mockedGasPrice = vi.fn().mockImplementation(() => {
+    const item = {
+      gasPriceUSD: vi.fn().mockReturnValue(gasPrice),
+      gasPriceETH: vi.fn().mockReturnValue(gasPrice),
+    }
+    return item
+  })
+  return {
+    default: mockedGasPrice,
+  }
+})
+
+// eslint-disable-next-line
+var mockWeb3Service = {
+  providerForNetwork: vi.fn(),
+  getLockContract: vi.fn((lock) => {
+    if (lock === lockAddress) {
+      return {
+        keyPrice: vi.fn(() => keyPrice),
+        tokenAddress: vi.fn(() => null),
+      }
+    }
+
+    // return mock for erc-20
+    return {
+      keyPrice: vi.fn(() => keyPrice),
+      tokenAddress: vi.fn(() => currencyContractAddress),
+    }
+  }),
+  purchasePriceFor: vi.fn(() => keyPrice),
+}
+
+vi.mock('@unlock-protocol/unlock-js', () => ({
+  Web3Service: function Web3Service() {
+    return mockWeb3Service
+  },
+  getErc20Decimals: function () {
+    return 6
+  },
+}))
+
+describe('pricing', () => {
+  beforeEach(() => {
+    // mock https://coins.llama.fi response
+    fetchMock.mockIf(
+      /^https?:\/\/coins.llama.fi\/prices\/current\/.*$/,
+      (req) => {
+        return '{"coins":{"coingecko:ethereum":{"price":1,"symbol":"ETH","timestamp":1675174381,"confidence":0.99}}}'
+      }
+    )
+  })
+
+  describe('getKeyPricingInUSD', () => {
+    it('returns key pricing for recipients', async () => {
+      expect.assertions(2)
+      const usdPricing = await getKeyPricingInUSD({
+        lockAddress,
+        network,
+        recipients,
+        data,
+        referrers: [],
+      })
+
+      expect(usdPricing.length).toBe(2)
+      expect(usdPricing).toMatchObject([
+        {
+          address: '0x6f59999AE79Bc593549918179454A47980a800E5',
+          price: {
+            amount: 0.009,
+            decimals: 18,
+            symbol: 'ETH',
+            amountInUSD: 0.009,
+          },
+        },
+        {
+          address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+          price: {
+            amount: 0.009,
+            decimals: 18,
+            symbol: 'ETH',
+            amountInUSD: 0.009,
+          },
+        },
+      ])
+    })
+
+    it('returns key pricing for recipients with "creditCard" lock setting price', async () => {
+      expect.assertions(2)
+      const usdPricing = await getKeyPricingInUSD({
+        lockAddress: lockAddressWithSettings,
+        network,
+        recipients,
+        data,
+        referrers: [],
+      })
+
+      expect(usdPricing.length).toBe(2)
+      expect(usdPricing).toMatchObject([
+        {
+          address: '0x6f59999AE79Bc593549918179454A47980a800E5',
+          price: {
+            amount: 1,
+            decimals: 18,
+            symbol: '$',
+            amountInUSD: 55.32,
+            amountInCents: 5532,
+          },
+        },
+        {
+          address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+          price: {
+            amount: 1,
+            decimals: 18,
+            symbol: '$',
+            amountInUSD: 55.32,
+            amountInCents: 5532,
+          },
+        },
+      ])
+    })
+  })
+
+  describe('createPricingForPurchase', () => {
+    it('return pricing for purchase', async () => {
+      expect.assertions(2)
+      const pricingForPurchase = await createPricingForPurchase({
+        lockAddress,
+        network,
+        recipients,
+        referrers: [],
+        data,
+      })
+
+      expect(pricingForPurchase.recipients.length).toBe(2)
+      expect(pricingForPurchase.recipients).toMatchObject([
+        {
+          address: '0x6f59999AE79Bc593549918179454A47980a800E5',
+          price: {
+            amount: 0.009,
+            decimals: 18,
+            symbol: 'ETH',
+            amountInUSD: 0.009,
+          },
+        },
+        {
+          address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+          price: {
+            amount: 0.009,
+            decimals: 18,
+            symbol: 'ETH',
+            amountInUSD: 0.009,
+          },
+        },
+      ])
+    })
+
+    it('returns purchase price with "creditCard" setting price', async () => {
+      expect.assertions(2)
+      const pricingForPurchase = await createPricingForPurchase({
+        lockAddress: lockAddressWithSettings,
+        network,
+        recipients,
+        referrers: [],
+        data,
+      })
+
+      expect(pricingForPurchase.recipients.length).toBe(2)
+      expect(pricingForPurchase.recipients).toMatchObject([
+        {
+          address: '0x6f59999AE79Bc593549918179454A47980a800E5',
+          price: {
+            amount: 1,
+            decimals: 18,
+            symbol: '$',
+            amountInUSD: 55.32,
+            amountInCents: 5532,
+          },
+        },
+        {
+          address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
+          price: {
+            amount: 1,
+            decimals: 18,
+            symbol: '$',
+            amountInUSD: 55.32,
+            amountInCents: 5532,
+          },
+        },
+      ])
+    })
+  })
+})

--- a/locksmith/src/operations/pricingOperations.ts
+++ b/locksmith/src/operations/pricingOperations.ts
@@ -85,7 +85,7 @@ interface GetPriceProps {
   network: number
   recipients?: string[]
 }
-/** Get pricing form settings  */
+/** Get pricing from settings  */
 export const getPricingFromSettings = async ({
   lockAddress,
   network,

--- a/locksmith/src/operations/pricingOperations.ts
+++ b/locksmith/src/operations/pricingOperations.ts
@@ -96,7 +96,7 @@ export const getPricingFromSettings = async ({
     network,
   })
 
-  // priority to custom credit card pricing
+  // return pricing object using the price from the settings
   if (creditCardPrice) {
     const keysToPurchase = recipients?.length || 1
 
@@ -112,6 +112,7 @@ export const getPricingFromSettings = async ({
     }
   }
 
+  // no custom price is found
   return null
 }
 

--- a/locksmith/src/operations/pricingOperations.ts
+++ b/locksmith/src/operations/pricingOperations.ts
@@ -3,6 +3,7 @@ import { getFees, getGasCost } from '../utils/pricing'
 import { MIN_PAYMENT_STRIPE_CREDIT_CARD } from '../utils/constants'
 import { ethers } from 'ethers'
 import { Web3Service, getErc20Decimals } from '@unlock-protocol/unlock-js'
+import * as lockSettingOperations from './lockSettingOperations'
 
 interface Price {
   decimals: number
@@ -77,6 +78,41 @@ export const toUsdPricing = ({
     amountInUSD: price ? amount * price : undefined,
     amountInCents: price ? Math.round(amount * price * 100) : 0,
   }
+}
+
+interface GetPriceProps {
+  lockAddress: string
+  network: number
+  recipients?: string[]
+}
+/** Get pricing form settings  */
+export const getPricingFromSettings = async ({
+  lockAddress,
+  network,
+  recipients = [],
+}: GetPriceProps): Promise<KeyPricingPrice | null> => {
+  const { creditCardPrice } = await lockSettingOperations.getSettings({
+    lockAddress,
+    network,
+  })
+
+  // priority to custom credit card pricing
+  if (creditCardPrice) {
+    const keysToPurchase = recipients?.length || 1
+
+    const amountInCents = creditCardPrice * keysToPurchase // this total is in basisPoints
+    const amountInUSD = amountInCents / 100 // get total price in USD
+
+    return {
+      amount: keysToPurchase,
+      decimals: 18,
+      symbol: '$',
+      amountInUSD,
+      amountInCents,
+    }
+  }
+
+  return null
 }
 
 export async function getDefiLammaPrice({
@@ -203,11 +239,21 @@ export const getDefaultUsdPricing = async ({
   lockAddress,
   network,
 }: DefaultPricingProps): Promise<KeyPricingPrice> => {
-  const { keyPrice, decimals, currencyContractAddress } =
-    await getLockKeyPricing({
+  // retrieve pricing
+  const [lockKeyPricing, pricingFromSettings] = await Promise.all([
+    getLockKeyPricing({
       lockAddress,
       network,
-    })
+    }),
+    getPricingFromSettings({ lockAddress, network }),
+  ])
+
+  // priority to pricing from settings if present
+  if (pricingFromSettings) {
+    return pricingFromSettings
+  }
+
+  const { keyPrice, decimals, currencyContractAddress } = lockKeyPricing
 
   const usdPricing = await getDefiLammaPrice({
     network,
@@ -243,14 +289,7 @@ export const getUsdPricingForRecipient = async ({
     network,
   })
 
-  const [purchasePrice, usdPricing] = await Promise.all([
-    web3Service.purchasePriceFor({
-      lockAddress,
-      userAddress,
-      data,
-      network,
-      referrer,
-    }),
+  const [usdPricing, pricingFromSettings] = await Promise.all([
     getDefiLammaPrice({
       network,
       erc20Address:
@@ -259,7 +298,24 @@ export const getUsdPricingForRecipient = async ({
           ? undefined
           : currencyContractAddress,
     }),
+    getPricingFromSettings({ lockAddress, network }),
   ])
+
+  // priority to pricing from settings if present
+  if (pricingFromSettings) {
+    return {
+      address: userAddress,
+      price: pricingFromSettings,
+    }
+  }
+
+  const purchasePrice = await web3Service.purchasePriceFor({
+    lockAddress,
+    userAddress,
+    data,
+    network,
+    referrer,
+  })
 
   const amount = fromDecimal(purchasePrice, decimals)
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- change `getDefaultUsdPricing`& `getUsdPricingForRecipient` to use custom credit card price for purchase when set, this functions are used for `getKeyPricingInUSD` included in `createPricingForPurchase` so more tests are added to check that everything works fine

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
