### PR TITLE
feat(contracts): add aliases for latest versions of the contracts

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -37,9 +37,9 @@ import UnlockDiscountTokenV3 from './abis/UnlockDiscountToken/UnlockDiscountToke
 import GovernorUnlockProtocol from './abis/Governor/UnlockProtocolGovernor.json'
 import GovernorUnlockProtocolTimelock from './abis/Governor/UnlockProtocolTimelock.json'
 import LockSerializer from './abis/utils/LockSerializer.json'
-import UnlockSwapPurchaser from './abis/utils/UnlockSwapPurchaser.json'
-import UnlockSwapBurner from './abis/utils/UnlockSwapBurner.json'
 import UniswapOracleV3 from './abis/utils/UniswapOracleV3.json'
+import UnlockSwapBurner from './abis/utils/UnlockSwapBurner.json'
+import UnlockSwapPurchaser from './abis/utils/UnlockSwapPurchaser.json'
 
 // exports
 export { PublicLockV0 }
@@ -77,9 +77,15 @@ export { UnlockDiscountTokenV2 }
 export { UnlockDiscountTokenV3 }
 export { GovernorUnlockProtocol }
 export { GovernorUnlockProtocolTimelock }
-export {
-  LockSerializer,
-  UnlockSwapPurchaser,
-  UnlockSwapBurner,
-  UniswapOracleV3,
-}
+export { LockSerializer }
+export { UniswapOracleV3 }
+export { UnlockSwapBurner }
+export { UnlockSwapPurchaser }
+
+// latest
+export { PublicLockV14 as PublicLock }
+const PUBLICLOCK_LATEST_VERSION = 14
+export { PUBLICLOCK_LATEST_VERSION }
+export { UnlockV13 as Unlock }
+const UNLOCK_LATEST_VERSION = 13
+export { UNLOCK_LATEST_VERSION }

--- a/packages/contracts/src/utils/files.ts
+++ b/packages/contracts/src/utils/files.ts
@@ -36,6 +36,7 @@ export const getAbiPaths = async () => {
     'abis/Unlock',
     'abis/UnlockDiscountToken',
     'abis/Governor',
+    'abis/utils',
   ]
 
   const paths = await Promise.all(folders.map((f) => parseExports(f)))

--- a/packages/contracts/src/utils/parser.ts
+++ b/packages/contracts/src/utils/parser.ts
@@ -1,11 +1,39 @@
 import { getAbiPaths } from './files'
 
+type contractVersion = {
+  contractName: string
+  versionNumber: string
+  abiPath: string
+}
+
+const findLatest = (exports: contractVersion[], contract: string) => {
+  const [latest] = exports
+    .filter(({ contractName }) => contractName === contract)
+    .sort(
+      ({ versionNumber: a }, { versionNumber: b }) =>
+        parseInt(b.replace('V', '')) - parseInt(a.replace('V', ''))
+    )
+  const { contractName, versionNumber } = latest
+  const varName = `${contract.toLocaleUpperCase()}_LATEST_VERSION`
+  const versionInt = versionNumber.replace('V', '')
+
+  console.log(`export { ${contractName}${versionNumber} as ${contract} }`)
+  console.log(`const ${varName} = ${versionInt}`)
+  console.log(`export { ${varName} }`)
+  return latest
+}
+
 async function main() {
   const paths = await getAbiPaths()
-  const exports = paths.flat().map((abiPath) => {
-    const s = abiPath.split('/')
-    const contractName = s[2]
-    const versionNumber = s[3].replace(contractName, '').replace('.json', '')
+  const exports: contractVersion[] = paths.flat().map((abiPath) => {
+    let contractName, fileName, versionNumber
+    if (abiPath.includes('/utils/')) {
+      ;[, , , fileName] = abiPath.split('/')
+      contractName = fileName.replace('.json', '')
+    } else {
+      ;[, , contractName, fileName] = abiPath.split('/')
+      versionNumber = fileName.replace(contractName, '').replace('.json', '')
+    }
     return {
       contractName,
       versionNumber,
@@ -16,28 +44,20 @@ async function main() {
   console.log("// This file is generated, please don't edit directly")
   console.log("// Refer to 'utils/parser.ts' and 'yarn build:index' for more\n")
 
-  exports.forEach(({ contractName, versionNumber, abiPath }) =>
+  exports.forEach(({ contractName, versionNumber = '', abiPath }) =>
     console.log(`import ${contractName}${versionNumber} from '${abiPath}'`)
   )
 
-  const utils = [
-    'LockSerializer',
-    'UnlockSwapPurchaser',
-    'UnlockSwapBurner',
-    'UniswapOracleV3',
-  ]
-
-  utils.forEach((util) => {
-    console.log(`import ${util} from './abis/utils/${util}.json'`)
-  })
-
   console.log('\n// exports')
 
-  exports.forEach(({ contractName, versionNumber }) =>
+  exports.forEach(({ contractName, versionNumber = '' }) =>
     console.log(`export { ${contractName}${versionNumber} }`)
   )
 
-  console.log(`export { ${utils.toString()} }`)
+  // alias for the newest versions
+  console.log('\n// latest')
+  findLatest(exports, 'PublicLock')
+  findLatest(exports, 'Unlock')
 }
 
 main()


### PR DESCRIPTION
# Description

This creates a consistent way to check the latest supported versions of Unlock and PublicLock by adding exports to our contracts package. That will prevent errors where various packages get out of sync across the monorepo

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
