### PR TITLE
feature(wedlocks): preview template is now an API that returns the whole email

### DIFF
--- a/wedlocks/src/functions/handler/handler.js
+++ b/wedlocks/src/functions/handler/handler.js
@@ -39,6 +39,7 @@ export const handler = async (event, context, responseCallback) => {
     const body = await preview({
       template: match[1],
       params: event.queryStringParameters,
+      json: !!event.headers.accept.match('application/json'),
     })
     return callback(null, {
       statusCode: 200,

--- a/wedlocks/src/route.js
+++ b/wedlocks/src/route.js
@@ -45,19 +45,8 @@ const getTemplateAndParams = async (args, opts) => {
   return [await wrap(template, opts), templateParams]
 }
 
-// This function loads the template and performs the actual email sending
-// args: {
-//  template: templateName string
-//  failoverTemplate: failoverTemplate string
-//  recipient: email address string
-//  params: params for the template (as a hash). Each param is key: value where value can be either a string, or an object with {sign: <boolean></boolean>, value: <string>}
-//  attachments: array of attachements as data-uri strings (nodemailer will handle them)
-// }
-export const route = async (args) => {
-  // Wrap the template
-  const [template, templateParams] = await getTemplateAndParams(args)
-
-  const email = {
+const buildEmail = async (template, templateParams, args) => {
+  return {
     from: {
       name: args?.emailSender || 'Unlock Labs',
       address: config.sender,
@@ -71,9 +60,21 @@ export const route = async (args) => {
       .concat(args.attachments, template.attachments)
       .filter((x) => !!x),
   }
+}
 
+// This function loads the template and performs the actual email sending
+// args: {
+//  template: templateName string
+//  failoverTemplate: failoverTemplate string
+//  recipient: email address string
+//  params: params for the template (as a hash). Each param is key: value where value can be either a string, or an object with {sign: <boolean></boolean>, value: <string>}
+//  attachments: array of attachements as data-uri strings (nodemailer will handle them)
+// }
+export const route = async (args) => {
+  // Wrap the template
+  const [template, templateParams] = await getTemplateAndParams(args)
   const transporter = nodemailer.createTransport(config)
-  return transporter.sendMail(email)
+  return transporter.sendMail(await buildEmail(template, templateParams, args))
 }
 
 /**
@@ -94,8 +95,10 @@ export const preview = async (args) => {
       templateParams[key] = param
     }
   })
-
-  return template.html(templateParams)
+  if (!args.json) {
+    return template.html(templateParams)
+  }
+  return JSON.stringify(await buildEmail(template, templateParams, args))
 }
 
 export default {


### PR DESCRIPTION
# Description

This minor change introduces the ability to get the "full" email (including subject) rather than just its body.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
