### PR TITLE
refactor(locksmith): changing the deployment scripts for locksmith

### DIFF
--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -4,6 +4,7 @@
   "description": "an unlock storage service",
   "main": "server.js",
   "scripts": {
+    "release": "./scripts/release.sh",
     "prod": "tsx -r ./config/envLoader.js ./src/server.ts",
     "start": "./scripts/start.sh server",
     "dev": "NODE_ENV=development yarn db:migrate && tsx watch -r ./config/envLoader.js src/server.ts",

--- a/locksmith/scripts/release.sh
+++ b/locksmith/scripts/release.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+echo "I was released!"


### PR DESCRIPTION
# Description

As I was looking for ways to make sure that Heroku does proper blue/green deployment, I found we need to use what Heroku calls the "release phase", so I started to work on adding this.
I then realized we could also refactor our "worker" approach by having a single application that runs both `web` and `worker` dynos (and `release`).


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
