### PR TITLE
refactor(locksmsith): using the public provider to send tx

### DIFF
--- a/locksmith/src/fulfillment/dispatcher.ts
+++ b/locksmith/src/fulfillment/dispatcher.ts
@@ -64,16 +64,13 @@ export const getPurchaser = async function ({
       speed: 'fast',
     })
     if (!address || address === (await wallet.getAddress())) {
-      return { wallet, provider }
+      return wallet
     }
   }
   const provider = await getPublicProviderForNetwork(network)
   const wallet = new ethers.Wallet(config.purchaserCredentials, provider)
   if (!address || address === (await wallet.getAddress())) {
-    return {
-      wallet,
-      provider,
-    }
+    return wallet
   }
   throw new Error(`The purchaser at ${address} is unavailable!`)
 }
@@ -192,8 +189,10 @@ export default class Dispatcher {
         .filter((network) => network.name !== 'localhost')
         .map(async (network: any) => {
           try {
-            const provider = await getProviderForNetwork(network.id)
-            const { wallet } = await getPurchaser({ network: network.id })
+            const [provider, wallet] = await Promise.all([
+              getProviderForNetwork(network.id),
+              getPurchaser({ network: network.id }),
+            ])
             const address = await wallet.getAddress()
             let timeout
             const balance: ethers.BigNumberish =
@@ -243,7 +242,7 @@ export default class Dispatcher {
     network: number,
     purchaser?: string
   ): Promise<boolean> {
-    const [provider, { wallet }] = await Promise.all([
+    const [provider, wallet] = await Promise.all([
       getProviderForNetwork(network),
       getPurchaser({ network, address: purchaser }),
     ])
@@ -292,7 +291,7 @@ export default class Dispatcher {
       timestamp: Date.now(),
     })
 
-    const { wallet } = await getPurchaser({ network })
+    const wallet = await getPurchaser({ network })
 
     return [payload, await wallet.signMessage(payload)]
   }
@@ -349,7 +348,7 @@ export default class Dispatcher {
       network,
       params,
     })
-    const { wallet } = await getPurchaser({
+    const wallet = await getPurchaser({
       network,
       address: transferSignerAddress, // we get the signer at that address! (this throws if the signer does not match!)
     })
@@ -376,8 +375,10 @@ export default class Dispatcher {
     const walletService = new WalletService(networks)
 
     // get any purchaser, as the address is not required here.
-    const { wallet, provider } = await getPurchaser({ network })
-
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
     await walletService.connect(provider, wallet)
 
     const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(network)
@@ -405,7 +406,10 @@ export default class Dispatcher {
     const walletService = new WalletService(networks)
 
     // Get any purchaser, as the address does not matter
-    const { wallet, provider } = await getPurchaser({ network })
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
 
     await walletService.connect(provider, wallet)
 
@@ -479,7 +483,10 @@ export default class Dispatcher {
   ) {
     const walletService = new WalletService(networks)
     // get any purchaser here as the address does not matter
-    const { wallet, provider } = await getPurchaser({ network })
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
     await walletService.connect(provider, wallet)
     return executeAndRetry(
       walletService.extendKey(
@@ -556,7 +563,10 @@ export default class Dispatcher {
     callback: (error: any, hash: string | null) => Promise<void> | void
   ) {
     // purchaser does not matter here
-    const { wallet, provider } = await getPurchaser({ network })
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
     const walletService = new WalletService(networks)
     await walletService.connect(provider, wallet)
     const { maxFeePerGas, maxPriorityFeePerGas } = await getGasSettings(network)
@@ -590,7 +600,10 @@ export default class Dispatcher {
   ) {
     const walletService = new WalletService(networks)
     // get any purchaser, as the sender of this transaction does not matter
-    const { wallet, provider } = await getPurchaser({ network })
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
     await walletService.connect(provider, wallet)
 
     const referrer = networks[network]?.multisig

--- a/locksmith/src/operations/authorizedLockOperations.ts
+++ b/locksmith/src/operations/authorizedLockOperations.ts
@@ -11,7 +11,7 @@ export const hasAuthorization = async (
   const lockAddress = Normalizer.ethereumAddress(address)
   const web3Service = new Web3Service(networks)
 
-  const { wallet } = await getPurchaser({ network })
+  const wallet = await getPurchaser({ network })
 
   const purchaserAddress = await wallet.getAddress()
 

--- a/locksmith/src/utils/keyPricer.ts
+++ b/locksmith/src/utils/keyPricer.ts
@@ -12,7 +12,7 @@ import {
   baseStripeFee,
   GAS_COST_TO_GRANT,
 } from './constants'
-import { getPurchaser } from '../fulfillment/dispatcher'
+import { getProviderForNetwork, getPurchaser } from '../fulfillment/dispatcher'
 
 const ZERO = ethers.constants.AddressZero
 
@@ -33,7 +33,10 @@ export default class KeyPricer {
     if (networks[network].fullySubsidizedGas) {
       return { canAfford: true }
     }
-    const { wallet, provider } = await getPurchaser({ network })
+    const [provider, wallet] = await Promise.all([
+      getProviderForNetwork(network),
+      getPurchaser({ network }),
+    ])
     const [gasPrice, balance] = await Promise.all([
       provider.getGasPrice(),
       provider.getBalance(await wallet.getAddress()),


### PR DESCRIPTION
# Description

We only use the OpenZeppelin relay provider when actually sending transactions.
This will reduce the risk of reaching the rate limit.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
