### PR TITLE
feat(unlock-app): hiding the field to customize the recipient address

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/useStepperItems.ts
+++ b/unlock-app/src/components/interface/checkout/main/useStepperItems.ts
@@ -80,7 +80,7 @@ export function useStepperItems(
       to: 'QUANTITY',
     },
     {
-      name: 'Add recipients',
+      name: 'Recipient(s)',
       to: 'METADATA',
       skip:
         (!hasOneLock


### PR DESCRIPTION
# Description

Hiding the field to customize the recipient address when skipRecipient is set. We then only show the metadata fields to be collected.

<img width="508" alt="Screenshot 2024-03-11 at 12 28 40 PM" src="https://github.com/unlock-protocol/unlock/assets/17735/167b1c3c-c24a-42f9-9d17-f79e29ab1541">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
