### PR TITLE
feature(unlock-app): adding migration for legacy events

### DIFF
--- a/locksmith/src/controllers/v2/eventsController.ts
+++ b/locksmith/src/controllers/v2/eventsController.ts
@@ -1,16 +1,16 @@
 import { RequestHandler } from 'express'
 import {
-  createEventSlug,
   getEventBySlug,
   getEventDataForLock,
+  saveEvent,
 } from '../../operations/eventOperations'
 import normalizer from '../../utils/normalizer'
-import { CheckoutConfig, EventData } from '../../models'
+import { CheckoutConfig } from '../../models'
 import { z } from 'zod'
 import { getLockSettingsBySlug } from '../../operations/lockSettingOperations'
 import { getLockMetadata } from '../../operations/metadataOperations'
 import { PaywallConfig, PaywallConfigType } from '@unlock-protocol/core'
-import { saveCheckoutConfig } from '../../operations/checkoutConfigOperations'
+import listManagers from '../../utils/lockManagers'
 
 // DEPRECATED!
 export const getEventDetailsByLock: RequestHandler = async (
@@ -31,6 +31,7 @@ export const EventBody = z.object({
     id: z.string().optional(),
   }),
 })
+export type EventBodyType = z.infer<typeof EventBody>
 
 const defaultPaywallConfig: Partial<PaywallConfigType> = {
   title: 'Registration',
@@ -48,44 +49,11 @@ const defaultPaywallConfig: Partial<PaywallConfigType> = {
 }
 
 export const saveEventDetails: RequestHandler = async (request, response) => {
-  const parsed = await EventBody.parseAsync(request.body)
-
-  const slug =
-    parsed.data.slug || (await createEventSlug(parsed.data.name, parsed.id))
-
-  const [event, created] = await EventData.upsert(
-    {
-      id: parsed.id,
-      name: parsed.data.name,
-      slug,
-      data: {
-        ...parsed.data,
-        slug, // Making sure we add the slug to the data as well.
-      },
-      createdBy: request.user!.walletAddress,
-    },
-    {
-      conflictFields: ['slug'],
-    }
+  const parsedBody = await EventBody.parseAsync(request.body)
+  const [event, created] = await saveEvent(
+    parsedBody,
+    request.user!.walletAddress
   )
-
-  if (!event.checkoutConfigId) {
-    const checkoutConfig = await PaywallConfig.strip().parseAsync(
-      parsed.checkoutConfig.config
-    )
-    const createdConfig = await saveCheckoutConfig({
-      name: `Checkout config for ${event.name}`,
-      config: checkoutConfig,
-      createdBy: request.user!.walletAddress,
-    })
-    // And now attach the id to the event
-    event.checkoutConfigId = createdConfig.id
-    await event.save()
-  }
-
-  // TODO: We should update the metadata on the locks
-  // to point to this event by default!
-
   const statusCode = created ? 201 : 200
   return response.status(statusCode).send(event.toJSON())
 }
@@ -137,6 +105,19 @@ export const getEvent: RequestHandler = async (request, response) => {
               },
             },
           }
+
+      await saveEvent(
+        {
+          data: { ...lockData },
+          checkoutConfig: checkoutConfig!,
+        },
+        (
+          await listManagers({
+            lockAddress: settings.lockAddress,
+            network: settings.network,
+          })
+        )[0]
+      )
       return response.status(200).send({
         data: { ...lockData },
         checkoutConfig,

--- a/locksmith/src/utils/lockManagers.ts
+++ b/locksmith/src/utils/lockManagers.ts
@@ -1,43 +1,24 @@
+import { SubgraphService } from '@unlock-protocol/unlock-js'
+
 interface listManagersProps {
   lockAddress: string
-  subgraphURI: string
+  network: number
 }
 
-// fetch all managers from the GRAPH
 export default async function listManagers({
   lockAddress,
-  subgraphURI,
+  network,
 }: listManagersProps) {
-  const query = `
+  const service = new SubgraphService()
+  const lock = await service.lock(
     {
-      locks(where:{
-        address: "${lockAddress}"
-      }) {
-        LockManagers {
-          address
-        }
-      }
+      where: {
+        address_in: [lockAddress],
+      },
+    },
+    {
+      network,
     }
-  `
-
-  const q = await fetch(subgraphURI, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      query,
-    }),
-  })
-
-  const { data, errors } = (await q.json()) as any
-  if (errors) {
-    // eslint-disable-next-line no-console
-    console.log('LOCK > Error while fetching the graph', errors)
-    return []
-  }
-
-  const {
-    locks: [{ LockManagers }],
-  } = data
-  const managers = LockManagers.map((m: any) => m.address)
-  return managers
+  )
+  return lock ? lock.lockManagers : []
 }

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
@@ -12,7 +12,11 @@ import { useEventOrganizer } from '~/hooks/useEventOrganizer'
 import { VerifierForm } from '~/components/interface/locks/Settings/forms/VerifierForm'
 import dayjs from 'dayjs'
 import { AiOutlineCalendar as CalendarIcon } from 'react-icons/ai'
-import { Event, PaywallConfigType } from '@unlock-protocol/core'
+import {
+  Event,
+  PaywallConfigType,
+  formDataToMetadata,
+} from '@unlock-protocol/core'
 import useClipboard from 'react-use-clipboard'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import { CoverImageDrawer } from './CoverImageDrawer'
@@ -21,6 +25,7 @@ import { EventLocation } from './EventLocation'
 import { RegistrationCard } from './RegistrationCard'
 import { useEvent } from '~/hooks/useEvent'
 import { SettingEmail } from '~/components/interface/locks/Settings/elements/SettingEmail'
+import { storage } from '~/config/storage'
 
 interface EventDetailsProps {
   event: Event
@@ -57,6 +62,28 @@ export const EventDetails = ({
   const eventUrl = getEventUrl({
     event,
   })
+  // Migrate legacy event and/or redirect
+  useEffect(() => {
+    const migrateAndRedirect = async () => {
+      if (router.pathname === '/event') {
+        if (event.slug) {
+          router.push(eventUrl)
+        } else {
+          const { data: savedEvent } = await storage.saveEventData({
+            data: formDataToMetadata(event),
+            // @ts-expect-error Property ''name'' is missing in type
+            checkoutConfig,
+          })
+          if (savedEvent.data) {
+            router.push({
+              event: savedEvent.data,
+            })
+          }
+        }
+      }
+    }
+    migrateAndRedirect()
+  }, [router, event, eventUrl])
 
   const [_, setCopied] = useClipboard(eventUrl, {
     successDuration: 1000,
@@ -110,8 +137,6 @@ export const EventDetails = ({
   const hasDate = startDate || startTime || endDate || endTime
 
   const coverImage = event.ticket.event_cover_image
-
-  console.log({ event })
 
   // TODO: OG for event!
   // const locksmithEventOG = new URL(

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -75,9 +75,11 @@ export const EventDetails = ({
             checkoutConfig,
           })
           if (savedEvent.data) {
-            router.push({
-              event: savedEvent.data,
-            })
+            router.push(
+              getEventUrl({
+                event: savedEvent.data,
+              })
+            )
           }
         }
       }

--- a/unlock-app/src/components/interface/locks/Settings/elements/EmailTemplatePreview.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/EmailTemplatePreview.tsx
@@ -181,7 +181,9 @@ export const EmailTemplatePreview = ({
 
           // add all params in URL
           Object.entries(params).map(([key, value]) => {
-            url.searchParams.append(key, value.toString())
+            if (value) {
+              url.searchParams.append(key, value.toString())
+            }
           })
 
           return (


### PR DESCRIPTION
# Description

When loading a legacy event route (using the lock address instead of the event's slug) we check if there is a slug and redirect.
If there is no slug, we then create the corresponding event object and redirect to it so the app can handle this better.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
