### PR TITLE
fix(unlock-app): using valueAsNumber: when applicable

### DIFF
--- a/unlock-app/src/components/content/certification/CertificationForm.tsx
+++ b/unlock-app/src/components/content/certification/CertificationForm.tsx
@@ -244,8 +244,10 @@ export const CertificationForm = ({ onSubmit }: FormProps) => {
                   </div>
                   <Input
                     disabled={forever}
+                    type="number"
                     error={errors.lock?.expirationDuration?.message as string}
                     {...register('lock.expirationDuration', {
+                      valueAsNumber: true,
                       required: {
                         value: !forever,
                         message: 'Please add a duration',
@@ -368,6 +370,7 @@ export const CertificationForm = ({ onSubmit }: FormProps) => {
                             step="any"
                             disabled={isFree}
                             {...register('lock.keyPrice', {
+                              valueAsNumber: true,
                               required: {
                                 value: !isFree,
                                 message: 'This value is required',
@@ -403,6 +406,7 @@ export const CertificationForm = ({ onSubmit }: FormProps) => {
                     </div>
                     <Input
                       {...register('lock.maxNumberOfKeys', {
+                        valueAsNumber: true,
                         min: 0,
                         required: {
                           value: !unlimitedQuantity,

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -446,6 +446,7 @@ export const Form = ({ onSubmit }: FormProps) => {
                       step="any"
                       disabled={isFree}
                       {...register('lock.keyPrice', {
+                        valueAsNumber: true,
                         required: !isFree,
                       })}
                     />
@@ -456,6 +457,7 @@ export const Form = ({ onSubmit }: FormProps) => {
               <Input
                 {...register('lock.maxNumberOfKeys', {
                   min: 0,
+                  valueAsNumber: true,
                   required: {
                     value: true,
                     message: 'Capacity is required. ',

--- a/unlock-app/src/components/interface/checkout/main/Quantity.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Quantity.tsx
@@ -122,7 +122,7 @@ export function Quantity({ injectedProvider, checkoutService }: Props) {
 
                   setQuantityInput(count)
                 }}
-                pattern="[0-9]{0,2}"
+                pattern="\d+"
                 value={quantityInput}
                 type="text"
                 className="w-16 text-sm border-2 border-gray-300 rounded-lg focus:ring-0 focus:border-brand-ui-primary"

--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
@@ -262,6 +262,7 @@ export const CreateLockForm = ({
                   step="any"
                   disabled={unlimitedDuration}
                   {...register('expirationDuration', {
+                    valueAsNumber: true,
                     min: 0,
                     required: !unlimitedDuration,
                   })}
@@ -302,6 +303,7 @@ export const CreateLockForm = ({
                   step={1}
                   disabled={unlimitedQuantity}
                   {...register('maxNumberOfKeys', {
+                    valueAsNumber: true,
                     min: 0,
                     required: !unlimitedQuantity,
                   })}
@@ -351,6 +353,7 @@ export const CreateLockForm = ({
                     step="any"
                     disabled={isFree}
                     {...register('keyPrice', {
+                      valueAsNumber: true,
                       required: !isFree,
                     })}
                   />

--- a/unlock-app/src/components/interface/locks/Manage/elements/WithdrawFundModal.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/WithdrawFundModal.tsx
@@ -228,6 +228,7 @@ export const WithdrawFundModal = ({
                 step="any"
                 disabled={withdrawMutation.isLoading}
                 {...register('amount', {
+                  valueAsNumber: true,
                   validate: (value) => {
                     const formattedValue = parseFloat(`${value}`)
 

--- a/unlock-app/src/components/interface/locks/Settings/forms/CancellationForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/CancellationForm.tsx
@@ -192,6 +192,7 @@ export const CancellationForm = ({
             step={1}
             error={errors?.freeTrialLength && 'This field is required'}
             {...register('freeTrialLength', {
+              valueAsNumber: true,
               required: true,
               min: 0,
             })}
@@ -221,6 +222,7 @@ export const CancellationForm = ({
               'This field accept percentage value between 0 and 100.'
             }
             {...register('refundPenaltyPercentage', {
+              valueAsNumber: true,
               required: true,
               min: 0,
               max: 100,

--- a/unlock-app/src/components/interface/locks/Settings/forms/CreditCardCustomPrice.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/CreditCardCustomPrice.tsx
@@ -189,6 +189,7 @@ export default function CreditCardCustomPrice({
                   description="Set a fixed price in fiat currency that is charged for card payments."
                   error={errors?.creditCardPrice?.message}
                   {...register('creditCardPrice', {
+                    valueAsNumber: true,
                     required: {
                       value: toggleActive,
                       message: 'This field is required.',

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateDurationForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateDurationForm.tsx
@@ -118,6 +118,7 @@ export const UpdateDurationForm = ({
             step={1}
             disabled={unlimitedDuration || disabledInput}
             {...register('expirationDuration', {
+              valueAsNumber: true,
               required: !unlimitedDuration,
               min: 0,
             })}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateMaxKeysPerAddress.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateMaxKeysPerAddress.tsx
@@ -108,6 +108,7 @@ export const UpdateMaxKeysPerAddress = ({
               'Please enter a positive numeric value'
             }
             {...register('maxKeysPerAddress', {
+              valueAsNumber: true,
               min: 1,
             })}
           />

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdatePriceForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdatePriceForm.tsx
@@ -173,6 +173,7 @@ export const UpdatePriceForm = ({
                 step="any"
                 disabled={isFree || disabledInput}
                 {...register('keyPrice', {
+                  valueAsNumber: true,
                   required: !isFree,
                   min: 0,
                 })}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateQuantityForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateQuantityForm.tsx
@@ -118,6 +118,7 @@ export const UpdateQuantityForm = ({
               'Please choose a number of memberships for sale for your lock.'
             }
             {...register('maxNumberOfKeys', {
+              valueAsNumber: true,
               min: 0,
               required: !unlimitedQuantity,
             })}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateReferralFee.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateReferralFee.tsx
@@ -97,6 +97,7 @@ export const UpdateReferralFee = ({
         <Input
           type="number"
           {...register('referralFeePercentage', {
+            valueAsNumber: true,
             min: 0,
             max: 100,
           })}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
@@ -113,6 +113,7 @@ export const UpdateTransferFee = ({
             placeholder="10%"
             disabled={disabledInput || !allowTransfer}
             {...register('transferFeePercentage', {
+              valueAsNumber: true,
               min: 0,
               max: 100,
             })}

--- a/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
@@ -224,7 +224,7 @@ export function AirdropForm({
         />
       )}
       <Input
-        pattern="[0-9]+"
+        pattern="\d+"
         label="Number of keys to airdrop"
         {...register('count', {
           valueAsNumber: true,


### PR DESCRIPTION
# Description

Per @searchableguy 's feedback, we should use `valueAsNumber` when applicable.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
