### PR TITLE
fix(unlock-app): using optional chaining operator on receipt prefix

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/forms/ReceiptBaseForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/ReceiptBaseForm.tsx
@@ -126,7 +126,7 @@ export const ReceiptBaseForm = ({
     if (receiptsBase) {
       reset(receiptsBase)
       setVatPercentage(receiptsBase?.vatRatePercentage > 0) // enable when percentage is set
-      setPrefix(receiptsBase?.prefix.length > 0)
+      setPrefix(receiptsBase?.prefix?.length > 0)
     }
   }, [receiptsBase, reset])
 


### PR DESCRIPTION

# Description

Opening the receipt settings form was crashing when the prefix didn't exist yet (db not migrated or `receiptsBase` not being initialised with empty values)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread



<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
