### PR TITLE
refactor(locksmith): the public provider should only ever be used to send transactions

### DIFF
--- a/locksmith/src/controllers/v2/priceController.ts
+++ b/locksmith/src/controllers/v2/priceController.ts
@@ -105,12 +105,15 @@ export const isCardPaymentEnabledForLock: RequestHandler = async (
   const network = Number(request.params.network)
 
   const web3Service = new Web3Service(networks)
-  const lock = await web3Service.getLock(lockAddress, network)
+
+  const lock = await web3Service.getLock(lockAddress, network, {
+    fields: ['keyPrice', 'currencyContractAddress'],
+  })
 
   const [defiLammaPricing, settingsPricing] = await Promise.all([
     pricingOperations.getDefiLammaPrice({
       network,
-      erc20Address: lock?.currencyContractAddress,
+      erc20Address: lock.currencyContractAddress,
       amount: Number(`${lock.keyPrice}`),
     }),
     lockSettingOperations.getSettings({

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -28,6 +28,16 @@ interface KeyToGrant {
  * @returns
  */
 export const getProviderForNetwork = async function (network = 1) {
+  return new ethers.providers.JsonRpcProvider(networks[network].provider)
+}
+
+/**
+ * Helper function to return the public provider for a network id
+ * (used to send tx only!)
+ * @param network
+ * @returns
+ */
+export const getPublicProviderForNetwork = async function (network = 1) {
   return new ethers.providers.JsonRpcProvider(networks[network].publicProvider)
 }
 
@@ -45,7 +55,7 @@ export const getPurchaser = async function (network = 1) {
     })
     return { wallet, provider }
   }
-  const provider = await getProviderForNetwork(network)
+  const provider = await getPublicProviderForNetwork(network)
   const wallet = new ethers.Wallet(config.purchaserCredentials, provider)
   return {
     wallet,
@@ -62,7 +72,8 @@ export default class Dispatcher {
     const balances = await Promise.all(
       Object.values(networks).map(async (network: any) => {
         try {
-          const { wallet, provider } = await getPurchaser(network.id)
+          const provider = await getPublicProviderForNetwork(network.id)
+          const { wallet } = await getPurchaser(network.id)
           const address = await wallet.getAddress()
           const balance: ethers.BigNumberish =
             await Promise.race<ethers.BigNumberish>([
@@ -104,8 +115,8 @@ export default class Dispatcher {
    * @returns
    */
   async hasFundsForTransaction(network: number): Promise<boolean> {
-    const { wallet, provider } = await getPurchaser(network)
-
+    const provider = await getProviderForNetwork(network)
+    const { wallet } = await getPurchaser(network)
     const gasPrice = await provider.getGasPrice()
     const address = await wallet.getAddress()
     const balance = await provider.getBalance(address)

--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -72,7 +72,7 @@ export default class Dispatcher {
     const balances = await Promise.all(
       Object.values(networks).map(async (network: any) => {
         try {
-          const provider = await getPublicProviderForNetwork(network.id)
+          const provider = await getProviderForNetwork(network.id)
           const { wallet } = await getPurchaser(network.id)
           const address = await wallet.getAddress()
           const balance: ethers.BigNumberish =

--- a/locksmith/src/routes/v2/price.ts
+++ b/locksmith/src/routes/v2/price.ts
@@ -6,6 +6,7 @@ import {
   total,
   getTotalChargesForLock,
 } from '../../controllers/v2/priceController'
+import { createCacheMiddleware } from '../../utils/middlewares/cacheMiddleware'
 
 const router = express.Router({ mergeParams: true })
 
@@ -15,6 +16,7 @@ router.get('/purchase/total', total)
 router.get('/price/:network/:lock/card', universalCard)
 router.get(
   '/credit-card-details/:network/locks/:lockAddress',
+  createCacheMiddleware(),
   isCardPaymentEnabledForLock
 )
 


### PR DESCRIPTION
# Description

Publick providers are heavily monitored and and tend to block/be slow if used to "read" state.
We had an issue where we used the public provider to read the gas settings...


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
