### PR TITLE
feat/implement-custom-endpoint-for-subgraph

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.44.0
+
+- adding the possibility to pass a custom url endpoint to the `SubgraphService` constructor.
+
 # 0.43.2
 
 - using `totalKeys` when possible (lock v11 and further)

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.43.2",
+  "version": "0.44.0",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/unlock-js/src/__tests__/subgraphCustomEndpoint.test.js
+++ b/packages/unlock-js/src/__tests__/subgraphCustomEndpoint.test.js
@@ -1,0 +1,15 @@
+/* eslint-disable prettier/prettier */
+import { describe, it, expect } from 'vitest'
+import { SubgraphService } from '../subgraph'
+
+describe('SubgraphService', () => {
+  it('creates SDK with provided endpoint URL', async () => {
+    const endpointUrl = 'https://test.endpoint.url';
+    const subgraphService = new SubgraphService(endpointUrl);
+
+    expect(subgraphService).toContain({
+      endpointUrl: endpointUrl
+    });
+    
+  })
+})

--- a/packages/unlock-js/src/subgraph/index.ts
+++ b/packages/unlock-js/src/subgraph/index.ts
@@ -25,15 +25,22 @@ interface QueryOptions {
 }
 
 export class SubgraphService {
-  networks: NetworkConfigs
-  constructor(networks?: NetworkConfigs) {
+  networks: NetworkConfigs;
+  endpointUrl?: string;
+  constructor(endpointUrl?: string, networks?: NetworkConfigs) {
     this.networks = networks || networkConfigs
+    this.endpointUrl = endpointUrl
   }
 
   createSdk(networkId = 1) {
     const network = this.networks[networkId]
+    const endpointUrl = this.endpointUrl
 
-    const client = new GraphQLClient(network.subgraph.endpoint!)
+    const GraphQLClientURL = endpointUrl
+      ? endpointUrl
+      : network.subgraph.endpoint!
+
+    const client = new GraphQLClient(GraphQLClientURL)
     const sdk = getSdk(client)
     return sdk
   }

--- a/packages/unlock-js/src/subgraph/index.ts
+++ b/packages/unlock-js/src/subgraph/index.ts
@@ -25,8 +25,8 @@ interface QueryOptions {
 }
 
 export class SubgraphService {
-  networks: NetworkConfigs;
-  endpointUrl?: string;
+  networks: NetworkConfigs
+  endpointUrl?: string
   constructor(endpointUrl?: string, networks?: NetworkConfigs) {
     this.networks = networks || networkConfigs
     this.endpointUrl = endpointUrl


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
The goal of this PR is to enable people to use their custom endpoint to perform queries.
If a endpoint is passed to the costructor then it will be used as the endpoint for each of the networks that will be queried.
If not, then everything remain the same as it is today.

I didn't touched anything else, life for example methods that were calling creatingSdk 'cause i thought that was not necessary at all.

I wrote a test to check if everything was working as expected.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
 I dunno if there's an issued open since we discussed this topic on the Unlock's discord server.
 The issue is that i need to use my personal Alchemy's endpoint to perform queries while still using the SubgraphService package that comes with Unlock.js

Refs #

![image](https://github.com/unlock-protocol/unlock/assets/80588981/5f2dcff6-53ca-494d-b1df-baf301d3e655)

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

The only change that is being made is that now is possible to pass an endpointUrl to the SubgraphService constructor.
If passed then the endpoint will be used to perform queries.
