### PR TITLE
feat(hardhat-plugin,contracts): bump contracts versions

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.23
+
+Add Unlock v13, PublicLock v14 and utils contracts
+
 ## 0.0.21
 
 - release fix post-attack on Fri Apr 21st 2023 #11690

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/contracts",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "main": "dist/index.js",
   "scripts": {
     "clean": "rm -rf dist docs",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 
-### 0.1.3
+### 0.1.4
 
 - Update default versions to Unlock 13 and PublicLock 14
+
+### 0.1.3
 
 ### 0.1.2
 

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.1.3
+
+- Update default versions to Unlock 13 and PublicLock 14
+
 ### 0.1.2
 
 - Changing the lock deployed version to the latest

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/hardhat-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Hardhat Plugin for Unlock Protocol",
   "author": "Unlock Protocol",
   "license": "MIT",

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/hardhat-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Hardhat Plugin for Unlock Protocol",
   "author": "Unlock Protocol",
   "license": "MIT",

--- a/packages/hardhat-plugin/src/constants.ts
+++ b/packages/hardhat-plugin/src/constants.ts
@@ -1,5 +1,5 @@
-export const UNLOCK_LATEST_VERSION = 11
-export const PUBLIC_LOCK_LATEST_VERSION = 13
+export const UNLOCK_LATEST_VERSION = 13
+export const PUBLIC_LOCK_LATEST_VERSION = 14
 
 // task names
 export const TASK_CREATE_LOCK = 'unlock:create-lock'


### PR DESCRIPTION
# Description

This updates default versions to Unlock 13 and PublicLock 14 when deploying protocol from hardhat plugin (currently used in integration tests)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
