### PR TITLE
fix(unlock-app): emit event when user signs

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Returning.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Returning.tsx
@@ -18,16 +18,19 @@ import { isEthPassSupported, Platform } from '~/services/ethpass'
 import { useQuery } from '@tanstack/react-query'
 import { useWeb3Service } from '~/utils/withWeb3Service'
 import { ReturningButton } from '../ReturningButton'
+import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 
 interface Props {
   injectedProvider: unknown
   checkoutService: CheckoutService
   onClose(params?: Record<string, string>): void
+  communication?: ReturnType<typeof useCheckoutCommunication>
 }
 
 export function Returning({
   checkoutService,
   injectedProvider,
+  communication,
   onClose,
 }: Props) {
   const config = useConfig()
@@ -56,6 +59,11 @@ export function Returning({
         address: account!,
       })
       setHasMessageToSign(false)
+      communication?.emitUserInfo({
+        address: account,
+        message: paywallConfig.messageToSign,
+        signedMessage: signature,
+      })
     } catch (error) {
       if (error instanceof Error) {
         ToastHelper.error(error.message)

--- a/unlock-app/src/components/interface/checkout/main/index.tsx
+++ b/unlock-app/src/components/interface/checkout/main/index.tsx
@@ -237,6 +237,7 @@ export function Checkout({
       case 'RETURNING': {
         return (
           <Returning
+            communication={communication}
             onClose={onClose}
             injectedProvider={injectedProvider}
             checkoutService={checkoutService}

--- a/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
+++ b/unlock-app/src/components/interface/locks/CheckoutUrl/elements/LocksForm.tsx
@@ -368,7 +368,7 @@ export const LocksForm = ({
           {Object.entries(locks ?? {})?.map(
             ([address, values]: [
               string,
-              z.infer<typeof PaywallLockConfig>
+              z.infer<typeof PaywallLockConfig>,
             ]) => {
               const hasEdit =
                 lockAddress?.toLowerCase() === address?.toLowerCase()

--- a/unlock-app/src/components/interface/locks/metadata/custom/index.tsx
+++ b/unlock-app/src/components/interface/locks/metadata/custom/index.tsx
@@ -65,9 +65,7 @@ export function LockCustomForm() {
             <div className="flex flex-wrap gap-6 mt-6">
               {properties
                 ?.filter((item) => item.trait_type && item.value)
-                .map((item, index) => (
-                  <Property {...item} key={index} />
-                ))}
+                .map((item, index) => <Property {...item} key={index} />)}
             </div>
           </div>
           <div className="py-2 border-b border-gray-300">
@@ -94,9 +92,7 @@ export function LockCustomForm() {
                 ?.filter(
                   (item) => item.trait_type && item.value && item.max_value
                 )
-                .map((item, index) => (
-                  <Level {...item} key={index} />
-                ))}
+                .map((item, index) => <Level {...item} key={index} />)}
             </div>
           </div>
           <div className="py-2 border-b border-gray-300">
@@ -123,9 +119,7 @@ export function LockCustomForm() {
                 ?.filter(
                   (item) => item.trait_type && item.value && item.max_value
                 )
-                .map((item, index) => (
-                  <Stat {...item} key={index} />
-                ))}
+                .map((item, index) => <Stat {...item} key={index} />)}
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Description

If the user signs on the last step of the checkout because they already have a membership we should also emit an event!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
