### PR TITLE
fix(unlock-app): better prompt user to sign 

### DIFF
--- a/unlock-app/src/components/interface/checkout/Connected.tsx
+++ b/unlock-app/src/components/interface/checkout/Connected.tsx
@@ -197,15 +197,8 @@ export function Connected({
 
   useEffect(() => {
     const autoSignIn = async () => {
-      if (
-        !isSignedIn &&
-        !signing &&
-        connected &&
-        (isUnlockAccount || useDelegatedProvider)
-      ) {
-        setSigning(true)
+      if (!isSignedIn && !signing && connected && isUnlockAccount) {
         await signIn()
-        setSigning(false)
       }
     }
     autoSignIn()
@@ -224,8 +217,26 @@ export function Connected({
     } else console.debug(`Connected as ${account}`)
   }, [account])
 
-  if (useDelegatedProvider) {
-    return <div className="space-y-2">{children}</div>
+  const signToSignIn = async () => {
+    setSigning(true)
+    await signIn()
+    setSigning(false)
+  }
+
+  if (useDelegatedProvider || isUnlockAccount) {
+    if (isSignedIn) {
+      return <div className="space-y-2">{children}</div>
+    }
+    return (
+      <Button
+        disabled={!connected || signing}
+        loading={signing}
+        onClick={signToSignIn}
+        className="w-full"
+      >
+        Sign the message
+      </Button>
+    )
   }
 
   const onDisconnect = async () => {


### PR DESCRIPTION
# Description

With this change, we only prompt user to sign when they perform an action when using the delegated provider.
The current approach is to "auto login" by automatically asking users to sign when the iframe is loaded. This is not ideal from a UX perspective already but gets worse when the user refuses to sign because that means we prompt again.

With this fix, we move to only asking them to sign when they click the button.
This is not yet ideal because this adds one more click, but this is much better and handle the use case of the user not signing much more elegantly.

In the end a better approach would be for apps to be able to "pass" a SIWE message directly to the Paywall, not requiring one to authenticate with locksmith.

# Issues

Fixes #13084
Refs #

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

Better sign when Paywall is embedded and using the delegated provider.