### PR TITLE
fix(locksmith): passing lockAdress as part of email sending so we can…

### DIFF
--- a/locksmith/src/controllers/v2/rsvpController.ts
+++ b/locksmith/src/controllers/v2/rsvpController.ts
@@ -82,8 +82,9 @@ export const rsvp = async (request: Request, response: Response) => {
     template: 'eventRsvpSubmitted',
     failoverTemplate: 'eventRsvpSubmitted',
     recipient: data.email,
-    // @ts-expect-error
+    // @ts-expect-error object incomplete
     params: {
+      lockAddress: lockAddress,
       eventName: eventDetail?.eventName,
       eventDate: eventDetail?.eventDate,
       eventTime: eventDetail?.eventTime,


### PR DESCRIPTION
# Description

Passing lockAdress as part of email sending so we can extract email settings

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
