### PR TITLE
feat(locksmith) - pass correct pricing amount from settings operations 

### DIFF
--- a/locksmith/__tests__/operations/pricingOperations.test.ts
+++ b/locksmith/__tests__/operations/pricingOperations.test.ts
@@ -179,7 +179,7 @@ describe('pricingOperations', () => {
         network,
       })
 
-      expect(pricing.amount).toBe(1)
+      expect(pricing.amount).toBe(55.32)
       expect(pricing.amountInCents).toBe(5532)
       expect(pricing.amountInUSD).toBe(55.32)
       expect(pricing.decimals).toBe(18)
@@ -237,7 +237,7 @@ describe('pricingOperations', () => {
       expect(pricing.price.symbol).toBe('$')
       expect(pricing.price.amountInUSD).toBe(55.32)
       expect(pricing.price.amountInCents).toBe(5532)
-      expect(pricing.price.amount).toBe(1)
+      expect(pricing.price.amount).toBe(55.32)
     })
   })
 
@@ -254,7 +254,7 @@ describe('pricingOperations', () => {
     })
 
     it('returns pricing when "creditCardPrice" is set in lockSettings', async () => {
-      expect.assertions(4)
+      expect.assertions(5)
 
       const pricing = await pricingOperations.getPricingFromSettings({
         lockAddress,
@@ -265,10 +265,11 @@ describe('pricingOperations', () => {
       expect(pricing?.symbol).toBe('$')
       expect(pricing?.amountInUSD).toBe(55.32)
       expect(pricing?.amountInCents).toBe(5532)
+      expect(pricing?.amount).toBe(55.32)
     })
 
     it('returns pricing when "creditCardPrice" is set in lockSettings for recipients', async () => {
-      expect.assertions(4)
+      expect.assertions(5)
 
       const pricing = await pricingOperations.getPricingFromSettings({
         lockAddress,
@@ -281,6 +282,7 @@ describe('pricingOperations', () => {
       // total for the 2 recipients
       expect(pricing?.amountInUSD).toBe(110.64)
       expect(pricing?.amountInCents).toBe(11064)
+      expect(pricing?.amount).toBe(110.64)
     })
   })
 })

--- a/locksmith/__tests__/utils/pricing.test.ts
+++ b/locksmith/__tests__/utils/pricing.test.ts
@@ -143,7 +143,7 @@ describe('pricing', () => {
         {
           address: '0x6f59999AE79Bc593549918179454A47980a800E5',
           price: {
-            amount: 1,
+            amount: 55.32,
             decimals: 18,
             symbol: '$',
             amountInUSD: 55.32,
@@ -153,7 +153,7 @@ describe('pricing', () => {
         {
           address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
           price: {
-            amount: 1,
+            amount: 55.32,
             decimals: 18,
             symbol: '$',
             amountInUSD: 55.32,
@@ -213,7 +213,7 @@ describe('pricing', () => {
         {
           address: '0x6f59999AE79Bc593549918179454A47980a800E5',
           price: {
-            amount: 1,
+            amount: 55.32,
             decimals: 18,
             symbol: '$',
             amountInUSD: 55.32,
@@ -223,7 +223,7 @@ describe('pricing', () => {
         {
           address: '0x9aBa7eeb134Fa94dfe735205DdA6aC6447d76F9b',
           price: {
-            amount: 1,
+            amount: 55.32,
             decimals: 18,
             symbol: '$',
             amountInUSD: 55.32,

--- a/locksmith/src/operations/pricingOperations.ts
+++ b/locksmith/src/operations/pricingOperations.ts
@@ -104,7 +104,7 @@ export const getPricingFromSettings = async ({
     const amountInUSD = amountInCents / 100 // get total price in USD
 
     return {
-      amount: keysToPurchase,
+      amount: amountInUSD, // amount is usd for the single key
       decimals: 18,
       symbol: '$',
       amountInUSD,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description

- Pass correct pricing in USD from pricing from price from setting

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
