### PR TITLE
fix(unlock-app): fixed pagination for CSV downloads until we have full export

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
@@ -11,8 +11,7 @@ import { subgraph } from '~/config/subgraph'
 import { storage } from '~/config/storage'
 import { Placeholder } from '@unlock-protocol/ui'
 import { useWeb3Service } from '~/utils/withWeb3Service'
-
-const itemsPerPage = 30
+import { MEMBERS_PER_PAGE } from '~/constants'
 
 interface MembersProps {
   lockAddress: string
@@ -53,7 +52,7 @@ export const Members = ({
       filters.filterKey,
       filters.expiration,
       page - 1, // API starts at 0
-      itemsPerPage
+      MEMBERS_PER_PAGE
     )
     return keys.data
   }
@@ -184,7 +183,7 @@ export const Members = ({
   const pageOffset = page - 1 ?? 0
   const { maxNumbersOfPage } = paginate({
     page: pageOffset,
-    itemsPerPage,
+    itemsPerPage: MEMBERS_PER_PAGE,
     totalItems: chainLock.outstandingKeys,
   })
 

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -31,12 +31,14 @@ import { Picker } from '../../Picker'
 import { storage } from '~/config/storage'
 import { useMetadata } from '~/hooks/metadata'
 import { getLockTypeByMetadata } from '@unlock-protocol/core'
+import { MEMBERS_PER_PAGE } from '~/constants'
 
 interface ActionBarProps {
   lockAddress: string
   network: number
   setIsOpen: (open: boolean) => void
   isOpen: boolean
+  page: number
 }
 
 interface TopActionBarProps {
@@ -49,6 +51,7 @@ interface DownloadOptions {
   cols: string[]
   metadata: any[]
 }
+
 export function downloadAsCSV({
   cols,
   metadata,
@@ -62,7 +65,7 @@ export function downloadAsCSV({
   FileSaver.saveAs(blob, fileName)
 }
 
-const ActionBar = ({ lockAddress, network }: ActionBarProps) => {
+const ActionBar = ({ lockAddress, network, page }: ActionBarProps) => {
   const { isLoading: isLoadingMetadata, data: metadata } = useMetadata({
     lockAddress,
     network,
@@ -77,7 +80,9 @@ const ActionBar = ({ lockAddress, network }: ActionBarProps) => {
       lockAddress,
       '',
       'owner',
-      'all'
+      'all',
+      page - 1,
+      MEMBERS_PER_PAGE
     )
     const members = response.data
     const cols: string[] = []
@@ -414,6 +419,7 @@ export const ManageLockPage = () => {
               <div className="flex flex-col gap-6 lg:col-span-9">
                 <TotalBar lockAddress={lockAddress} network={lockNetwork!} />
                 <ActionBar
+                  page={page}
                   lockAddress={lockAddress}
                   network={lockNetwork!}
                   isOpen={airdropKeys}

--- a/unlock-app/src/constants.tsx
+++ b/unlock-app/src/constants.tsx
@@ -147,3 +147,5 @@ The Unlock team
 
 // We show unlimited renewals as if it's above this.
 export const UNLIMITED_RENEWAL_LIMIT = 100000000000
+
+export const MEMBERS_PER_PAGE = 30


### PR DESCRIPTION
# Description

Fixing the CSV pagination until we fix it allowing full download. (https://github.com/unlock-protocol/unlock/issues/12835)
This just makes things consistent by letting users download page by page.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
