### PR TITLE
feat(paywall): loadCheckoutModal now resolves when the modal is closed

### DIFF
--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/paywall",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "main": "./dist/unlock.latest.umd.js",
   "module": "./dist/unlock.latest.es.js",
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
# Description

By resolving we let 3rd party applications handle things on their own when the modal is closed.
This is requested by the team at Coinage/Best Dish Ever.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
