### PR TITLE
✨ Set Custom Referrer Fees

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -48,7 +48,9 @@
     "christopherdro",
     "patrickworkman",
     "PJijin",
-    "adeelhasan"
+    "adeelhasan",
+    "kosmoskey",
+    "easyrun42"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the the file `.clabot`.\nThank you! "
 }

--- a/.clabot
+++ b/.clabot
@@ -49,7 +49,7 @@
     "patrickworkman",
     "PJijin",
     "adeelhasan",
-    "kosmoskey",
+    "KosmosKey",
     "easyrun42"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the the file `.clabot`.\nThank you! "

--- a/packages/unlock-js/src/web3Service.ts
+++ b/packages/unlock-js/src/web3Service.ts
@@ -905,18 +905,35 @@ export default class Web3Service extends UnlockService {
   async referrerFees({
     lockAddress,
     network,
-    address,
   }: {
     lockAddress: string
     network: number
-    address: string
   }) {
-    const lockContract = await this.getLockContract(
-      lockAddress,
-      this.providerForNetwork(network)
+    const query = `{
+      lock(id:"${lockAddress}") {
+        referrerFees {
+          id
+          referrer
+          fee
+        }
+      }
+    }`
+
+    const result = await fetch(
+      'https://api.thegraph.com/subgraphs/name/easyrun2023/unlock-goerli',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ query }),
+      }
     )
-    const referrerFees = await lockContract.referrerFees(address)
-    return ethers.BigNumber.from(referrerFees).toNumber()
+      .then((r) => r.json())
+      .then((res) => res?.data?.lock?.referrerFees || [])
+
+    return result
   }
 
   async getBaseTokenURI({

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -33,6 +33,8 @@ type Lock @entity {
   deployer: Bytes!
   "Total number of receipts of lock"
   numberOfReceipts: BigInt!
+  "Referrers fees set per custom address"
+  referrerFees: [ReferrerFee!]! @derivedFrom(field: "lock")
 }
 
 type Key @entity {
@@ -116,4 +118,15 @@ type Receipt @entity {
   gasTotal: BigInt!
   "Increasing number of receipt"
   receiptNumber: BigInt!
+}
+
+type ReferrerFee @entity {
+  "Transaction Hash"
+  id: ID!
+  "Address of the referrer."
+  referrer: Bytes!
+  "Fee attributed to the referrer. E.g., 200 represents 20%."
+  fee: BigInt!
+  "In the Unlock ecosystem, a “Lock” is a smart contract that creates (or “mints”) NFTs"
+  lock: Lock!
 }

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -14,10 +14,17 @@ import {
   Transfer as TransferEvent,
   LockMetadata as LockMetadataEvent,
   LockConfig as LockConfigEvent,
+  ReferrerFee as ReferrerFeeEvent,
 } from '../generated/templates/PublicLock/PublicLock'
 
 import { PublicLockV11 as PublicLock } from '../generated/templates/PublicLock/PublicLockV11'
-import { Key, Lock, UnlockStats, LockStats } from '../generated/schema'
+import {
+  Key,
+  Lock,
+  UnlockStats,
+  LockStats,
+  ReferrerFee,
+} from '../generated/schema'
 
 import {
   genKeyID,
@@ -397,5 +404,18 @@ export function handleLockMetadata(event: LockMetadataEvent): void {
 
     // lock.symbol = event.params.symbol
     lock.save()
+  }
+}
+
+export function handleReferrerFees(event: ReferrerFeeEvent): void {
+  const lock = Lock.load(event.address.toHexString())
+
+  if (lock) {
+    const hash = event.transaction.hash.toHexString()
+    const referrerFee = new ReferrerFee(hash)
+    referrerFee.referrer = event.params.referrer
+    referrerFee.fee = event.params.fee
+    referrerFee.lock = lock.id
+    referrerFee.save()
   }
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -55,6 +55,7 @@ templates:
         - LockManagerRemoved
         - PricingChanged
         - Transfer
+        - ReferrerFee
       abis:
         - name: PublicLock
           file: ./abis/PublicLock.json
@@ -108,6 +109,9 @@ templates:
           receipt: true
         - event: LockMetadata(string,string,string)
           handler: handleLockMetadata
+          receipt: true
+        - event: ReferrerFee(indexed address,uint256)
+          handler: handleReferrerFees
           receipt: true
       file: ./src/public-lock.ts
     network: base

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -18,6 +18,7 @@ import {
 import { lockAddress, lockAddressV8 } from './constants'
 import { LOCK_MANAGER } from '../src/helpers'
 import { PricingChanged } from '../generated/templates/PublicLock/PublicLock'
+import { ReferrerFee } from '../generated/templates/PublicLock/PublicLock'
 
 export function mockDataSourceV8(): void {
   const v8context = new DataSourceContext()

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -15,6 +15,7 @@ import {
   handleLockManagerRemoved,
   handlePricingChanged,
   handleLockMetadata,
+  handleReferrerFees,
 } from '../src/public-lock'
 
 import {
@@ -43,6 +44,7 @@ import {
   maxNumberOfKeys,
   maxKeysPerAddress,
   lockAddressV8,
+  defaultMockAddress,
 } from './constants'
 
 // mock contract functions

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingMisc.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingMisc.tsx
@@ -52,7 +52,7 @@ export const SettingMisc = ({
     <div className="grid grid-cols-1 gap-6">
       <SettingCard
         label="Referral fee"
-        description="Set up a percentage of the membership price to be sent to the referrer. This is great use cases to reward your members to promote your membership."
+        description="Set custom referral percentage for each address. Easily decide how much each promoter earns from your membership."
         isLoading={isLoading}
       >
         <UpdateReferralFee

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateReferralFee.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateReferralFee.tsx
@@ -1,9 +1,10 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { Button, Input, ToggleSwitch } from '@unlock-protocol/ui'
+import { Button, Input, ToggleSwitch, Card } from '@unlock-protocol/ui'
 import { ethers } from 'ethers'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { ToastHelper } from '~/components/helpers/toast.helper'
+import LoadingIcon from '~/components/interface/Loading'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { useWeb3Service } from '~/utils/withWeb3Service'
 
@@ -16,9 +17,14 @@ interface UpdateReferralFeeProps {
 
 interface FormProps {
   referralFeePercentage: number
+  referralAddress: string
 }
 
-const ZERO = ethers.constants.AddressZero
+interface ReferrerFee {
+  id: string
+  referrer: string
+  fee: string
+}
 
 export const UpdateReferralFee = ({
   lockAddress,
@@ -26,57 +32,64 @@ export const UpdateReferralFee = ({
   isManager,
   disabled,
 }: UpdateReferralFeeProps) => {
-  const [referralFee, setReferralFee] = useState(false)
+  const [isReferralFeeEnabled, setIsReferralFeeEnabled] = useState(false)
+  const [isReferralAddressEnabled, setIsReferralAddressEnabled] =
+    useState(false)
   const web3Service = useWeb3Service()
   const { getWalletService } = useAuth()
 
   const {
     register,
     handleSubmit,
-    setValue,
+    reset,
     formState: { errors },
-  } = useForm<FormProps>()
+  } = useForm<FormProps>({
+    defaultValues: { referralFeePercentage: 0, referralAddress: '' },
+  })
 
   const setReferrerFee = async (fields: FormProps) => {
     const walletService = await getWalletService(network)
     await walletService.setReferrerFee({
       lockAddress,
-      address: ZERO,
+      address: fields?.referralAddress,
       feeBasisPoint: fields?.referralFeePercentage * 100,
     })
   }
 
-  const getReferrerFees = async () => {
-    return await web3Service.referrerFees({
+  const getReferrerFees = async (): Promise<ReferrerFee[]> => {
+    return web3Service.referrerFees({
       lockAddress,
       network,
-      address: ZERO,
     })
   }
 
   const setReferrerFeeMutation = useMutation(setReferrerFee)
 
   const onSubmit = async (fields: FormProps) => {
-    const setReferrerFeePromise = setReferrerFeeMutation.mutateAsync(fields)
+    const setReferrerFeePromise = setReferrerFeeMutation.mutateAsync({
+      ...fields,
+      referralAddress: ethers.utils.getAddress(
+        fields.referralAddress.toLowerCase()
+      ),
+    })
 
     await ToastHelper.promise(setReferrerFeePromise, {
-      loading: 'Updating referrer fee',
+      loading: 'Setting new referrer',
       error: 'Failed to update the values, please try again.',
-      success: 'Referrer fee updated.',
+      success: 'New referrer set',
     })
+
+    reset()
   }
 
-  const { isLoading, data: referralFeePercentage } = useQuery(
+  const { isLoading, data: referralFeesData } = useQuery(
     ['getReferrerFees', lockAddress, network, setReferrerFeeMutation.isSuccess],
     async () => getReferrerFees()
   )
 
-  useEffect(() => {
-    setValue('referralFeePercentage', (referralFeePercentage ?? 0) / 100)
-    setReferralFee((referralFeePercentage ?? 0) > 0)
-  }, [referralFeePercentage])
+  const referralFees = referralFeesData || []
 
-  const disabledInput =
+  const isDisabledReferrerInput =
     disabled || setReferrerFeeMutation.isLoading || isLoading
 
   return (
@@ -84,14 +97,10 @@ export const UpdateReferralFee = ({
       <div className="grid gap-2">
         <ToggleSwitch
           title="Referrer fee %"
-          enabled={referralFee}
-          disabled={disabledInput}
-          setEnabled={(enabled) => {
-            setReferralFee(enabled)
-            setValue(
-              'referralFeePercentage',
-              enabled ? (referralFeePercentage ?? 0) / 100 : 0
-            )
+          enabled={isReferralFeeEnabled}
+          disabled={isDisabledReferrerInput}
+          setEnabled={(enabled: boolean) => {
+            setIsReferralFeeEnabled(enabled)
           }}
         />
         <Input
@@ -105,19 +114,78 @@ export const UpdateReferralFee = ({
             errors?.referralFeePercentage &&
             'This field accept percentage value between 0 and 100.'
           }
-          disabled={disabledInput || !referralFee}
+          disabled={isDisabledReferrerInput || !isReferralFeeEnabled}
         />
       </div>
+
+      <div className="grid gap-2">
+        <ToggleSwitch
+          title="Referrer address"
+          enabled={isReferralAddressEnabled}
+          disabled={isDisabledReferrerInput}
+          setEnabled={(enabled: boolean) => {
+            setIsReferralAddressEnabled(enabled)
+          }}
+        />
+        <Input
+          type="text"
+          {...register('referralAddress', {
+            validate: (value) =>
+              ethers.utils.isAddress(value.toLowerCase()) || 'Invalid address',
+            required: {
+              value: true,
+              message: 'This field is required.',
+            },
+          })}
+          error={errors?.referralAddress?.message}
+          disabled={isDisabledReferrerInput || !isReferralAddressEnabled}
+        />
+      </div>
+
       {isManager && (
         <Button
           className="w-full md:w-1/3"
           type="submit"
-          disabled={disabledInput}
+          disabled={isDisabledReferrerInput}
           loading={setReferrerFeeMutation.isLoading}
         >
           Apply
         </Button>
       )}
+
+      <div className="flex flex-col mt-5 items-start">
+        <Card.Title>Referrers ({referralFees.length})</Card.Title>
+
+        {isLoading ? (
+          <div className="w-full flex items-center justify-center">
+            <LoadingIcon />
+          </div>
+        ) : referralFees.length ? (
+          <div className="w-full grid gap-5 grid-cols-1 mt-3">
+            {referralFees.map(({ id, referrer, fee }) => {
+              const feeNumber = Number(fee)
+
+              return (
+                <div
+                  key={id}
+                  className="w-full overflow-x-auto flex justify-between items-center border border-gray-300 p-3 rounded-xl"
+                >
+                  <h2 className="text-md font-medium break-words">
+                    {referrer}
+                  </h2>
+                  <h2 className="text-md pl-3 font-medium break-words">
+                    ({feeNumber / 100}%)
+                  </h2>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <h2 className="text-1xl mt-3 w-full text-center">
+            You haven&apos;t added any referrers yet
+          </h2>
+        )}
+      </div>
     </form>
   )
 }


### PR DESCRIPTION
### Description

Update! For your "lock", set fees like 20% for "vitalik.eth" or 50% for "david.eth". Just head to lock -> advanced -> referral fee. Adjust and see all referrers there. Easy!


Issue: [Show and set custom referrer fees](https://github.com/unlock-protocol/unlock/issues/12557)


### Demo (Unlock-app & Subgraph)
Quick demo showing how it works for both existing "locks" and for creating a brand new "lock".

### Existing Lock

https://github.com/unlock-protocol/unlock/assets/136458308/4c352fb9-64d6-43a3-9280-96a919270d9b

### Brand New Lock

https://github.com/unlock-protocol/unlock/assets/136458308/d2d1efb6-e4c4-4d01-9a50-5099747ecf64

### Subgraph (Goerli & Optimism)

Optimism: https://thegraph.com/hosted-service/subgraph/easyrun2023/unlock-optimism-mainnet

Goerli: https://thegraph.com/hosted-service/subgraph/easyrun2023/unlock-goerli

https://github.com/unlock-protocol/unlock/assets/136458308/0e85ca44-2c52-4b8c-a3a7-f62850af500c


