### PR TITLE
fix(locksmith): sold out locks are not claimable

### DIFF
--- a/locksmith/src/controllers/purchaseController.ts
+++ b/locksmith/src/controllers/purchaseController.ts
@@ -236,12 +236,21 @@ export class PurchaseController {
       const pricer = new KeyPricer()
 
       const fulfillmentDispatcher = new Dispatcher()
-      const totalAmount = await getTotalPurchasePriceInCrypto({
-        lockAddress,
-        network,
-        recipients,
-        data: data || [],
-      })
+      const [totalAmount, soldOut] = await Promise.all([
+        getTotalPurchasePriceInCrypto({
+          lockAddress,
+          network,
+          recipients,
+          data: data || [],
+        }),
+        isSoldOut(lockAddress, network, recipients.length),
+      ])
+
+      if (soldOut) {
+        return response.status(400).send({
+          message: 'Lock is sold out',
+        })
+      }
 
       if (totalAmount.gt(0)) {
         return response.status(400).send({

--- a/locksmith/src/routes/claim.ts
+++ b/locksmith/src/routes/claim.ts
@@ -6,7 +6,7 @@ const purchaseController = new PurchaseController()
 const router = express.Router({ mergeParams: true })
 
 // Disallow claim due to spam and bot activity
-const geoRestriction = createGeoRestriction(['RU', 'UA'])
+const geoRestriction = createGeoRestriction([])
 
 router.post(
   '/:network/locks/:lockAddress',


### PR DESCRIPTION
# Description

Our API that shows if a a key can be "claimed" from a lock should return false when the lock is sold out!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
