### PR TITLE
feat(governance) refactored the script to check multisig signers and settings

### DIFF
--- a/governance/scripts/multisig/_helpers.js
+++ b/governance/scripts/multisig/_helpers.js
@@ -18,11 +18,10 @@ const getProvider = async (chainId) => {
 
 // custom services URL for network not supported by Safe
 const safeServiceURLs = {
-  42220: 'http://mainnet-tx-svc.celo-safe-prod.celo-networks-dev.org/',
-  // mumbai isnt supported by Safe Global, you need to run Safe infrastructure locally
-  80001: 'http://localhost:8000/cgw/',
-  // for some reasons, zkevm throws in lib
-  1101: 'https://safe-transaction-zkevm.safe.global',
+  324: 'https://safe-transaction-zksync.safe.global/api',
+  1101: 'https://safe-transaction-zkevm.safe.global/api',
+  534352: 'https://transaction.safe.scroll.xyz/api',
+  59144: 'https://safe.linea.build/api',
 }
 
 // get safeAddress directly from unlock if needed

--- a/governance/scripts/multisig/addOwner.js
+++ b/governance/scripts/multisig/addOwner.js
@@ -1,5 +1,4 @@
 const { ethers } = require('hardhat')
-
 const { getNetwork } = require('@unlock-protocol/hardhat-helpers')
 const Safe = require('@safe-global/protocol-kit').default
 const { EthersAdapter } = require('@safe-global/protocol-kit')

--- a/governance/scripts/multisig/info.js
+++ b/governance/scripts/multisig/info.js
@@ -5,8 +5,25 @@ const { networks } = require('@unlock-protocol/networks')
 
 const SafeApiKit = require('@safe-global/api-kit').default
 
-const getMultigiInfo = async (chainId, multisig) => {
+const prodSigners = [
+  '0x9d3ea9e9adde71141f4534dB3b9B80dF3D03Ee5f', // cc
+  '0x4Ce2DD8373ECe0d7baAA16E559A5817CC875b16a', // jg
+  '0x4011d09a86D0acA8377a4A8baD691F1ACeeCd672', // nf
+  '0xcFd35259E3A468E7bDF84a95bCddAc0B614A9212', // aa
+  '0xccb5D94FbfBFDc4953Ca8a114f88773C2fF98e80', // sm
+  '0x246A13358Fb27523642D86367a51C2aEB137Ac6C', // cr
+].sort()
+
+const devSigners = [
+  '0x4Ce2DD8373ECe0d7baAA16E559A5817CC875b16a', // jg
+  '0x246A13358Fb27523642D86367a51C2aEB137Ac6C', // cr
+  '0x9d3ea9e9adde71141f4534dB3b9B80dF3D03Ee5f', // cc
+].sort()
+
+const getMultiSigInfo = async (chainId, multisig) => {
   const errors = []
+  const { isTestNetwork } = networks[chainId]
+  const expectedSigners = isTestNetwork ? devSigners : prodSigners
   const provider = await getProvider(chainId)
   // get Safe service
   const safeService = new SafeApiKit({
@@ -26,24 +43,37 @@ const getMultigiInfo = async (chainId, multisig) => {
   //   queued: false,
   // })
 
-  const safe = new ethers.Contract(multisig, multisigABI, provider)
-  const owners = await safe.getOwners()
-  const policy = await safe.getThreshold()
   if (!multisig) {
     errors.push('Missing multisig')
   } else {
-    if (policy == 1) {
-      errors.push('❌ Single policy owner!')
+    const safe = new ethers.Contract(multisig, multisigABI, provider)
+    const owners = await safe.getOwners()
+    const policy = await safe.getThreshold()
+
+    if (isTestNetwork && policy < 2) {
+      errors.push('❌ Policy below 2!')
     }
-    if (policy <= 2 || policy / BigInt(owners.length) > 1.5) {
-      errors.push(`Low policy owner (${policy}/${owners.length})`)
+    if (!isTestNetwork && policy < 4) {
+      errors.push(
+        `❌ Unexpected policy: ${policy}/${owners.length} for 4/${expectedSigners.length} expected`
+      )
+    }
+
+    let extraSigners = owners.filter((x) => !expectedSigners.includes(x))
+    if (extraSigners.length > 0) {
+      errors.push(`❌ Extra signers: ${[...extraSigners].sort()}`)
+    }
+
+    let missingSigners = expectedSigners.filter((x) => !owners.includes(x))
+    if (missingSigners.length > 0) {
+      errors.push(`❌ Missing signers: ${missingSigners}`)
     }
   }
   return errors
 }
 
-const log = (name, chainId, msg) =>
-  console.log(`[${name} (${chainId})]: ${msg}`)
+const log = (name, chainId, multisig, msg) =>
+  console.log(`[${name} (${chainId})]: ${multisig} ${msg}`)
 
 async function main() {
   for (let chainId in networks) {
@@ -52,11 +82,11 @@ async function main() {
     const { multisig, name } = networks[chainId]
 
     try {
-      errors = await getMultigiInfo(chainId, multisig)
+      errors = await getMultiSigInfo(chainId, multisig)
     } catch (error) {
       errors = [`Couldn't fetch multisig info: ${error.message}`]
     }
-    errors.forEach((error) => log(name, chainId, error))
+    errors.forEach((error) => log(name, chainId, multisig, error))
   }
 }
 


### PR DESCRIPTION
# Description

In order to make sure we have everything set-up and cleaned up, I am refactoring the mutlsig check!
Here is the current output:

```
[Ethereum (1)]: 0x9168EABE624e9515f3836bA1716EC1DDd4C461D4 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Goerli (5)]: 0x95C06469e557d8645966077891B4aeDe8D55A755 Couldn't fetch multisig info: request to https://safe-transaction-goerli.safe.global/api/v1/safes/0x95C06469e557d8645966077891B4aeDe8D55A755/ failed, reason: getaddrinfo ENOTFOUND safe-transaction-goerli.safe.global
[Optimism (10)]: 0x6E78b4447e34e751EC181DCBed63633aA753e145 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[BNB Chain (56)]: 0x373D7cbc4F2700719DEa237500c7a154310B0F9B ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Gnosis Chain (100)]: 0xfAC611a5b5a578628C28F77cEBDDB8C6159Ae79D ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Polygon (137)]: 0x479f3830fbd715342868BA95E438609BCe443DFB ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[zkSync Era (324)]: 0xFa5592CE9C52FA5214ccEa10cB72Faa88eC80a3c ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[zkEVM (Polygon) (1101)]: 0xD62EF39c54d9100B17c8fA3C2D15e0262338AED0 2 pending txs are waiting to be signed
[zkEVM (Polygon) (1101)]: 0xD62EF39c54d9100B17c8fA3C2D15e0262338AED0 ❌ Unexpected policy: 2/9 for 4/6 expected
[zkEVM (Polygon) (1101)]: 0xD62EF39c54d9100B17c8fA3C2D15e0262338AED0 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[localhost (31337)]: undefined Couldn't fetch multisig info: There is no transaction service available for chainId 31337. Please set the txServiceUrl property to use a custom transaction service.
[Arbitrum (42161)]: 0x310e9f9E3918a71dB8230cFCF32a083c7D9536d0 1 pending txs are waiting to be signed
[Arbitrum (42161)]: 0x310e9f9E3918a71dB8230cFCF32a083c7D9536d0 ❌ Unexpected policy: 2/10 for 4/6 expected
[Arbitrum (42161)]: 0x310e9f9E3918a71dB8230cFCF32a083c7D9536d0 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b,0xDD8e2548da5A992A63aE5520C6bC92c37a2Bcc44
[Celo (42220)]: 0xc293E2da9E558bD8B1DFfC4a7b174729fAb2e4E8 1 pending txs are waiting to be signed
[Celo (42220)]: 0xc293E2da9E558bD8B1DFfC4a7b174729fAb2e4E8 ❌ Unexpected policy: 2/9 for 4/6 expected
[Celo (42220)]: 0xc293E2da9E558bD8B1DFfC4a7b174729fAb2e4E8 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Avalanche (C-Chain) (43114)]: 0xEc7777C51327917fd2170c62873272ea168120Cb 3 pending txs are waiting to be signed
[Avalanche (C-Chain) (43114)]: 0xEc7777C51327917fd2170c62873272ea168120Cb ❌ Unexpected policy: 3/8 for 4/6 expected
[Avalanche (C-Chain) (43114)]: 0xEc7777C51327917fd2170c62873272ea168120Cb ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Avalanche (C-Chain) (43114)]: 0xEc7777C51327917fd2170c62873272ea168120Cb ❌ Missing signers: 0x9d3ea9e9adde71141f4534dB3b9B80dF3D03Ee5f
[Linea (59144)]: undefined Couldn't fetch multisig info: Cannot read properties of undefined (reading 'split')
[Mumbai (Polygon) (80001)]: 0x12E37A8880801E1e5290c815a894d322ac591607 Couldn't fetch multisig info: There is no transaction service available for chainId 80001. Please set the txServiceUrl property to use a custom transaction service.
[Scroll (534352)]: 0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172 1 pending txs are waiting to be signed
[Scroll (534352)]: 0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172 ❌ Unexpected policy: 2/8 for 4/6 expected
[Scroll (534352)]: 0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172 ❌ Extra signers: 0x2785f2a3DDaCfDE5947F1A9D6c878CCD7F885400,0x7A23608a8eBe71868013BDA0d900351A83bb4Dc2,0x8de33D8204929ceb2F7AA6299d0643a7f6664c9b
[Scroll (534352)]: 0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172 ❌ Missing signers: 0x9d3ea9e9adde71141f4534dB3b9B80dF3D03Ee5f
```

The Goerli and Mumbai failures are due to these networks being deprecated and we will remove them on our end shortly.
The localhost one will soon go away (as soon as https://github.com/unlock-protocol/unlock/pull/13321 gets merged).

For zkEVM, the [transaction to change the policy to 4 is up](https://app.safe.global/transactions/queue?safe=zkevm:0xD62EF39c54d9100B17c8fA3C2D15e0262338AED0). Please don't sign the rejection!

For Celo, the [transaction to change the policy to 4 is up](https://app.safe.global/transactions/queue?safe=celo:0xc293E2da9E558bD8B1DFfC4a7b174729fAb2e4E8). 

For Avax, we have [the following transactions](https://app.safe.global/transactions/queue?safe=avax:0xEc7777C51327917fd2170c62873272ea168120Cb):
* protocol upgrade
* add a signer
* change the policy from 2 to 4!

For scroll, the [transaction to change the policy to 4 is up](https://safe.scroll.xyz/transactions/tx?id=multisig_0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172_0x1613963047e13b69a69cc0ced4c15a13cbf2dd23b56b4576628ba9591920cd1e&safe=scr:0x0feE9413A626a05a08AcB0E0e5D6A483e6A0a172)

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
