### PR TITLE
fix(unlock-app): password and promocode hooks are not supported for renewals yet

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
+++ b/unlock-app/src/components/interface/checkout/main/checkoutMachine.ts
@@ -273,14 +273,14 @@ export const checkoutMachine = createMachine(
               actions: ['selectLock'],
               target: 'PASSWORD',
               cond: (_, event) => {
-                return event.hook === 'password'
+                return !event.expiredMember && event.hook === 'password'
               },
             },
             {
               actions: ['selectLock'],
               target: 'PROMO',
               cond: (_, event) => {
-                return event.hook === 'promocode'
+                return !event.expiredMember && event.hook === 'promocode'
               },
             },
             {


### PR DESCRIPTION
# Description

Skipping the password and promo screens when doing a renewal.
Later we will add support for these hooks on renewals, but not yet! https://github.com/unlock-protocol/unlock/issues/13226

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
