### PR TITLE
feat(governance): proposal to transfer remaining DAO's liquidity from uni v2 pool to migration multisig

### DIFF
--- a/governance/proposals/007-uniswap-v2-half-liquidity-tokens.js
+++ b/governance/proposals/007-uniswap-v2-half-liquidity-tokens.js
@@ -1,6 +1,6 @@
 /**
- * Example of a bridged proposal that will be sent across Connext to multisigs
- * on the other side of the network.
+ * Migrating 50% of Unlock DAO's existing UDT/WETH Liquidity Position
+ * from Uniswap v2 pool to the Uniswap v3 pool
  */
 const { ethers } = require('hardhat')
 const { getTokenInfo } = require('../helpers/uniswap')

--- a/governance/proposals/008-uniswap-v2-remaining-liquidity-tokens.js
+++ b/governance/proposals/008-uniswap-v2-remaining-liquidity-tokens.js
@@ -1,0 +1,114 @@
+/**
+ * Migrating Unlock DAO's remaining UDT/WETH Liquidity Position
+ * from Uniswap v2 pool to the Uniswap v3 pool
+ */
+const { ethers } = require('hardhat')
+const { getTokenInfo } = require('../helpers/uniswap')
+
+// const daoAddress = '0x440d9D4E66d39bb28FB58729Cb4D3ead2A595591'
+const timelockAddress = '0x17EEDFb0a6E6e06E95B3A1F928dc4024240BC76B'
+
+// remaining lp tokens
+const percentageToMigrate = 100
+const multisigAddress = '0xc3F2bcBE6fB42faC83dd8a42893C6c0B3809e070'
+const udtWethV2poolAddress = '0x9cA8AEf2372c705d6848fddA3C1267a7F51267C1'
+
+const poolV2Abi = [
+  'function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+  'function token0() external view returns (address)',
+  'function token1() external view returns (address)',
+  'function balanceOf(address) external view returns (uint256)',
+  'function transfer(address,uint256) external view',
+  'function approve(address,uint256) external',
+  'function totalSupply() external view returns (uint256)',
+  'function allowance(address, address) external view returns (uint256)',
+]
+
+module.exports = async () => {
+  console.log(
+    `Migrate ${percentageToMigrate}% of liquidity from v2 to multisig`
+  )
+
+  // parse call data for function call
+  const poolV2 = await ethers.getContractAt(poolV2Abi, udtWethV2poolAddress)
+  const poolV2Address = await poolV2.getAddress()
+
+  // pool v2 info
+  const [token0, token1, [reserve0, reserve1], totalSupply] = await Promise.all(
+    [
+      poolV2.token0(),
+      poolV2.token1(),
+      poolV2.getReserves(),
+      poolV2.totalSupply(),
+    ]
+  )
+
+  const [{ symbol: symbol0 }, { symbol: symbol1 }] = await Promise.all([
+    await getTokenInfo(token0),
+    await getTokenInfo(token1),
+  ])
+
+  // how many ERC20 owned by the timelock
+  const liquidity = await poolV2.balanceOf(timelockAddress)
+
+  // calculate the share of the entire liquidity for each token
+  // to determine the amount of tokens owned by the timelock in the pool
+  const lp0 = (liquidity * reserve0) / totalSupply
+  const lp1 = (liquidity * reserve1) / totalSupply
+
+  // Total amount of LP tokens to be transferred
+  const amountToTransfer = liquidity
+
+  // encode transfer call
+  const transferCalldata = poolV2.interface.encodeFunctionData('transfer', [
+    multisigAddress,
+    amountToTransfer,
+  ])
+
+  // return all calls parsed for the DAO to process
+  const calls = [
+    {
+      contractAddress: poolV2Address,
+      calldata: transferCalldata,
+      functionName: 'transfer', // explainer
+    },
+  ]
+  const proposalName = `Migrating the remaining amount of UDT/WETH Liquidity Position from Uniswap v2 pool
+
+### Goal of the proposal
+
+This proposal aims at moving the remaining amount (100%) of the liquidity tokens currently owned by the DAO in [Uniswap V2 UDT/WETH pool](https://etherscan.io/address/${poolV2Address}) to a [multisig](https://etherscan.io/address/${multisigAddress}) owned by trustees . This transfer is a necessary step towards the end goal: migrate the current V2 liquidty position to the UDT/WETH Uniswap v3 pool (without risking a sandwich attack during the migration).
+
+
+### Current situation of the ${symbol0}/${symbol1} V2 pool 
+
+Address: ${poolV2Address}
+
+#### DAO's liquidity tokens in V2 pool
+
+- total : ${liquidity.toString()}
+- **to transfer:${amountToTransfer.toString()}**
+
+For reference, the total DAO's liquidity in V2 pool is ${ethers.formatEther(
+    lp0
+  )} ${symbol0} and ${ethers.formatEther(lp1)} ${symbol1}.
+
+
+### About the proposal
+
+The proposal contains a single call to the v2 pool \`transfer\` function that will transfer half of that liquidity tokens to the multisig - \`transfer(${multisigAddress},${amountToTransfer.toString()})\`.
+
+Once approved and executed, the tokens will be transferred. The 5 signers of the multisig will take care of migrating the v2 position to the v3 pool.
+
+Thank you!
+The Unlock Team`
+
+  console.log(proposalName)
+  console.log(calls)
+
+  // send to multisig / DAO
+  return {
+    proposalName,
+    calls,
+  }
+}


### PR DESCRIPTION
# Description

here is the simulation of the call to be sent as proposal : https://dashboard.tenderly.co/shared/fork/3abe89cd-077f-49b1-95d6-d000ff888938/simulation/0410047c-d013-4b53-9013-691a7ddb7f44


execution can be tested from `governance` folder with :

```
RUN_FORK=1 yarn hardhat gov  --gov-address 0x440d9D4E66d39bb28FB58729Cb4D3ead2A595591  --proposal proposals/008-uniswap-v2-remaining-liquidity-tokens.js
```

Here is the text  (first line is the title)

---


# Migrating the remaining amount of UDT/WETH Liquidity Position from Uniswap v2 pool

### Goal of the proposal

This proposal aims at moving the remaining amount (100%) of the liquidity tokens currently owned by the DAO in [Uniswap V2 UDT/WETH pool](https://etherscan.io/address/0x9cA8AEf2372c705d6848fddA3C1267a7F51267C1) to a [multisig](https://etherscan.io/address/0xc3F2bcBE6fB42faC83dd8a42893C6c0B3809e070) owned by trustees . This transfer is a necessary step towards the end goal: migrate the current V2 liquidty position to the UDT/WETH Uniswap v3 pool (without risking a sandwich attack during the migration).


### Current situation of the UDT/WETH V2 pool

Address: 0x9cA8AEf2372c705d6848fddA3C1267a7F51267C1

#### DAO's liquidity tokens in V2 pool

- total : 85116245781832601704
- **to transfer:85116245781832601704**

For reference, the total DAO's liquidity in V2 pool is 2117.913872974150943852 UDT and 18.76683586595037034 WETH.


### About the proposal

The proposal contains a single call to the v2 pool `transfer` function that will transfer half of that liquidity tokens to the multisig - `transfer(0xc3F2bcBE6fB42faC83dd8a42893C6c0B3809e070,85116245781832601704)`.

Once approved and executed, the tokens will be transferred. The 5 signers of the multisig will take care of migrating the v2 position to the v3 pool.

Thank you!
The Unlock Team




