### PR TITLE
adjusting for how prettier locates solidity plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "packageManager": "yarn@3.5.1",
   "lint-staged": {
     "*.{js,ts,tsx}": "yarn run lint --fix",
-    "*.{js,ts,tsx,sol,css,md}": "prettier --write",
+    "*.{js,ts,tsx,sol,css,md}": "prettier --write --plugin=prettier-plugin-solidity",
     "*.sol": "yarn lint:contracts"
   }
 }


### PR DESCRIPTION
recent changes in prettier have altered how default plugins are located; the solidity plugin is passed as a command line param accordingly, though possibly it could also be a config change elsewhere.
