### PR TITLE
fix(unlock-app): fixing automatically add recipients from paywall config

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -318,9 +318,7 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
       const fieldsRequired = quantity - fields.length
       Array.from({ length: fieldsRequired }).map((_, index) => {
         const addAccountAddress = !index && !isMember
-        const recipients = addAccountAddress
-          ? { recipient: recipient }
-          : { recipient: '' }
+        const recipients = addAccountAddress ? { recipient } : { recipient: '' }
         append(recipients, {
           shouldFocus: false,
         })
@@ -443,12 +441,12 @@ const recipientFromConfig = (
   lock: Lock | LockState | undefined
 ): string => {
   const paywallRecipient = paywall.recipient
-  const lockReceip = paywall?.locks[lock!.address].recipient
+  const lockRecipient = paywall?.locks[lock!.address].recipient
 
   if (paywallRecipient != undefined && paywallRecipient != '') {
     return paywallRecipient
-  } else if (lockReceip != undefined && lockReceip != '') {
-    return lockReceip
+  } else if (lockRecipient != undefined && lockRecipient != '') {
+    return lockRecipient
   }
   return ''
 }

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -112,8 +112,6 @@ export const MetadataInputs = ({
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account
 
-  console.log(typeof recipient, hideRecipientAddress)
-
   return (
     <div className="grid gap-2">
       {hideRecipientAddress ? (
@@ -299,7 +297,6 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
   })
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account || ''
-  console.log(recipient, 'recipient')
 
   const { isInitialLoading: isMemberLoading, data: isMember } = useQuery(
     ['isMember', recipient, lock],
@@ -397,7 +394,6 @@ export function Metadata({ checkoutService, injectedProvider }: Props) {
           <form id="metadata" onSubmit={handleSubmit(onSubmit)}>
             {fields.map((item, index) => {
               const hideRecipient = !index && !isMember
-              console.log(!index, !isMember)
               return (
                 <div
                   key={item.id}


### PR DESCRIPTION
# Description

Takes the recipient address from the checkout config automatically instead to added manually with the change button(if not applicable)

# Checklist:

- [*] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [*] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet
![Screenshot_2](https://github.com/unlock-protocol/unlock/assets/34518489/74f9365d-94bc-48e2-bd1c-d206f5174dd3)
![Screenshot_4](https://github.com/unlock-protocol/unlock/assets/34518489/6c8ae41d-b275-4a27-87fe-2dac22b27678)



