### PR TITLE
fix(unlock-js): not requiring the user to be a on a supported network…

### DIFF
--- a/packages/unlock-js/src/walletService.ts
+++ b/packages/unlock-js/src/walletService.ts
@@ -105,10 +105,7 @@ export default class WalletService extends UnlockService {
       this.networkId = networkId
     }
 
-    if (!this.networks[networkId]) {
-      throw new Error(`Missing config for ${networkId}`)
-    }
-    if (this.networks[networkId].unlockAddress) {
+    if (this.networks[networkId]?.unlockAddress) {
       this.unlockAddress = this.networks[networkId].unlockAddress
     }
     return networkId


### PR DESCRIPTION
# Description

This lets users who are on a network that we do not support still connect since we can ask them to change network later when they need to interact with the app!


# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
