### PR TITLE
fix to use the right version of matchstick

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -20,7 +20,7 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001",
     "introspect": "/bin/sh -c 'if test \"$CI\" != \"true\" ; then node bin/introspect.js; fi'",
     "introspect:local": "INTROSPECT_NETWORK=31337 node bin/introspect.js",
-    "test": "graph test -v 0.5.2 #change_me_when_changing_matchstick_version ",
+    "test": "graph test -v 0.5.2",
     "prepare:test": "yarn copy-manifest && yarn copy-networks",
     "copy-networks": "rm -rf networks.json && cp ../docker/development/eth-node/networks.json networks.json",
     "copy-manifest": "rm -rf subgraph.yaml && cp ../tests/subgraph.test.yaml subgraph.yaml",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -20,7 +20,7 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001",
     "introspect": "/bin/sh -c 'if test \"$CI\" != \"true\" ; then node bin/introspect.js; fi'",
     "introspect:local": "INTROSPECT_NETWORK=31337 node bin/introspect.js",
-    "test": "graph test -v 0.5.2 # change me when changing matchstick version ",
+    "test": "graph test -v 0.5.2 #change_me_when_changing_matchstick_version ",
     "prepare:test": "yarn copy-manifest && yarn copy-networks",
     "copy-networks": "rm -rf networks.json && cp ../docker/development/eth-node/networks.json networks.json",
     "copy-manifest": "rm -rf subgraph.yaml && cp ../tests/subgraph.test.yaml subgraph.yaml",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -20,7 +20,7 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001",
     "introspect": "/bin/sh -c 'if test \"$CI\" != \"true\" ; then node bin/introspect.js; fi'",
     "introspect:local": "INTROSPECT_NETWORK=31337 node bin/introspect.js",
-    "test": "graph test",
+    "test": "graph test -v 0.5.2 # change me when changing matchstick version ",
     "prepare:test": "yarn copy-manifest && yarn copy-networks",
     "copy-networks": "rm -rf networks.json && cp ../docker/development/eth-node/networks.json networks.json",
     "copy-manifest": "rm -rf subgraph.yaml && cp ../tests/subgraph.test.yaml subgraph.yaml",


### PR DESCRIPTION
# Description

By dfault the `graph` binary downloads the latest version of `matchstick` but for some reason it uses the wrong binary, resulting in a 404 (it assumes Linux 2.0 when it should use 2.2).

https://github.com/unlock-protocol/unlock/actions/runs/6551451121/job/17792649336

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
