### PR TITLE
feature(unlock-app): Adding a `recipient` option to the checkout

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -113,6 +113,12 @@ export const PaywallLockConfig = z.object({
     })
     .default(true)
     .optional(),
+  recipient: z
+    .string({
+      description:
+        'Hardcoded address for the recipient of the NFT. Can be used with skipRecipient.',
+    })
+    .optional(),
 })
 
 export type PaywallLockConfigType = z.infer<typeof PaywallLockConfig>
@@ -237,7 +243,6 @@ export const PaywallConfig = z
       })
       .default(true)
       .optional(),
-
     skipSelect: z
       .boolean({
         description:
@@ -245,7 +250,6 @@ export const PaywallConfig = z
       })
       .default(false)
       .optional(),
-
     expectedAddress: z
       .string({
         description: 'Expected wallet address for user.',
@@ -257,6 +261,12 @@ export const PaywallConfig = z
           '(Advanced): forces the use the provider from the parent window when the checkout is embeded as an iframe.',
       })
       .default(false)
+      .optional(),
+    recipient: z
+      .string({
+        description:
+          'Hardcoded address for the recipient of the NFT. Can be used with skipRecipient.',
+      })
       .optional(),
   })
   .passthrough()

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -47,15 +47,20 @@ interface RecipientInputProps {
   id: number
   hideFirstRecipient?: boolean
   lock: Lock
+  checkoutService: CheckoutService
 }
 
 export const MetadataInputs = ({
+  checkoutService,
   metadataInputs,
   disabled,
   id,
   lock,
   hideFirstRecipient,
 }: RecipientInputProps) => {
+  const [state] = useActor(checkoutService)
+  const { paywallConfig } = state.context
+
   const [hideRecipientAddress, setHideRecipientAddress] = useState<boolean>(
     hideFirstRecipient || false
   )
@@ -69,6 +74,7 @@ export const MetadataInputs = ({
     formState: { errors },
   } = useFormContext<FormData>()
   const networkConfig = config.networks[lock.network]
+
   const onRecipientChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value
@@ -105,16 +111,22 @@ export const MetadataInputs = ({
       'border-brand-secondary hover:border-brand-secondary focus:border-brand-secondary focus:ring-brand-secondary'
   )
 
+  let recipient = account
+  // The first recipient could be hardcoded
+  if (id == 0 && paywallConfig.recipient) {
+    recipient = paywallConfig.recipient
+  }
+
   return (
     <div className="grid gap-2">
       {hideRecipientAddress ? (
         <div className="space-y-1">
           <div className="ml-1 text-sm">
-            {isUnlockAccount ? 'Email' : 'Wallet'}
+            {isUnlockAccount ? 'Email:' : 'Wallet:'}
           </div>
           <div className="flex items-center pl-4 pr-2 py-1.5 justify-between bg-gray-200 rounded-lg">
             <div className="w-32 text-sm truncate">
-              {isUnlockAccount ? email : account}
+              {isUnlockAccount ? email : recipient}
             </div>
             <Button
               type="button"
@@ -395,6 +407,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
                 >
                   <FormProvider {...methods}>
                     <MetadataInputs
+                      checkoutService={checkoutService}
                       hideFirstRecipient={hideRecipient}
                       disabled={isSubmitting}
                       metadataInputs={metadataInputs}

--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
@@ -251,6 +251,8 @@ export const checkoutMachine = createMachine(
               actions: ['selectLock'],
               target: 'METADATA',
               cond: (_, event) => {
+                // For expired memberships we do not offer the ability
+                // to change the metadadata and recipient...
                 return !event.skipRecipient && !event.expiredMember
               },
             },


### PR DESCRIPTION

# Description

Allowing the paywall config to include a recipient address wich will be set by default for the first recipient.
This will be useful for applications which are letting users mint NFT from an EOA to a smart wallet.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

