### PR TITLE
feat(locksmith): adding a cache for the defilama API results

### DIFF
--- a/locksmith/src/operations/pricingOperations.ts
+++ b/locksmith/src/operations/pricingOperations.ts
@@ -6,6 +6,23 @@ import { Web3Service, getErc20Decimals } from '@unlock-protocol/unlock-js'
 import * as lockSettingOperations from './lockSettingOperations'
 import { Currencies } from '@unlock-protocol/core'
 import normalizer from '../utils/normalizer'
+import { MemoryCache } from 'memory-cache-node'
+
+interface DefiLamaResponse {
+  price?: number
+  symbol?: string
+  timestamp?: number
+  confidence?: number
+  priceInAmount?: number
+}
+
+// Price is cached for 5 minutes
+const pricingCacheDuration = 60 * 5
+// We check values every minute
+const defiLammaPriceCache = new MemoryCache<string, DefiLamaResponse>(
+  pricingCacheDuration / 5,
+  1000
+)
 
 interface Price {
   decimals: number
@@ -131,11 +148,9 @@ export const getPricingFromSettings = async ({
   return null
 }
 
-// TODO: add cache!
-export async function getDefiLammaPrice({
+export async function getDefiLammaPriceNoCache({
   network,
   erc20Address,
-  amount = 1,
 }: Options): Promise<PriceResults> {
   const networkConfig = networks[network]
   if (!network) {
@@ -177,12 +192,38 @@ export async function getDefiLammaPrice({
     return {}
   }
 
-  const priceInAmount = item.price * amount
-
   return {
     ...item,
-    priceInAmount,
   }
+}
+
+export async function getDefiLammaPrice({
+  network,
+  erc20Address,
+  amount = 1,
+}: Options): Promise<PriceResults> {
+  let pricing = defiLammaPriceCache.retrieveItemValue(
+    `${erc20Address}@${network}`
+  )
+  if (!pricing) {
+    pricing = await getDefiLammaPriceNoCache({
+      network,
+      erc20Address,
+      amount,
+    })
+    defiLammaPriceCache.storeExpiringItem(
+      `${erc20Address}@${network}`,
+      pricing,
+      pricingCacheDuration
+    )
+  }
+  if (pricing.price) {
+    return {
+      ...pricing,
+      priceInAmount: pricing.price * amount,
+    }
+  }
+  return pricing
 }
 
 /**

--- a/locksmith/src/worker/worker.ts
+++ b/locksmith/src/worker/worker.ts
@@ -30,7 +30,7 @@ const crontabProduction = `
 */5 * * * * addHookJobs
 0 0 * * * notifyExpiringKeysForNetwork
 0 0 * * * notifyExpiredKeysForNetwork
-0 */6 * * * checkBalances
+30 */6 * * * checkBalances
 `
 
 const cronTabTesting = `


### PR DESCRIPTION
# Description

I noticed a few errors in Sentry that /i suspect are related to us bumping into a rate limit.
Caching results for 5 minutes should help a lot (and also make things a bit faster!)

# Issues


Fixes https://unlock-protocol.sentry.io/issues/4597591358/?project=5685514&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=6


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
