### PR TITLE
fix(unlock-app, paywall): Autoconnect with delegated provider

### DIFF
--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "./dist/unlock.latest.umd.js",
   "module": "./dist/unlock.latest.es.js",
   "typings": "./dist/index.d.ts",

--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "./dist/unlock.latest.umd.js",
   "module": "./dist/unlock.latest.es.js",
   "typings": "./dist/index.d.ts",

--- a/packages/paywall/src/Paywall.ts
+++ b/packages/paywall/src/Paywall.ts
@@ -126,10 +126,7 @@ export class Paywall {
     } else {
       await this.shakeHands(unlockUrl || unlockAppUrl)
     }
-    this.sendOrBuffer(
-      'setConfig',
-      injectProviderInfo(config || this.paywallConfig, this.provider)
-    )
+    this.setPaywallConfig(config || this.paywallConfig)
   }
 
   setPaywallConfig = (config: PaywallConfig) => {

--- a/unlock-app/src/components/interface/checkout/Connected.tsx
+++ b/unlock-app/src/components/interface/checkout/Connected.tsx
@@ -64,7 +64,12 @@ export function SignedIn({
 
 interface SignedOutProps {
   authenticateWithProvider(
-    provider: 'METAMASK' | 'UNLOCK' | 'WALLET_CONNECT' | 'COINBASE'
+    provider:
+      | 'METAMASK'
+      | 'UNLOCK'
+      | 'WALLET_CONNECT'
+      | 'COINBASE'
+      | 'DELEGATED_PROVIDER'
   ): Promise<void>
   onUnlockAccount(): void
   injectedProvider: any
@@ -201,13 +206,6 @@ export function Connected({
     }
     autoSignIn()
   }, [connected, autoconnect, isUnlockAccount, signIn, signing, isSignedIn])
-
-  // Autoconnect
-  useEffect(() => {
-    if (autoconnect) {
-      authenticateWithProvider('METAMASK')
-    }
-  }, [autoconnect, authenticateWithProvider])
 
   useEffect(() => {
     if (!account) {

--- a/unlock-app/src/components/interface/checkout/index.tsx
+++ b/unlock-app/src/components/interface/checkout/index.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import React, { useEffect } from 'react'
-import { selectProvider } from '~/hooks/useAuthenticate'
+import { selectProvider, useAuthenticate } from '~/hooks/useAuthenticate'
 import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 import { getPaywallConfigFromQuery } from '~/utils/paywallConfig'
 import getOauthConfigFromQuery from '~/utils/oauth'
@@ -18,6 +18,8 @@ import { ethers } from 'ethers'
 export function CheckoutPage() {
   const { query } = useRouter()
   const config = useConfig()
+  const { authenticateWithProvider } = useAuthenticate({})
+
   // Fetch config from parent in iframe context
   const communication = useCheckoutCommunication()
   const { isInitialLoading, data: checkout } = useCheckoutConfig({
@@ -46,6 +48,11 @@ export function CheckoutPage() {
 
   const injectedProvider =
     communication.providerAdapter || selectProvider(config)
+
+  // Autoconnect, provider might change (we could receive the provider from the parent with a delay!)
+  useEffect(() => {
+    authenticateWithProvider('DELEGATED_PROVIDER', injectedProvider)
+  }, [authenticateWithProvider, injectedProvider])
 
   const checkoutRedirectURI =
     paywallConfig?.redirectUri ||

--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -47,6 +47,7 @@ interface AuthenticateProps {
 
 export enum WALLET_PROVIDER {
   METAMASK,
+  DELEGATED_PROVIDER,
   WALLET_CONNECT,
   COINBASE,
   UNLOCK,
@@ -68,6 +69,13 @@ export function useAuthenticate(options: AuthenticateProps = {}) {
   }, [authenticate, injectedOrDefaultProvider])
 
   const handleUnlockProvider = useCallback(
+    async (provider: any) => {
+      return authenticate(provider)
+    },
+    [authenticate]
+  )
+
+  const handleDelegatedProvider = useCallback(
     async (provider: any) => {
       return authenticate(provider)
     },
@@ -111,6 +119,7 @@ export function useAuthenticate(options: AuthenticateProps = {}) {
   const walletHandlers: {
     [key in WalletProvider]: (provider?: any) => Promise<any | void>
   } = {
+    DELEGATED_PROVIDER: handleDelegatedProvider,
     METAMASK: handleInjectProvider,
     WALLET_CONNECT: handleWalletConnectProvider,
     COINBASE: handleCoinbaseWalletProvider,


### PR DESCRIPTION
# Description

Making sure we use the delegated provider, even if an injected provider is already connected.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
