### PR TITLE
feat(unlock-app) - fix metadata url

### DIFF
--- a/unlock-app/src/components/interface/Picker/index.tsx
+++ b/unlock-app/src/components/interface/Picker/index.tsx
@@ -129,6 +129,8 @@ export function Picker({
       ? tokenUrl(lockAddress, state.keyId)
       : ''
 
+  const hasValidOpenSeaUrl = openSeaCollectionUrl || openSeaTokenUrl
+
   const showLocks =
     state.network && collect.lockAddress && (lockExists || isLoadingLocks)
 
@@ -181,19 +183,23 @@ export function Picker({
                 {`Enter the key ID you want to use. This can be an existing key ID
                 or a new one which doesn't exist yet.`}
               </span>
-              <Link
-                target="_blank"
-                rel="noopener noreferrer"
-                href={state.keyId ? openSeaTokenUrl! : openSeaCollectionUrl!}
-                className="font-semibold text-brand-ui-primary"
-              >
-                <div className="flex gap-2">
-                  <span>
-                    {state.keyId ? 'See NFT on OpenSea' : ' See NFT Collection'}
-                  </span>
-                  <ExternalLinkIcon size={20} />
-                </div>
-              </Link>
+              {hasValidOpenSeaUrl && (
+                <Link
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={state.keyId ? openSeaTokenUrl! : openSeaCollectionUrl!}
+                  className="font-semibold text-brand-ui-primary"
+                >
+                  <div className="flex gap-2">
+                    <span>
+                      {state.keyId
+                        ? 'See NFT on OpenSea'
+                        : ' See NFT Collection'}
+                    </span>
+                    <ExternalLinkIcon size={20} />
+                  </div>
+                </Link>
+              )}
             </>
           }
           value={state.keyId}


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

Fix issue on metadata editor

- Not all networks have links to `opensea`, this breaks the metadata editor when we look a specific keyId in `gnosis` for example

ref: 
```
opensea: {
    tokenUrl: (_lockAddress, _tokenId) => null,
  },
```

in this case, there is no need to show the URL 

**Fix `networks` without opensea URL**

- links to opensea in hidden

<img width="500" alt="Screenshot 2023-06-15 at 15 11 00" src="https://github.com/unlock-protocol/unlock/assets/20865711/0545c658-cfbc-4050-a201-6364d4f45c25">


**Other networks with opensea URL** 

<img width="500" alt="Screenshot 2023-06-15 at 15 12 14" src="https://github.com/unlock-protocol/unlock/assets/20865711/f47f88f5-5fbb-4394-8ece-ff808b7cb3b9">


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
