### PR TITLE
fix(verifier): fixing verification when the owner has changed for airdropped keys.

### DIFF
--- a/locksmith/src/controllers/v2/ticketsController.tsx
+++ b/locksmith/src/controllers/v2/ticketsController.tsx
@@ -283,6 +283,7 @@ export const getTicket: RequestHandler = async (request, response) => {
     keyId: key.tokenId,
     lockAddress: key.lock.address,
     owner: key.owner,
+    manager: key.manager,
     publicLockVersion: key.lock.version,
   }
 

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1728,6 +1728,7 @@ paths:
                   - name
                   - lockAddress
                   - keyId
+                  - manager
                   - publicLockVersion
                   - userMetadata
                   - isVerifier
@@ -1744,6 +1745,8 @@ paths:
                   name:
                     type: string
                   owner:
+                    type: string
+                  manager:
                     type: string
                   lockAddress:
                     type: string

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -157,7 +157,10 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
     )
   )
 
+  console.log(ticket)
   const invalid = invalidMembership({
+    network,
+    manager: ticket!.manager,
     keyId: ticket!.keyId,
     owner: ticket!.owner,
     expiration:

--- a/unlock-app/src/components/interface/VerificationStatus.tsx
+++ b/unlock-app/src/components/interface/VerificationStatus.tsx
@@ -157,7 +157,6 @@ export const VerificationStatus = ({ config, onVerified, onClose }: Props) => {
     )
   )
 
-  console.log(ticket)
   const invalid = invalidMembership({
     network,
     manager: ticket!.manager,

--- a/unlock-app/src/components/interface/verification/MembershipCard.tsx
+++ b/unlock-app/src/components/interface/verification/MembershipCard.tsx
@@ -5,7 +5,6 @@ import {
 } from '@radix-ui/react-avatar'
 import dayjs from 'dayjs'
 import relativeTimePlugin from 'dayjs/plugin/relativeTime'
-import { addressMinify } from '~/utils/strings'
 import { useConfig } from '~/utils/withConfig'
 import {
   RiCloseCircleFill as InvalidIcon,
@@ -14,6 +13,7 @@ import {
 import { ReactNode } from 'react'
 import { RiCloseLine as CloseIcon } from 'react-icons/ri'
 import { Button, Placeholder } from '@unlock-protocol/ui'
+import { AddressLink } from '../AddressLink'
 
 dayjs.extend(relativeTimePlugin)
 
@@ -114,10 +114,15 @@ export function MembershipCard({
           </div>
         </div>
         <div className="space-y-2">
-          <Item label="Lock Address" value={addressMinify(lockAddress)} />
+          <Item label="Lock">
+            <AddressLink lockAddress={lockAddress} network={network} />
+          </Item>
           <Item label="Network" value={config.networks[network].name} />
           <Item label="Time since signed" value={timeSinceSigned} />
-          <Item label="Owner" value={addressMinify(owner)} />
+          <Item label="Owner">
+            <AddressLink lockAddress={owner} network={network} />
+          </Item>
+
           {!!userMetadata?.public && (
             <MetadataItems metadata={userMetadata.public} />
           )}
@@ -133,14 +138,16 @@ export function MembershipCard({
 
 interface ItemProps {
   label: string
-  value: string
+  value?: string
+  children?: ReactNode
 }
 
-export function Item({ label, value }: ItemProps) {
+export function Item({ label, value, children }: ItemProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-gray-500"> {label}: </span>
-      <span className="font-medium">{value}</span>
+      {value && <span className="font-medium">{value}</span>}
+      {children}
     </div>
   )
 }

--- a/unlock-app/src/components/interface/verification/invalidMembership.ts
+++ b/unlock-app/src/components/interface/verification/invalidMembership.ts
@@ -1,8 +1,11 @@
 import * as z from 'zod'
+import { config } from '~/config/app'
 import { MembershipVerificationData } from '~/utils/verification'
 
 interface Options {
+  network: number
   owner: string
+  manager: string
   keyId: string
   expiration: number
   isSignatureValid: boolean
@@ -10,18 +13,33 @@ interface Options {
 }
 
 export function invalidMembership({
+  network,
+  owner,
+  manager,
   keyId,
   expiration,
   isSignatureValid,
   verificationData,
 }: Options) {
-  const { tokenId } = verificationData
+  const { account, tokenId } = verificationData
+
+  const networkConfig = config.networks[network]
+
   if (!isSignatureValid) {
     return 'Signature does not match'
   }
 
   if (tokenId && keyId !== tokenId.toString()) {
     return 'This key does not match the user'
+  }
+
+  // When the key manager is our key manager contract, the owner can be different as the key
+  // may have been transfered!
+  if (
+    manager.toLowerCase() != networkConfig.keyManagerAddress.toLowerCase() &&
+    owner.toLowerCase().trim() !== account.toLowerCase().trim()
+  ) {
+    return 'The current owner of this key does not match the QR code'
   }
 
   if (expiration != -1 && expiration < new Date().getTime() / 1000) {

--- a/unlock-app/src/components/interface/verification/invalidMembership.ts
+++ b/unlock-app/src/components/interface/verification/invalidMembership.ts
@@ -10,23 +10,18 @@ interface Options {
 }
 
 export function invalidMembership({
-  owner,
   keyId,
   expiration,
   isSignatureValid,
   verificationData,
 }: Options) {
-  const { account, tokenId } = verificationData
+  const { tokenId } = verificationData
   if (!isSignatureValid) {
     return 'Signature does not match'
   }
 
   if (tokenId && keyId !== tokenId.toString()) {
     return 'This key does not match the user'
-  }
-
-  if (owner.toLowerCase().trim() !== account.toLowerCase().trim()) {
-    return 'The owner of this key does not match the QR code'
   }
 
   if (expiration != -1 && expiration < new Date().getTime() / 1000) {

--- a/unlock-app/src/components/interface/verification/invalidMembership.ts
+++ b/unlock-app/src/components/interface/verification/invalidMembership.ts
@@ -36,7 +36,8 @@ export function invalidMembership({
   // When the key manager is our key manager contract, the owner can be different as the key
   // may have been transfered!
   if (
-    manager.toLowerCase() != networkConfig.keyManagerAddress.toLowerCase() &&
+    networkConfig.keyManagerAddress &&
+    manager.toLowerCase() !== networkConfig.keyManagerAddress.toLowerCase() &&
     owner.toLowerCase().trim() !== account.toLowerCase().trim()
   ) {
     return 'The current owner of this key does not match the QR code'

--- a/unlock-app/src/config/app.ts
+++ b/unlock-app/src/config/app.ts
@@ -55,7 +55,10 @@ export const config = {
   walletConnectApiKey: '1535029cc7500ace23802e2e990c58d7', // https://cloud.walletconnect.com/app/project?uuid=7920be27-1e19-43a8-8f7d-cafbb00d4b80
   googleMapsApiKey: 'AIzaSyDp0Y4yQn6WtYEFEgRZg52EiDSgLwxzVMA',
   httpProvider: process.env.NEXT_PUBLIC_HTTP_PROVIDER || 'localhost',
-  locksmithSigners: ['0x58b5CeDE554a39666091F96C8058920dF5906581'], // TODO: cleanup? We use config from networks package!
+  locksmithSigners: [
+    '0x58b5CeDE554a39666091F96C8058920dF5906581',
+    '0x22c095c69c38b66afAad4eFd4280D94Ec9D12f4C',
+  ], // TODO: cleanup? We should use config from networks package!
   networks: Object.keys(networksConfig).reduce<NetworkConfigs>(
     (networks, network) => {
       networks[network] = {


### PR DESCRIPTION
# Description

Airdropped keys can change owner (will like do in fact) so we check that if the manager is correct we allow for transfers.
A better solution would be to regenerate a QR code when a key is transferred and send it to the user!


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
