### PR TITLE
refactor(locksmith): if the signer is not correct, do not throw

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -349,16 +349,22 @@ export default class Dispatcher {
       network,
       params,
     })
-    const { wallet } = await getPurchaser({
-      network,
-      address: transferSignerAddress, // we get the signer at that address! (this throws if the signer does not match!)
-    })
-    const walletAddress = await wallet.getAddress()
-    const isSignedByLocksmith =
-      normalizer.ethereumAddress(transferSignerAddress) ===
-      normalizer.ethereumAddress(walletAddress)
-
-    return isSignedByLocksmith
+    try {
+      const { wallet } = await getPurchaser({
+        network,
+        address: transferSignerAddress, // we get the signer at that address! (this throws if the signer does not match!)
+      })
+      const walletAddress = await wallet.getAddress()
+      const isSignedByLocksmith =
+        normalizer.ethereumAddress(transferSignerAddress) ===
+        normalizer.ethereumAddress(walletAddress)
+      return isSignedByLocksmith
+    } catch (error) {
+      logger.error(`We could not find a signer for ${transferSignerAddress}`, {
+        error,
+      })
+      return false
+    }
   }
 
   /** Sends a purchase transaction */


### PR DESCRIPTION
# Description

When requesting a transfer code the recovered address will not be us if the signed message was not signed by us.
We should not fail but just return false!


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
