### PR TITLE
fix(governance): fetch delay mod address from networks package

### DIFF
--- a/governance/scripts/multisig/crossExec.js
+++ b/governance/scripts/multisig/crossExec.js
@@ -1,4 +1,5 @@
 const { ethers } = require('hardhat')
+const { networks } = require('@unlock-protocol/networks')
 
 const delayABI = [
   {
@@ -422,14 +423,21 @@ const delayABI = [
     type: 'function',
   },
 ]
-async function main({
-  delayModuleAddress = '0xE12CCcf36449907db62b10Fe0f4Aa70DACACeBff',
-  bridgeTxHash = '0x17c6d4fb1b80c867c54ef2e57f0f29bf608f4da6d114192e54479da480e4bd5c',
-} = {}) {
-  const delayMod = await ethers.getContractAt(delayABI, delayModuleAddress)
 
-  // TODO: fetch delayMod address from networks package
+async function main({ delayModuleAddress, bridgeTxHash } = {}) {
+  // fetch delayMod address from networks package
+  if (!delayModuleAddress) {
+    const { chainId } = await ethers.provider.getNetwork()
+    ;({
+      governanceBridge: {
+        modules: { delayMod: delayModuleAddress },
+      },
+    } = networks[chainId])
+  }
+
+  const delayMod = await ethers.getContractAt(delayABI, delayModuleAddress)
   // TODO: fetch tx from Connext graph
+  console.log({ delayModuleAddress, bridgeTxHash })
 
   // get the nonces
   const currentNonce = await delayMod.txNonce()


### PR DESCRIPTION
# Description

This adds ability to fetch delay mod address directly from the `networks` package when using the `safe:bridge:execute` command

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
