### PR TITLE
fix(unlock-app): improved `isUnlockAccount` to be true when the user has not yet entered their password!

### DIFF
--- a/unlock-app/src/components/interface/keychain/Key.tsx
+++ b/unlock-app/src/components/interface/keychain/Key.tsx
@@ -69,10 +69,9 @@ export interface Props {
 function Key({ ownedKey, account, network }: Props) {
   const { lock, expiration, tokenId, isExpired, isExtendable, isRenewable } =
     ownedKey
-  const { getWalletService } = useAuth()
+  const { getWalletService, isUnlockAccount, watchAsset } = useAuth()
   const wedlockService = useContext(WedlockServiceContext)
   const web3Service = useWeb3Service()
-  const { watchAsset } = useAuth()
   const config = useConfig()
   const [showingQR, setShowingQR] = useState(false)
   const [showMoreInfo, setShowMoreInfo] = useState(false)
@@ -307,18 +306,20 @@ function Key({ ownedKey, account, network }: Props) {
                       </MenuButton>
                     )}
                   </Menu.Item>
-                  <Menu.Item>
-                    {({ active, disabled }) => (
-                      <MenuButton
-                        disabled={disabled}
-                        active={active}
-                        onClick={addToWallet}
-                      >
-                        <WalletIcon />
-                        Add to my crypto wallet
-                      </MenuButton>
-                    )}
-                  </Menu.Item>
+                  {!isUnlockAccount && (
+                    <Menu.Item>
+                      {({ active, disabled }) => (
+                        <MenuButton
+                          disabled={disabled}
+                          active={active}
+                          onClick={addToWallet}
+                        >
+                          <WalletIcon />
+                          Add to my crypto wallet
+                        </MenuButton>
+                      )}
+                    </Menu.Item>
+                  )}
                   {tokenId && isEthPassSupported(network) && (
                     <>
                       <Menu.Item>

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -39,7 +39,8 @@ export const useProvider = (config: any) => {
   const { addNetworkToWallet } = useAddToNetwork(connected)
   const { session: account, refetchSession } = useSession()
 
-  const isUnlockAccount = !!provider?.isUnlock
+  const isUnlockAccount =
+    !!provider?.isUnlock || (!provider && getStorage('provider') === 'UNLOCK')
   const email = provider?.emailAddress || getStorage('email')
   const encryptedPrivateKey = provider?.passwordEncryptedPrivateKey
 


### PR DESCRIPTION
# Description

`isUnlockAccount` is true even if the provider is not available as long as the stored provider is unlock!
We also use this to hide actions that the user cannot perform!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
