### PR TITLE
feat(ci): add deploy key from 1password in gh-actions

### DIFF
--- a/.github/workflows/_subgraph.yml
+++ b/.github/workflows/_subgraph.yml
@@ -3,7 +3,7 @@ name: Subgraphs deployment
 on:
   workflow_call:
     secrets:
-      SUBGRAPH_DEPLOY_KEY:
+      SUBGRAPH_STUDIO_DEPLOY_KEY:
         required: true
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
-      SUBGRAPH_DEPLOY_KEY: ${{ secrets.SUBGRAPH_DEPLOY_KEY }}
+      SUBGRAPH_STUDIO_DEPLOY_KEY: ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,14 +10,14 @@ jobs:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
     uses: ./.github/workflows/_subgraph.yml
     secrets:
-      SUBGRAPH_DEPLOY_KEY: ${{ secrets.SUBGRAPH_DEPLOY_KEY }}
+      SUBGRAPH_STUDIO_DEPLOY_KEY: op://secrets/subgraph/studio-deploy-key
 
   deploy-locksmith-production:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
     uses: ./.github/workflows/_heroku.yml
     with:
       bypass_diff_check: bypass
-      service: locksmith
+      service: locksmith7df5e70995a89872e0ec80de04ca7251
       app-name: unlock-locksmith-production
     secrets:
       HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/_heroku.yml
     with:
       bypass_diff_check: bypass
-      service: locksmith7df5e70995a89872e0ec80de04ca7251
+      service: locksmith
       app-name: unlock-locksmith-production
     secrets:
       HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}


### PR DESCRIPTION
# Description

add `SUBGRAPH_STUDIO_DEPLOY_KEY` from 1password in gh-actions to automate subgraph on prod deploy

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
