### PR TITLE
fix(paywal): updated script to detect localstorage

### DIFF
--- a/packages/paywall/src/utils/localStorage.ts
+++ b/packages/paywall/src/utils/localStorage.ts
@@ -1,8 +1,9 @@
 // copied from the MDN docs as the best way to detect localStorage presence
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Testing_for_availability
 export default function localStorageAvailable(): boolean {
-  const storage = localStorage
+  let storage
   try {
+    storage = window['localStorage']
     const x = '__storage_test__'
     storage.setItem(x, x)
     storage.removeItem(x)
@@ -20,6 +21,7 @@ export default function localStorageAvailable(): boolean {
         // Firefox
         e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
       // acknowledge QuotaExceededError only if there's something already stored
+      storage &&
       storage.length !== 0
     )
   }


### PR DESCRIPTION
# Description

In incognito, we cannot access `localstorage` so we need to load it _inside_ the `try/catch`.
Taken from https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
