### PR TITLE
fix(unlock-app): refactored routes for crosschain purchase

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -370,12 +370,6 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
               </button>
             )}
 
-            {isLoadingMoreRoutes && !enableClaim && (
-              <div className="flex items-center justify-center w-full gap-2 text-sm text-center">
-                <LoadingIcon size={16} /> Loading more payment options...
-              </div>
-            )}
-
             {!isUniswapRoutesLoading &&
               !enableClaim &&
               uniswapRoutes?.map((route, index) => {
@@ -474,6 +468,13 @@ export function Payment({ injectedProvider, checkoutService }: Props) {
                   </button>
                 )
               })}
+
+            {isLoadingMoreRoutes && !enableClaim && (
+              <div className="flex items-center justify-center w-full gap-2 text-sm text-center">
+                <LoadingIcon size={16} /> Loading more payment options...
+              </div>
+            )}
+
             {allDisabled && (
               <div className="text-sm">
                 <p className="mb-4">

--- a/unlock-app/src/hooks/useCrossChainRoutes.ts
+++ b/unlock-app/src/hooks/useCrossChainRoutes.ts
@@ -80,11 +80,19 @@ export const useCrossChainRoutes = ({
       }
 
       // @ts-expect-error For some reason Typescript does not like that the type of the accumulator and the currnet value are different
-      return routes.reduce<CrossChainRoute>(
-        // @ts-expect-error For some reason Typescript does not like that the type of the accumulator and the currnet value are different
-        reduce,
-        [] as CrossChainRoute[]
-      )
+      return routes
+        .map((route) => {
+          delete route.tx.gasLimit
+          delete route.tx.maxFeePerGas
+          delete route.tx.maxPriorityFeePerGas
+          delete route.tx.gasPrice
+          return route
+        })
+        .reduce<CrossChainRoute>(
+          // @ts-expect-error For some reason Typescript does not like that the type of the accumulator and the currnet value are different
+          reduce,
+          [] as CrossChainRoute[]
+        )
     },
     {
       enabled,


### PR DESCRIPTION
# Description

It looks like the Decent API changed and they return gas price and others as `00000n` values.
We actually don't need these as the wallets will recompute so we're removing them.


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
