### PR TITLE
deployed password hook on avalanche

### DIFF
--- a/packages/networks/src/networks/avalanche.ts
+++ b/packages/networks/src/networks/avalanche.ts
@@ -25,6 +25,11 @@ export const avalanche: NetworkConfig = {
         id: HookType.CAPTCHA,
         name: 'Captcha',
       },
+      {
+        address: '0x58D86Dc056c442867485941FeBeA8D3bB4657eAC',
+        id: HookType.PASSWORD,
+        name: 'Password required',
+      }
     ],
   },
   id: 43114,


### PR DESCRIPTION
There was no Password Hook deployed on Avalanche chain.

Deployed at address: 0x58D86Dc056c442867485941FeBeA8D3bB4657eAC

Updated config at: packages/networks/src/networks/avalanche.ts