### PR TITLE
fix(unlock-app): setting the fee at 100 when transfers are disabled

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateTransferFee.tsx
@@ -48,7 +48,7 @@ export const UpdateTransferFee = ({
   const onSubmit = async (fields: FormProps) => {
     if (isValid) {
       const updateTransferFeePromise = updateTransferFeeMutation.mutateAsync(
-        fields?.transferFeePercentage
+        allowTransfer ? fields?.transferFeePercentage : 100
       )
 
       await ToastHelper.promise(updateTransferFeePromise, {


### PR DESCRIPTION
# Description

We had a bug where the toggle was not taken into account.

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
