### PR TITLE
feat(locksmith) - unlock fee settings

### DIFF
--- a/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
+++ b/locksmith/__tests__/controllers/v2/lockSettingController.test.ts
@@ -11,6 +11,7 @@ const lockSettingMock = {
   lockAddress: '0xF3850C690BFF6c1E343D2449bBbbb00b0E934f7b',
   network,
   sendEmail: true,
+  unlockFeeChargedToUser: true,
   creditCardPrice: 0.04,
   emailSender: 'Custom Sender',
   slug: 'slug-test',
@@ -70,7 +71,7 @@ describe('LockSettings v2 endpoints for lock', () => {
   })
 
   it('should correctly enable "sendEmail" setting when user is lockManager', async () => {
-    expect.assertions(3)
+    expect.assertions(4)
 
     const { loginResponse } = await loginRandomUser(app)
     expect(loginResponse.status).toBe(200)
@@ -80,15 +81,17 @@ describe('LockSettings v2 endpoints for lock', () => {
       .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
       .send({
         sendEmail: true,
+        unlockFeeChargedToUser: false,
       })
 
     const response = saveSettingResponse.body
     expect(saveSettingResponse.status).toBe(200)
     expect(response.sendEmail).toBe(true)
+    expect(response.unlockFeeChargedToUser).toBe(false)
   })
 
   it('should correctly save settings when user is lockManager', async () => {
-    expect.assertions(8)
+    expect.assertions(9)
 
     const { loginResponse } = await loginRandomUser(app)
     const saveSettingResponse = await request(app)
@@ -96,6 +99,7 @@ describe('LockSettings v2 endpoints for lock', () => {
       .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
       .send({
         sendEmail: false,
+        unlockFeeChargedToUser: false,
         replyTo: 'example@gmail.com',
         slug: 'slug-demo',
         emailSender: 'Example',
@@ -112,10 +116,11 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(response.emailSender).toBe('Example')
     expect(response.checkoutConfigId).toBe('f549d936-24e6-49e0-9acb')
     expect(response.hookGuildId).toBe(14)
+    expect(response.unlockFeeChargedToUser).toBe(false)
   })
 
   it('should save and retrieve setting when user is lockManager', async () => {
-    expect.assertions(17)
+    expect.assertions(19)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -125,6 +130,7 @@ describe('LockSettings v2 endpoints for lock', () => {
       .set('authorization', `Bearer ${loginResponse.body.accessToken}`)
       .send({
         sendEmail: false,
+        unlockFeeChargedToUser: false,
         replyTo: 'example@gmail.com',
         creditCardPrice: 0.04,
         slug: 'slug-test-2',
@@ -136,6 +142,7 @@ describe('LockSettings v2 endpoints for lock', () => {
     const response = saveSettingResponse.body
     expect(saveSettingResponse.status).toBe(200)
     expect(response.sendEmail).toBe(false)
+    expect(response.unlockFeeChargedToUser).toBe(false)
     expect(response.replyTo).toBe('example@gmail.com')
     expect(response.creditCardPrice).toBe(0.04)
     expect(response.slug).toBe('slug-test-2')
@@ -150,6 +157,7 @@ describe('LockSettings v2 endpoints for lock', () => {
 
     expect(getSettingResponse.status).toBe(200)
     expect(getSettingResponse.body.sendEmail).toBe(false)
+    expect(getSettingResponse.body.unlockFeeChargedToUser).toBe(false)
     expect(getSettingResponse.body.replyTo).toBe('example@gmail.com')
     expect(getSettingResponse.body.lockAddress).toBe(
       lockSettingMock.lockAddress
@@ -164,7 +172,7 @@ describe('LockSettings v2 endpoints for lock', () => {
   })
 
   it('should retrieve default settings for a lock', async () => {
-    expect.assertions(8)
+    expect.assertions(9)
 
     const { loginResponse } = await loginRandomUser(app)
 
@@ -176,6 +184,7 @@ describe('LockSettings v2 endpoints for lock', () => {
     expect(getSettingResponse.body.sendEmail).toBe(
       DEFAULT_LOCK_SETTINGS.sendEmail
     )
+    expect(getSettingResponse.body.unlockFeeChargedToUser).toBe(true)
     expect(getSettingResponse.body.replyTo).toBe(undefined)
     expect(getSettingResponse.body.creditCardPrice).toBe(undefined)
     expect(getSettingResponse.body.slug).toBe(undefined)

--- a/locksmith/migrations/20230623135442-add-unlock-fee-settings.js
+++ b/locksmith/migrations/20230623135442-add-unlock-fee-settings.js
@@ -1,0 +1,17 @@
+'use strict'
+const table = 'LockSettings'
+/** @type {import('sequelize-cli').Migration} */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(table, 'unlockFeeChargedToUser', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(table, 'unlockFeeChargedToUser')
+  },
+}

--- a/locksmith/src/controllers/v2/lockSettingController.ts
+++ b/locksmith/src/controllers/v2/lockSettingController.ts
@@ -39,6 +39,12 @@ const LockSettingSchema = z.object({
       description: 'Checkout config URL id.',
     })
     .nullish(),
+  unlockFeeChargedToUser: z
+    .boolean({
+      description:
+        'When enabled the Unlock fee will be included to the total cost for the user, otherwise the lock manager will absorb" that cost.',
+    })
+    .default(true),
   hookGuildId: z
     .preprocess(
       (a) => parseInt(z.string().parse(a), 10),
@@ -53,6 +59,7 @@ export type LockSettingProps = z.infer<typeof LockSettingSchema>
 
 export const DEFAULT_LOCK_SETTINGS: LockSettingProps = {
   sendEmail: true,
+  unlockFeeChargedToUser: true,
   replyTo: undefined,
   creditCardPrice: undefined,
   emailSender: undefined,

--- a/locksmith/src/models/lockSetting.ts
+++ b/locksmith/src/models/lockSetting.ts
@@ -15,6 +15,7 @@ export class LockSetting extends Model<
   declare slug?: string
   declare checkoutConfigId?: string | null
   declare hookGuildId?: number | null
+  declare unlockFeeChargedToUser?: boolean
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 }
@@ -63,6 +64,11 @@ LockSetting.init(
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,
+    },
+    unlockFeeChargedToUser: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
     createdAt: {
       allowNull: false,


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR adds  `unlockFeeChargedToUser` settings in `lockSettings`, this will use to enable/disable if the user will be charged with the Unlock fee.

ref:  https://github.com/unlock-protocol/unlock/issues/12167 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
