### PR TITLE
feature(smart-contracts): adding a cap for the password hook

### DIFF
--- a/smart-contracts/test/Lock/hooks/PasswordRequiredHook.js
+++ b/smart-contracts/test/Lock/hooks/PasswordRequiredHook.js
@@ -92,11 +92,13 @@ describe('PasswordRequiredHook', function () {
       user.address.toLowerCase()
     )
 
-    // Set the password on the hook for the lock
-    await (await hook.setSigner(lock.address, signer)).wait()
+    const usages = 10
 
-    const s = await hook.signers(lock.address)
-    expect(s).to.equal(signer)
+    // Set the password on the hook for the lock
+    await (await hook.setSigner(lock.address, signer, usages)).wait()
+
+    const s = await hook.signers(lock.address, signer)
+    expect(s.toString()).to.equal(usages.toString())
 
     // And now make a purchase that should fail because we did not submit a data
     await reverts(
@@ -122,5 +124,75 @@ describe('PasswordRequiredHook', function () {
     await reverts(
       lock.purchase([0], [user.address], [user.address], [user.address], [data])
     ).not
+
+    // Check the usages!
+    const usageAfter = await hook.counters(lock.address, signer)
+    expect(usageAfter.toString()).to.equal((1).toString())
+  })
+
+  it('should fail if the code has been used enough', async function () {
+    const [user, another] = await ethers.getSigners()
+
+    await unlock.deployProtocol()
+    const expirationDuration = 60 * 60 * 24 * 7
+    const maxNumberOfKeys = 100
+    const keyPrice = 0
+
+    const { lock } = await unlock.createLock({
+      expirationDuration,
+      maxNumberOfKeys,
+      keyPrice,
+      name: 'ticket',
+    })
+    const PasswordRequiredHook = await ethers.getContractFactory(
+      'PasswordRequiredHook'
+    )
+    const hook = await PasswordRequiredHook.deploy()
+    await hook.deployed()
+
+    await (
+      await lock.setEventHooks(
+        hook.address,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero
+      )
+    ).wait()
+
+    // Build the signer from password
+    const password = 'unguessable!'
+    const [data, signer] = await getSignatureForPassword(
+      password,
+      user.address.toLowerCase()
+    )
+
+    const usages = 1
+
+    // Set the password on the hook for the lock
+    await (await hook.setSigner(lock.address, signer, usages)).wait()
+
+    // And a purchase that succeeds when we use the correct password!
+    await reverts(
+      lock.purchase([0], [user.address], [user.address], [user.address], [data])
+    ).not
+
+    const [newData] = await getSignatureForPassword(
+      password,
+      another.address.toLowerCase()
+    )
+
+    // And a purchase that succeeds when we use the correct password!
+    await reverts(
+      lock.purchase(
+        [0],
+        [another.address],
+        [another.address],
+        [another.address],
+        [newData]
+      )
+    )
   })
 })


### PR DESCRIPTION
# Description

One of the frequent feature requests we're getting for both the password hook and the promo code hook is the ability to set a maximum number of use.
This PR adds that support in the contracts.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
