### PR TITLE
feature(unlock-app): not showing unlimited amount or unlimited duration to simplify the flow

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -105,32 +105,38 @@ const LockOption = ({ disabled, lock }: LockOptionProps) => {
             <div className="w-full space-y-2">
               <div className="flex justify-between w-full place-items-center">
                 <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
-                  <LabeledItem
-                    label="Duration"
-                    icon={DurationIcon}
-                    value={formattedData?.formattedDuration}
-                  />
-                  <LabeledItem
-                    label="Quantity"
-                    icon={QuantityIcon}
-                    value={
-                      formattedData?.isSoldOut
-                        ? 'Sold out'
-                        : formattedData?.formattedKeysAvailable
-                    }
-                  />
-                  {!!lock.recurringPayments &&
-                    parseInt(lock.recurringPayments.toString()) > 1 && (
+                  {formattedData?.formattedDuration !== 'Forever' && (
+                    <>
                       <LabeledItem
-                        label="Renew"
-                        icon={RecurringIcon}
-                        value={
-                          typeof lock.recurringPayments === 'number'
-                            ? `${lock.recurringPayments} times`
-                            : lock.recurringPayments
-                        }
+                        label="Duration"
+                        icon={DurationIcon}
+                        value={formattedData?.formattedDuration}
                       />
-                    )}
+                      {!!lock.recurringPayments &&
+                        parseInt(lock.recurringPayments.toString()) > 1 && (
+                          <LabeledItem
+                            label="Renew"
+                            icon={RecurringIcon}
+                            value={
+                              typeof lock.recurringPayments === 'number'
+                                ? `${lock.recurringPayments} times`
+                                : lock.recurringPayments
+                            }
+                          />
+                        )}
+                    </>
+                  )}
+                  {formattedData?.formattedKeysAvailable !== 'Unlimited' && (
+                    <LabeledItem
+                      label="Quantity"
+                      icon={QuantityIcon}
+                      value={
+                        formattedData?.isSoldOut
+                          ? 'Sold out'
+                          : formattedData?.formattedKeysAvailable
+                      }
+                    />
+                  )}
                 </div>
                 <div>
                   {checked ? (


### PR DESCRIPTION
# Description

A small UI improvement suggested by the Consensys team: when amounts or expirations are unlimited, no need to show them!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
