### PR TITLE
feat(unlock-app): not showing currency amount when chosing a payment method

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -32,17 +32,13 @@ interface Props {
   checkoutService: CheckoutService
 }
 
-interface AmountBadgeProps {
+interface CurrencyBadgeProps {
   symbol: string
-  amount: string
 }
 
-const AmountBadge = ({ symbol, amount }: AmountBadgeProps) => {
+const CurrencyBadge = ({ symbol }: CurrencyBadgeProps) => {
   return (
     <div className="flex items-center gap-x-1 px-2 py-0.5 rounded border font-medium text-sm">
-      {Number(amount) <= 0
-        ? 'FREE'
-        : `${formatNumber(Number(amount))} ${symbol.toUpperCase()}`}
       <CryptoIcon size={16} symbol={symbol} />
     </div>
   )
@@ -177,7 +173,7 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
               >
                 <div className="flex justify-between w-full">
                   <h3 className="font-bold"> Pay with {symbol} </h3>
-                  <AmountBadge amount={price.toString()} symbol={symbol} />
+                  <CurrencyBadge symbol={symbol} />
                 </div>
                 <div className="flex items-center justify-between w-full">
                   <div className="flex items-center w-full text-sm text-left text-gray-500">
@@ -361,8 +357,7 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
                       <h3 className="font-bold">
                         Pay with {route!.trade.inputAmount.currency.symbol}
                       </h3>
-                      <AmountBadge
-                        amount={route!.quote.toFixed()}
+                      <CurrencyBadge
                         symbol={route!.trade.inputAmount.currency.symbol ?? ''}
                       />
                     </div>

--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -124,8 +124,7 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
   const { data: routes, isInitialLoading: isUniswapRoutesLoading } =
     useUniswapRoutes({
       routes: uniswapRoutes!,
-      enabled:
-        isSwapAndPurchaseEnabled && !enableClaim && recipients.length === 1, // Disabled swap and purchase for multiple recipients
+      enabled: isSwapAndPurchaseEnabled && !enableClaim,
     })
 
   // Universal card is enabled if credit card is not enabled by the lock manager and the lock is USDC


### PR DESCRIPTION
# Description

Showing the amount was creating multiple challenges:
* inconsistencies: we show the amount for crypto payments but not for credit cards
* innacurracies: the amount shown was not using the amount actually paid by the user

We now just let the user select their payment method and the totals are shown on the next screen!

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
