### PR TITLE
feat(unlock-app): waits even in optimisitic checkout

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -130,7 +130,7 @@ export function Minting({
   const [doneWaiting, setDoneWaiting] = useState(false)
 
   useEffect(() => {
-    if (doneWaiting) {
+    if (doneWaiting || !mint) {
       return
     }
     const waitForTokenIds = async (): Promise<string[]> => {

--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -3,7 +3,7 @@ import { Connected } from '../Connected'
 import { Icon } from '@unlock-protocol/ui'
 import { RiExternalLinkLine as ExternalLinkIcon } from 'react-icons/ri'
 import { useConfig } from '~/utils/withConfig'
-import { Fragment, useEffect } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import { useActor } from '@xstate/react'
@@ -62,7 +62,6 @@ export const MintingScreen = ({
     }
   )
   const hasTokenId = !!tokenId
-
   return (
     <div className="flex flex-col items-center justify-evenly h-full space-y-2">
       <TransactionAnimation status={mint?.status} />
@@ -128,12 +127,12 @@ export function Minting({
   const config = useConfig()
   const { mint, lock, messageToSign, metadata, recipients } = state.context
   const processing = mint?.status === 'PROCESSING'
+  const [doneWaiting, setDoneWaiting] = useState(false)
 
   useEffect(() => {
-    if (mint?.status !== 'PROCESSING') {
+    if (doneWaiting) {
       return
     }
-
     const waitForTokenIds = async (): Promise<string[]> => {
       const web3Service = new Web3Service(networks)
 
@@ -188,6 +187,7 @@ export function Minting({
             network: mint!.network,
             transactionHash: mint!.transactionHash!,
           })
+          setDoneWaiting(true)
         }
       } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
# Description

We are waiting for the tx to complete and updating the UX, even if the user is not required to wait and they can just close the modal.

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #https://github.com/unlock-protocol/unlock/issues/13452
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
