### PR TITLE
Fix checkout modal: available quantity and overflow

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -128,7 +128,7 @@ const LockOption = ({ disabled, lock }: LockOptionProps) => {
                   )}
                   {formattedData?.formattedKeysAvailable !== 'Unlimited' && (
                     <LabeledItem
-                      label="Tickets available"
+                      label="Available"
                       icon={QuantityIcon}
                       value={
                         formattedData?.isSoldOut

--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -72,7 +72,7 @@ const LockOption = ({ disabled, lock }: LockOptionProps) => {
           <Fragment>
             <div className="flex w-full gap-x-4">
               <div>
-                <Avatar.Root className="inline-flex items-center justify-center w-14 h-14 rounded-xl">
+                <Avatar.Root className="inline-flex items-center justify-center w-14 h-14 rounded-xl overflow-hidden">
                   <Avatar.Image src={lockImageURL} alt={lock.name} />
                   <Avatar.Fallback className="bg-gray-50">
                     {lock.name.slice(0, 2).toUpperCase()}
@@ -128,7 +128,7 @@ const LockOption = ({ disabled, lock }: LockOptionProps) => {
                   )}
                   {formattedData?.formattedKeysAvailable !== 'Unlimited' && (
                     <LabeledItem
-                      label="Quantity"
+                      label="Tickets available"
                       icon={QuantityIcon}
                       value={
                         formattedData?.isSoldOut

--- a/unlock-app/src/components/interface/checkout/main/Select.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Select.tsx
@@ -72,7 +72,7 @@ const LockOption = ({ disabled, lock }: LockOptionProps) => {
           <Fragment>
             <div className="flex w-full gap-x-4">
               <div>
-                <Avatar.Root className="inline-flex items-center justify-center w-14 h-14 rounded-xl overflow-hidden">
+                <Avatar.Root className="inline-flex items-center justify-center w-14 h-14 rounded-xl">
                   <Avatar.Image src={lockImageURL} alt={lock.name} />
                   <Avatar.Fallback className="bg-gray-50">
                     {lock.name.slice(0, 2).toUpperCase()}


### PR DESCRIPTION
Fixing two issues:

- overflow of the ticket image
- misleading label: "quantity" implies it's the quantity that you want to order. But there is no way to change that. So it's misleading and the user may hesitate to press next until they find a way to change the quantity

Before:

<img width="461" alt="Screenshot 2023-08-14 at 2 12 02 PM" src="https://github.com/unlock-protocol/unlock/assets/74358/faac0d1e-9c5b-49e3-af93-35c41d30c58d">

After:
<img width="467" alt="Screenshot 2023-08-14 at 2 11 43 PM" src="https://github.com/unlock-protocol/unlock/assets/74358/aba6ef4a-b752-469a-958b-3ba2f7652d8e">

