### PR TITLE
feature(unlock-app, locksmith): using the countries enabled currencies

### DIFF
--- a/locksmith/src/controllers/lockController.ts
+++ b/locksmith/src/controllers/lockController.ts
@@ -43,14 +43,17 @@ export const connectStripe = async (req: Request, res: Response) => {
 
 export const stripeConnected = async (req: Request, res: Response) => {
   try {
-    const { stripeEnabled, stripeAccount: account } =
-      await stripeOperations.getStripeConnectForLock(
-        Normalizer.ethereumAddress(req.params.lockAddress),
-        req.chain
-      )
+    const {
+      stripeEnabled,
+      stripeAccount: account,
+      countrySpec,
+    } = await stripeOperations.getStripeConnectForLock(
+      Normalizer.ethereumAddress(req.params.lockAddress),
+      req.chain
+    )
 
     if (stripeEnabled) {
-      return res.json({ connected: 1, account })
+      return res.json({ connected: 1, account, countrySpec })
     }
 
     return res.json({

--- a/locksmith/src/controllers/v2/purchaseController.ts
+++ b/locksmith/src/controllers/v2/purchaseController.ts
@@ -98,14 +98,18 @@ export const createPaymentIntent: RequestHandler = async (
     throw new Error('Lock is sold out.')
   }
 
-  const { stripeEnabled, stripeAccount: stripeConnectApiKey = '' } =
-    await getStripeConnectForLock(lockAddress, network)
+  const { stripeEnabled, stripeAccount } = await getStripeConnectForLock(
+    lockAddress,
+    network
+  )
 
-  if (!stripeEnabled) {
+  if (!stripeEnabled || !stripeAccount) {
     return response
       .status(400)
       .send({ message: 'Missing Stripe Connect integration' })
   }
+
+  const stripeConnectApiKey = stripeAccount.id
 
   let stripeCustomerId = await getStripeCustomerIdForAddress(userAddress)
 

--- a/locksmith/src/operations/stripeOperations.ts
+++ b/locksmith/src/operations/stripeOperations.ts
@@ -248,7 +248,11 @@ export const getStripeConnectLockDetails = async (
 export const getStripeConnectForLock = async (
   lock: string,
   chain: number
-): Promise<{ stripeAccount?: string; stripeEnabled: boolean }> => {
+): Promise<{
+  countrySpec?: Stripe.CountrySpec
+  stripeAccount?: Stripe.Account | null
+  stripeEnabled: boolean
+}> => {
   const stripeConnectLockDetails = await getStripeConnectLockDetails(
     lock,
     chain
@@ -262,9 +266,15 @@ export const getStripeConnectForLock = async (
 
   const account = await stripeConnection(stripeConnectLockDetails.stripeAccount)
 
+  let countrySpec
+  if (account?.country) {
+    countrySpec = await stripe.countrySpecs.retrieve(account?.country)
+  }
+
   return {
     stripeEnabled: !!account?.charges_enabled,
-    stripeAccount: stripeConnectLockDetails.stripeAccount,
+    stripeAccount: account,
+    countrySpec,
   }
 }
 

--- a/locksmith/src/worker/helpers/renewFiatKey.ts
+++ b/locksmith/src/worker/helpers/renewFiatKey.ts
@@ -36,7 +36,7 @@ export async function renewFiatKey({
       lockAddress,
     }
 
-    const { stripeEnabled, stripeAccount = '' } = await getStripeConnectForLock(
+    const { stripeEnabled, stripeAccount } = await getStripeConnectForLock(
       lockAddress,
       network
     )
@@ -71,7 +71,7 @@ export async function renewFiatKey({
     const customer = await stripe.customers.retrieve(
       subscription.connectedCustomer,
       {
-        stripeAccount,
+        stripeAccount: stripeAccount.id,
       }
     )
 
@@ -85,7 +85,7 @@ export async function renewFiatKey({
         type: 'card',
       },
       {
-        stripeAccount,
+        stripeAccount: stripeAccount.id,
       }
     )
 
@@ -129,7 +129,7 @@ export async function renewFiatKey({
         },
       },
       {
-        stripeAccount,
+        stripeAccount: stripeAccount.id,
       }
     )
 
@@ -158,7 +158,7 @@ export async function renewFiatKey({
 
           // Capture it on the connected stripe account
           const intent = await stripe.paymentIntents.capture(paymentIntent.id, {
-            stripeAccount,
+            stripeAccount: stripeAccount.id,
           })
 
           switch (intent.status) {
@@ -177,7 +177,7 @@ export async function renewFiatKey({
                   },
                 },
                 {
-                  stripeAccount,
+                  stripeAccount: stripeAccount.id,
                 }
               )
               await KeyRenewal.create(recordedrenewalInfo)

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1825,8 +1825,27 @@ paths:
               schema:
                 type: object
                 properties:
+                  countrySpec:
+                    type: object
+                    properties:
+                      supported_payment_currencies:
+                        type: array
+                        items:
+                          type: string
                   account:
-                    type: string
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      charges_enabled:
+                        type: boolean
+                      payouts_enabled:
+                        type: boolean
+                      requirements:
+                        type: object
+                        properties:
+                          disabled_reason:
+                            type: string
                   connected:
                     type: number
 

--- a/unlock-app/src/components/interface/locks/Settings/forms/CreditCardCustomPrice.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/CreditCardCustomPrice.tsx
@@ -20,7 +20,6 @@ import { SettingCardDetail } from '../elements/SettingCard'
 import { formatNumber } from '~/utils/formatter'
 import { storage } from '~/config/storage'
 import { useUSDPricing } from '~/hooks/useUSDPricing'
-import { Currencies } from '@unlock-protocol/core'
 
 interface CreditCardFormSchema {
   creditCardPrice?: string | number | null
@@ -32,6 +31,8 @@ interface CreditCardCustomPriceProps {
   network: number
   disabled: boolean
   lock: any
+  currencies: string[]
+  connectedStripeAccount: any
 }
 
 export default function CreditCardCustomPrice({
@@ -39,19 +40,26 @@ export default function CreditCardCustomPrice({
   network,
   disabled,
   lock,
+  currencies,
+  connectedStripeAccount,
 }: CreditCardCustomPriceProps) {
   const [useCustomPrice, setUseCustomPrice] = useState(false)
   const [hasPriceConversion, setHasPriceConversion] = useState(false)
-  const [currency, setCurrency] = useState('') // default currency is USD
+  const [currency, setCurrency] = useState(
+    connectedStripeAccount.default_currency
+  )
 
   const {
     isLoading: isLoadingSettings,
-    data: { creditCardCurrency = 'usd ' } = {},
+    data: { creditCardCurrency = connectedStripeAccount.default_currency } = {},
   } = useGetLockSettings({ lockAddress, network })
 
   const getDefaultValues = async (): Promise<CreditCardFormSchema> => {
     const settings = (await storage.getLockSettings(network, lockAddress)).data
-    const { creditCardPrice: price, creditCardCurrency = 'usd' } = settings
+    const {
+      creditCardPrice: price,
+      creditCardCurrency = connectedStripeAccount.default_currency,
+    } = settings
 
     if (price && creditCardCurrency) {
       const priceInUsd = parseFloat(formatNumber(price / 100)).toFixed(2)
@@ -66,7 +74,7 @@ export default function CreditCardCustomPrice({
 
     return {
       creditCardPrice: undefined,
-      creditCardCurrency: 'usd',
+      creditCardCurrency: connectedStripeAccount.default_currency,
     }
   }
 
@@ -138,9 +146,9 @@ export default function CreditCardCustomPrice({
   const symbol = lock?.currencySymbol
 
   // list of currencies for dropdown
-  const currencyOptions = Currencies.map(({ currency, symbol }) => {
+  const currencyOptions = currencies.map((currency: string) => {
     return {
-      label: `${currency.toUpperCase()} - ${symbol}`,
+      label: `${currency.toUpperCase()}`,
       value: currency,
     }
   })

--- a/unlock-app/src/components/interface/locks/Settings/forms/CreditCardForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/CreditCardForm.tsx
@@ -67,7 +67,7 @@ const DisconnectStripe = ({
       <div className="flex flex-col items-center gap-4 md:gap-8 md:flex-row">
         <Badge variant="green" className="justify-center w-full md:w-1/3">
           <div className="flex items-center gap-2">
-            <span>Payment method enabled</span>
+            <span>Fiat payments enabled</span>
             <CheckCircleIcon />
           </div>
         </Badge>
@@ -251,7 +251,7 @@ const StripeNotReady = ({
   connectedStripeAccount,
 }: Pick<ConnectStripeProps, 'isManager' | 'disabled'> &
   ConnectStripe & {
-    connectedStripeAccount?: string
+    connectedStripeAccount?: any
   }) => {
   return (
     <span className="grid gap-2 text-sm">
@@ -313,9 +313,10 @@ export const CreditCardForm = ({
       return getKeyGranter()
     }
   )
-
   const stripeConnectionState = stripeConnectionDetails?.connected ?? 0
   const connectedStripeAccount = stripeConnectionDetails?.account
+  const supportedCurrencies =
+    stripeConnectionDetails?.countrySpec?.supported_payment_currencies ?? []
 
   const getKeyGranter = async () => {
     return await storageService.getKeyGranter(network)
@@ -416,6 +417,13 @@ export const CreditCardForm = ({
             onDisconnect={onDisconnectStripe}
             disabled={disabled || disconnectStipeMutation.isLoading}
           />
+          {connectedStripeAccount && (
+            <span>
+              You will receive payments on your Stripe account{' '}
+              <code>{connectedStripeAccount.id}</code>
+            </span>
+          )}
+
           {isManager && (
             <>
               <CreditCardCustomPrice
@@ -423,6 +431,8 @@ export const CreditCardForm = ({
                 network={network}
                 disabled={disabled}
                 lock={lock}
+                currencies={supportedCurrencies}
+                connectedStripeAccount={connectedStripeAccount}
               />
               <CreditCardUnlockFee
                 lockAddress={lockAddress}

--- a/unlock-app/src/components/interface/locks/Settings/forms/CreditCardForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/CreditCardForm.tsx
@@ -67,7 +67,7 @@ const DisconnectStripe = ({
       <div className="flex flex-col items-center gap-4 md:gap-8 md:flex-row">
         <Badge variant="green" className="justify-center w-full md:w-1/3">
           <div className="flex items-center gap-2">
-            <span>Fiat payments enabled</span>
+            <span>Card payments enabled</span>
             <CheckCircleIcon />
           </div>
         </Badge>


### PR DESCRIPTION
# Description

Instead of adding support for currencies one by one, we let lock manager chose any currency supported in their country.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
