### PR TITLE
refactor(locksmith): we should not return 500 unless there is really an error.

### DIFF
--- a/locksmith/__tests__/controllers/v2/grantKeysController.test.ts
+++ b/locksmith/__tests__/controllers/v2/grantKeysController.test.ts
@@ -193,7 +193,7 @@ describe('grantKeys endpoint', () => {
         ],
       })
     expect(response.body.error).toBe('Gas fees too high to grant keys')
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(422)
   })
 
   it('returns an error when the purchaser does not have enough funds', async () => {
@@ -221,6 +221,6 @@ describe('grantKeys endpoint', () => {
     expect(response.body.error).toBe(
       'Purchaser does not have enough to pay for gas on 2000'
     )
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(422)
   })
 })

--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -261,13 +261,13 @@ export class PurchaseController {
       ])
 
       if (!canAffordGas.canAfford) {
-        return response.status(500).send({
+        return response.status(400).send({
           message: canAffordGas.reason,
         })
       }
 
       if (!hasEnoughToPayForGas) {
-        return response.status(500).send({
+        return response.status(400).send({
           message:
             'Purchaser does not have enough funds to allow claiming the membership',
         })

--- a/locksmith/src/controllers/v2/certificateController.ts
+++ b/locksmith/src/controllers/v2/certificateController.ts
@@ -17,7 +17,7 @@ export const generateCertificate: RequestHandler = async (
   })
 
   if (!certificate) {
-    return response.status(500).send({
+    return response.status(422).send({
       message: `Certificate can't be generated for the provided tokenId`,
     })
   }

--- a/locksmith/src/controllers/v2/grantKeysController.ts
+++ b/locksmith/src/controllers/v2/grantKeysController.ts
@@ -49,7 +49,7 @@ export class GrantKeysController {
 
       // We max at 5 cts per transaction
       if (gasCost > 5) {
-        response.status(500).send({
+        response.status(422).send({
           error: 'Gas fees too high to grant keys',
         })
         return
@@ -60,7 +60,7 @@ export class GrantKeysController {
       )
 
       if (!hasEnoughToPayForGas) {
-        response.status(500).send({
+        response.status(422).send({
           error: `Purchaser does not have enough to pay for gas on ${network}`,
         })
         return

--- a/locksmith/src/controllers/v2/metadataController.ts
+++ b/locksmith/src/controllers/v2/metadataController.ts
@@ -81,7 +81,7 @@ export const getBulkKeysMetadata: RequestHandler = async (
         .send({
           message: 'Parameter `keys` is not present',
         })
-        .status(500)
+        .status(400)
     }
 
     const owners: { owner: string; keyId: string }[] = keys?.map(

--- a/locksmith/src/utils/middlewares/isVerifierMiddleware.ts
+++ b/locksmith/src/utils/middlewares/isVerifierMiddleware.ts
@@ -41,7 +41,8 @@ export const isVerifierMiddleware: RequestHandler = async (req, res, next) => {
   } catch (err) {
     logger.error(err)
     return res.status(500).send({
-      message: 'There is some unexpected issue, please try again',
+      message:
+        'There is some unexpected issue when checking if the user is a verifier or manager.',
     })
   }
 }


### PR DESCRIPTION
# Description

All in the title! The main reason for this is that we use monitoring tools that look at the kind of responses our app is sending. So when we send 500 for "expected" errors then we're triggering systems that should not be triggered.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
