### PR TITLE
fix(smart-contracts): remove limitation on max number of keys

### DIFF
--- a/smart-contracts/contracts/mixins/MixinErrors.sol
+++ b/smart-contracts/contracts/mixins/MixinErrors.sol
@@ -40,7 +40,6 @@ contract MixinErrors {
   error OWNER_CANT_BE_ADDRESS_ZERO();
   error MAX_KEYS_REACHED();
   error KEY_TRANSFERS_DISABLED();
-  error CANT_BE_SMALLER_THAN_SUPPLY();
 
   // transfers and approvals
   error TRANSFER_TO_SELF();

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -599,9 +599,6 @@ contract MixinKeys is MixinErrors, MixinLockCore {
     if (_maxKeysPerAcccount == 0) {
       revert NULL_VALUE();
     }
-    if (_maxNumberOfKeys < _totalSupply) {
-      revert CANT_BE_SMALLER_THAN_SUPPLY();
-    }
     _maxKeysPerAddress = _maxKeysPerAcccount;
     expirationDuration = _newExpirationDuration;
     maxNumberOfKeys = _maxNumberOfKeys;

--- a/smart-contracts/test/Lock/updateLockConfig.js
+++ b/smart-contracts/test/Lock/updateLockConfig.js
@@ -74,15 +74,12 @@ contract('Lock / updateLockConfig', (accounts) => {
       await lock.updateLockConfig(expirationDuration, 201, maxKeysPerAddress)
       assert.equal((await lock.maxNumberOfKeys()).toNumber(), 201)
     })
-    it('should prevent from setting a value lower than total supply', async () => {
+    it('should allow setting a value lower than total supply', async () => {
       // buy 10 keys
       await purchaseKeys(lock, 10)
 
-      // increase supply
-      await reverts(
-        lock.updateLockConfig(expirationDuration, 5, maxKeysPerAddress),
-        'SMALLER_THAN_SUPPLY'
-      )
+      await lock.updateLockConfig(expirationDuration, 0, maxKeysPerAddress)
+      assert.equal((await lock.maxNumberOfKeys()).toNumber(), 0)
     })
     it('should allow setting a value equal to current total supply', async () => {
       // redeploy lock


### PR DESCRIPTION
# Description

We should not prevent a lock manager from setting a value lower than supply.
In practice we already allow for that state (number of keys > maxKeysForSale) because we let lock manager airdrop keys to users even when we are above the limit!

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
