### PR TITLE
Deployed Password Hook on Avalanche(C-Chain)

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -51,7 +51,8 @@
     "adeelhasan",
     "KosmosKey",
     "easyrun42",
-    "gundamdweeb"
+    "gundamdweeb",
+    "pavvann"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the the file `.clabot`.\nThank you! "
 }

--- a/packages/networks/src/networks/avalanche.ts
+++ b/packages/networks/src/networks/avalanche.ts
@@ -25,6 +25,11 @@ export const avalanche: NetworkConfig = {
         id: HookType.CAPTCHA,
         name: 'Captcha',
       },
+      {
+        address: '0xF57a29012Bc367a6FDBB0Aead9A8909Ce15a8aCf',
+        id: HookType.PASSWORD,
+        name: 'Password required',
+      },
     ],
   },
   id: 43114,


### PR DESCRIPTION
There was no Password Hook deployed on Avalanche chain.

Deployed at address: 0xF57a29012Bc367a6FDBB0Aead9A8909Ce15a8aCf

Updated config at: packages/networks/src/networks/avalanche.ts
