### PR TITLE
fix(locksmith, unlock-app): fixing 500 on revoke

### DIFF
--- a/locksmith/src/controllers/v2/authController.ts
+++ b/locksmith/src/controllers/v2/authController.ts
@@ -116,6 +116,12 @@ export const logout: RequestHandler = async (request, response) => {
 export const revoke: RequestHandler = async (request, response) => {
   try {
     const id = request.user?.session
+    if (!id) {
+      // Missing id... so we can't revoke
+      return response.status(400).send({
+        message: 'Missing id, cannot revoke',
+      })
+    }
     await Session.destroy({
       where: {
         id,

--- a/unlock-app/src/hooks/useSIWE.tsx
+++ b/unlock-app/src/hooks/useSIWE.tsx
@@ -30,8 +30,10 @@ export interface SIWEContextType {
 const signOutToken = async () => {
   const session = getAccessToken()
   if (session) {
-    removeAccessToken()
-    return storage.revoke().catch(console.error)
+    // First, revoke the session on the server with the token
+    await storage.revoke().catch(console.error)
+    // Then remove token locally
+    return removeAccessToken()
   }
 }
 


### PR DESCRIPTION
# Description

I found there was a 500 on revoke. This is happening because we remove(d) token before calling revoke.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
