### PR TITLE
fix(unlock-app): fixing an issue where the user was prompted to sign twice.

### DIFF
--- a/unlock-app/src/components/interface/checkout/Connect/Confirm.tsx
+++ b/unlock-app/src/components/interface/checkout/Connect/Confirm.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useState } from 'react'
-import { Button, Icon } from '@unlock-protocol/ui'
+import { Button } from '@unlock-protocol/ui'
 import { RiUser3Line as UserIcon } from 'react-icons/ri'
-import { FaEthereum as EthereumIcon } from 'react-icons/fa'
 import { OAuthConfig } from '~/unlockTypes'
 import { PaywallConfigType as PaywallConfig } from '@unlock-protocol/core'
 import { useAuth } from '~/contexts/AuthenticationContext'
@@ -30,13 +29,39 @@ export function ConfirmConnect({
   communication,
 }: Props) {
   const [loading, setLoading] = useState(false)
-  const { siweSign } = useSIWE()
+  const { siweSign, signature, message } = useSIWE()
   const { account, isUnlockAccount } = useAuth()
 
-  const onSignIn = async () => {
-    try {
-      setLoading(true)
+  const onCancel = async () => {
+    onClose({
+      error: 'access-denied',
+      state: oauthConfig.state,
+    })
+  }
 
+  const onSuccess = (signature: string, message: string) => {
+    const code = Buffer.from(
+      JSON.stringify({
+        d: message,
+        s: signature,
+      })
+    ).toString('base64')
+    communication?.emitUserInfo({
+      address: account,
+      message: message,
+      signedMessage: signature,
+    })
+    onClose({
+      code,
+      state: oauthConfig.state,
+    })
+  }
+
+  const onSignIn = async () => {
+    setLoading(true)
+    if (signature && message) {
+      onSuccess(signature, message)
+    } else {
       const result = await siweSign(
         generateNonce(),
         paywallConfig?.messageToSign || '',
@@ -44,32 +69,11 @@ export function ConfirmConnect({
           resources: [new URL('https://' + oauthConfig.clientId).toString()],
         }
       )
-
       if (result) {
-        const { message, signature } = result
-        const code = Buffer.from(
-          JSON.stringify({
-            d: message,
-            s: signature,
-          })
-        ).toString('base64')
-        communication?.emitUserInfo({
-          address: account,
-          message: message,
-          signedMessage: signature,
-        })
-        onClose({
-          code,
-          state: oauthConfig.state,
-        })
-        setLoading(false)
-      } else {
-        setLoading(false)
+        onSuccess(result.signature, result.message)
       }
-    } catch (error: any) {
-      setLoading(false)
-      console.error(error)
     }
+    setLoading(false)
   }
 
   return (
@@ -106,6 +110,7 @@ export function ConfirmConnect({
               <div className="text-brand-gray">
                 Please use your{' '}
                 <a
+                  className="underline"
                   target="_blank"
                   href="https://ethereum.org/en/wallets/"
                   rel="noreferrer noopener"
@@ -120,22 +125,29 @@ export function ConfirmConnect({
         </ol>
       </main>
       <footer className="grid items-center px-6 pt-6 border-t">
-        <Connected injectedProvider={injectedProvider} service={connectService}>
-          <Button
-            onClick={onSignIn}
-            disabled={loading || !account}
-            loading={loading}
-            iconLeft={<Icon icon={EthereumIcon} size="medium" key="ethereum" />}
-            className="w-full"
-          >
-            {isUnlockAccount && 'Continue'}
-            {!isUnlockAccount && (
-              <>
-                {loading && 'Please sign the message'}
-                {!loading && 'Sign-in with Wallet'}
-              </>
-            )}
-          </Button>
+        <Connected
+          skipAccountDetails
+          injectedProvider={injectedProvider}
+          service={connectService}
+        >
+          <div className="flex gap-4">
+            <Button
+              onClick={onSignIn}
+              loading={loading}
+              disabled={loading || !account}
+              className="w-1/2"
+            >
+              Accept
+            </Button>
+            <Button
+              variant="outlined-primary"
+              onClick={onCancel}
+              disabled={!account}
+              className="w-1/2"
+            >
+              Refuse
+            </Button>
+          </div>
         </Connected>
         <PoweredByUnlock />
       </footer>

--- a/unlock-app/src/components/interface/checkout/Connect/connectMachine.typegen.ts
+++ b/unlock-app/src/components/interface/checkout/Connect/connectMachine.typegen.ts
@@ -8,14 +8,16 @@ export interface Typegen0 {
   invokeSrcNameMap: {}
   missingImplementations: {
     actions: never
-    services: never
-    guards: never
     delays: never
+    guards: never
+    services: never
   }
   eventsCausingActions: {}
-  eventsCausingServices: {}
-  eventsCausingGuards: {}
   eventsCausingDelays: {}
+  eventsCausingGuards: {}
+  eventsCausingServices: {
+    unlockAccount: 'UNLOCK_ACCOUNT'
+  }
   matchesStates: 'CONNECT' | 'SIGN_IN'
   tags: never
 }

--- a/unlock-app/src/components/interface/checkout/Connected.tsx
+++ b/unlock-app/src/components/interface/checkout/Connected.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip } from '@unlock-protocol/ui'
+import { Button, Tooltip, Icon } from '@unlock-protocol/ui'
+import { FaEthereum as EthereumIcon } from 'react-icons/fa'
 import { useActor } from '@xstate/react'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { useAuth } from '~/contexts/AuthenticationContext'
@@ -169,12 +170,14 @@ export function SignedOut({
 }
 
 interface ConnectedCheckoutProps {
+  skipAccountDetails?: boolean
   injectedProvider?: unknown
   service: CheckoutService | ConnectService
   children?: ReactNode
 }
 
 export function Connected({
+  skipAccountDetails = false,
   service,
   injectedProvider,
   children,
@@ -236,13 +239,15 @@ export function Connected({
   return account ? (
     <div className="space-y-2">
       {children}
-      <SignedIn
-        isDisconnecting={isDisconnecting}
-        account={account}
-        email={email}
-        isUnlockAccount={!!isUnlockAccount}
-        onDisconnect={state.can('DISCONNECT') ? onDisconnect : undefined}
-      />
+      {!skipAccountDetails && (
+        <SignedIn
+          isDisconnecting={isDisconnecting}
+          account={account}
+          email={email}
+          isUnlockAccount={!!isUnlockAccount}
+          onDisconnect={state.can('DISCONNECT') ? onDisconnect : undefined}
+        />
+      )}
     </div>
   ) : connected ? (
     <div className="grid">
@@ -252,6 +257,7 @@ export function Connected({
           event.preventDefault()
           signIn()
         }}
+        iconLeft={<Icon icon={EthereumIcon} size="medium" key="ethereum" />}
       >
         Sign message to Continue
       </Button>

--- a/unlock-app/src/hooks/useSIWE.tsx
+++ b/unlock-app/src/hooks/useSIWE.tsx
@@ -25,6 +25,8 @@ export interface SIWEContextType {
   signOut: () => Promise<unknown> | unknown
   status?: Status
   isSignedIn: boolean
+  signature?: string
+  message?: string
 }
 
 const signOutToken = async () => {
@@ -44,6 +46,8 @@ const SIWEContext = createContext<SIWEContextType>({
   signIn: () => {
     throw new Error('No SIWE provider found')
   },
+  signature: undefined,
+  message: undefined,
   signOut: signOutToken,
   session: undefined,
   isSignedIn: false,
@@ -54,6 +58,10 @@ interface Props {
 }
 
 export const SIWEProvider = ({ children }: Props) => {
+  const [siweResult, setSiweResult] = useState<{
+    message: string
+    signature: string
+  } | null>(null)
   const { connected, getWalletService, network } = useAuth()
   const { provider } = useContext(ProviderContext)
   const { session, refetchSession } = useSession()
@@ -152,6 +160,7 @@ export const SIWEProvider = ({ children }: Props) => {
       const siweResult = await siweSign(nonce, '')
 
       if (siweResult) {
+        setSiweResult(siweResult)
         const { message, signature } = siweResult
         const response = await storage.login({
           message,
@@ -177,7 +186,16 @@ export const SIWEProvider = ({ children }: Props) => {
   const isSignedIn = !!session
   return (
     <SIWEContext.Provider
-      value={{ session, signIn, siweSign, status, signOut, isSignedIn }}
+      value={{
+        session,
+        signIn,
+        siweSign,
+        status,
+        signOut,
+        isSignedIn,
+        signature: siweResult?.signature,
+        message: siweResult?.message,
+      }}
     >
       {children}
     </SIWEContext.Provider>


### PR DESCRIPTION
# Description

On the oauth flow we asked users to sign twice. We are now re-using the signature and only asking for one if we don't have a recent one.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #https://github.com/unlock-protocol/unlock/issues/12560
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
