### PR TITLE
cleanup(unlock-app): remove extra saving of metadata in the confirmation steps

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCard.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCard.tsx
@@ -13,7 +13,6 @@ import { Lock } from '~/unlockTypes'
 import { RiErrorWarningFill as ErrorIcon } from 'react-icons/ri'
 import { ViewContract } from '../../ViewContract'
 import { usePurchase } from '~/hooks/usePurchase'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import { usePricing } from '~/hooks/usePricing'
 import { usePurchaseData } from '~/hooks/usePurchaseData'
 import { useCapturePayment } from '~/hooks/useCapturePayment'
@@ -133,7 +132,7 @@ export function ConfirmCard({
   const [state] = useActor(checkoutService)
   const config = useConfig()
   const [isConfirming, setIsConfirming] = useState(false)
-  const { lock, recipients, payment, paywallConfig, metadata, data, renew } =
+  const { lock, recipients, payment, paywallConfig, data, renew } =
     state.context
 
   const { address: lockAddress, network: lockNetwork } = lock!
@@ -155,8 +154,6 @@ export function ConfirmCard({
     lockAddress,
     network: lockNetwork,
   })
-
-  const { mutateAsync: updateUsersMetadata } = useUpdateUsersMetadata()
 
   const { isInitialLoading: isInitialDataLoading, data: purchaseData } =
     usePurchaseData({
@@ -377,9 +374,6 @@ export function ConfirmCard({
               disabled={isConfirming || isLoading || isError}
               onClick={async (event) => {
                 event.preventDefault()
-                if (metadata) {
-                  await updateUsersMetadata(metadata)
-                }
                 onConfirmCard()
               }}
             >

--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmClaim.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmClaim.tsx
@@ -11,7 +11,6 @@ import { Lock } from '~/unlockTypes'
 import { RiErrorWarningFill as ErrorIcon } from 'react-icons/ri'
 import { ViewContract } from '../../ViewContract'
 import { useClaim } from '~/hooks/useClaim'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import { usePricing } from '~/hooks/usePricing'
 import { usePurchaseData } from '~/hooks/usePurchaseData'
 import { useConfig } from '~/utils/withConfig'
@@ -35,8 +34,7 @@ export function ConfirmClaim({
 
   const recaptchaRef = useRef<any>()
   const [isConfirming, setIsConfirming] = useState(false)
-  const { lock, recipients, payment, paywallConfig, metadata, data } =
-    state.context
+  const { lock, recipients, payment, paywallConfig, data } = state.context
 
   const { address: lockAddress, network: lockNetwork } = lock!
 
@@ -46,8 +44,6 @@ export function ConfirmClaim({
     lockAddress,
     network: lockNetwork,
   })
-
-  const { mutateAsync: updateUsersMetadata } = useUpdateUsersMetadata()
 
   const { isInitialLoading: isInitialDataLoading, data: purchaseData } =
     usePurchaseData({
@@ -163,9 +159,6 @@ export function ConfirmClaim({
               disabled={isConfirming || isLoading || isPricingDataError}
               onClick={async (event) => {
                 event.preventDefault()
-                if (metadata) {
-                  await updateUsersMetadata(metadata)
-                }
                 onConfirmClaim()
               }}
             >

--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCrypto.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCrypto.tsx
@@ -16,7 +16,6 @@ import { Lock } from '~/unlockTypes'
 import ReCaptcha from 'react-google-recaptcha'
 import { RiErrorWarningFill as ErrorIcon } from 'react-icons/ri'
 import { ViewContract } from '../../ViewContract'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import { usePricing } from '~/hooks/usePricing'
 import { usePurchaseData } from '~/hooks/usePurchaseData'
 import { formatNumber } from '~/utils/formatter'
@@ -42,16 +41,8 @@ export function ConfirmCrypto({
   const web3Service = useWeb3Service()
   const recaptchaRef = useRef<any>()
   const [isConfirming, setIsConfirming] = useState(false)
-  const {
-    lock,
-    recipients,
-    payment,
-    paywallConfig,
-    keyManagers,
-    metadata,
-    data,
-    renew,
-  } = state.context
+  const { lock, recipients, payment, paywallConfig, keyManagers, data, renew } =
+    state.context
 
   const { address: lockAddress, network: lockNetwork, keyPrice } = lock!
 
@@ -80,8 +71,6 @@ export function ConfirmCrypto({
     lockAddress,
     network: lockNetwork,
   })
-
-  const { mutateAsync: updateUsersMetadata } = useUpdateUsersMetadata()
 
   const { isInitialLoading: isInitialDataLoading, data: purchaseData } =
     usePurchaseData({
@@ -308,9 +297,6 @@ export function ConfirmCrypto({
               }
               onClick={async (event) => {
                 event.preventDefault()
-                if (metadata) {
-                  await updateUsersMetadata(metadata)
-                }
                 onConfirmCrypto()
               }}
             >

--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmSwapAndPurchase.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmSwapAndPurchase.tsx
@@ -14,7 +14,6 @@ import { Lock } from '~/unlockTypes'
 import ReCaptcha from 'react-google-recaptcha'
 import { RiErrorWarningFill as ErrorIcon } from 'react-icons/ri'
 import { ViewContract } from '../../ViewContract'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import { usePricing } from '~/hooks/usePricing'
 import { usePurchaseData } from '~/hooks/usePurchaseData'
 import { ethers } from 'ethers'
@@ -38,16 +37,8 @@ export function ConfirmSwapAndPurchase({
   const config = useConfig()
   const recaptchaRef = useRef<any>()
   const [isConfirming, setIsConfirming] = useState(false)
-  const {
-    lock,
-    recipients,
-    payment,
-    paywallConfig,
-    keyManagers,
-    metadata,
-    data,
-    renew,
-  } = state.context
+  const { lock, recipients, payment, paywallConfig, keyManagers, data, renew } =
+    state.context
 
   const { address: lockAddress, network: lockNetwork, keyPrice } = lock!
 
@@ -74,8 +65,6 @@ export function ConfirmSwapAndPurchase({
   const recurringPayments: number[] | undefined = recurringPaymentAmount
     ? new Array(recipients.length).fill(recurringPaymentAmount)
     : undefined
-
-  const { mutateAsync: updateUsersMetadata } = useUpdateUsersMetadata()
 
   const { isInitialLoading: isInitialDataLoading, data: purchaseData } =
     usePurchaseData({
@@ -276,9 +265,6 @@ export function ConfirmSwapAndPurchase({
               disabled={isConfirming || isLoading || isPricingDataError}
               onClick={async (event) => {
                 event.preventDefault()
-                if (metadata) {
-                  await updateUsersMetadata(metadata)
-                }
                 onConfirmCrypto()
               }}
             >


### PR DESCRIPTION
# Description


I checked and we are indeed saving the metadata in the `Metadata` screen, so this was duplicated.
Copying @searchableguy who may have a bit more knowledge about _why_ we were also doing it in the confirmation steps.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
