### PR TITLE
fix(unlock-app): metadataInputs at the lock level

### DIFF
--- a/unlock-app/src/components/content/event/NewEvent.tsx
+++ b/unlock-app/src/components/content/event/NewEvent.tsx
@@ -24,26 +24,26 @@ export const defaultEventCheckoutConfigForLockOnNetwork = (
     locks: {
       [lockAddress]: {
         network: network,
+        metadataInputs: [
+          {
+            name: 'email',
+            type: 'email',
+            label: 'Email address (will receive the QR code)',
+            required: true,
+            placeholder: 'your@email.com',
+            defaultValue: '',
+          },
+          {
+            name: 'fullname',
+            type: 'text',
+            label: 'Full name',
+            required: true,
+            placeholder: 'Satoshi Nakamoto',
+            defaultValue: '',
+          },
+        ],
       },
     },
-    metadataInputs: [
-      {
-        name: 'email',
-        type: 'email',
-        label: 'Email address (will receive the QR code)',
-        required: true,
-        placeholder: 'your@email.com',
-        defaultValue: '',
-      },
-      {
-        name: 'fullname',
-        type: 'text',
-        label: 'Full name',
-        required: true,
-        placeholder: 'Satoshi Nakamoto',
-        defaultValue: '',
-      },
-    ],
   } as PaywallConfigType
 }
 


### PR DESCRIPTION
# Description

Moving metadataInputs at the lock level on default events checkout so it can be changed.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
