### PR TITLE
fix(locksmith): rescuing timeout on balance request

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -52,7 +52,19 @@ export default class Dispatcher {
       Object.values(networks).map(async (network: any) => {
         try {
           const { wallet, provider } = await this.getPurchaser(network.id)
-          const balance = await provider.getBalance(wallet.address)
+
+          const balance: ethers.BigNumberish =
+            await Promise.race<ethers.BigNumberish>([
+              new Promise((resolve) =>
+                setTimeout(() => {
+                  console.log(
+                    `Could not retrieve balance on network ${network.id}`
+                  )
+                  resolve(0)
+                }, 3000)
+              ),
+              provider.getBalance(wallet.address),
+            ])
           return [
             network.id,
             {
@@ -62,7 +74,10 @@ export default class Dispatcher {
             },
           ]
         } catch (error) {
-          logger.error(error)
+          logger.error('Could not retrieve balance on network', {
+            network,
+            error,
+          })
           return [network.id, {}]
         }
       })


### PR DESCRIPTION
# Description

Some networks are slow to respond to when querying balances... 

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
