### PR TITLE
feat(governance): cleaner logs when pulling proxy admin address

### DIFF
--- a/governance/scripts/getters/unlock-info.js
+++ b/governance/scripts/getters/unlock-info.js
@@ -28,21 +28,21 @@ async function main({ unlockAddress, quiet = false }) {
   const proxyAdminOwner = await proxyAdmin.owner()
 
   if (proxyAdminOwner !== unlockOwner) {
-    errorLog(`Unlock contract and ProxyAdmin have different owners!`)
+    errorLog(`Unlock contract and ProxyAdmin have different owners`)
   }
   if (proxyAdminOwner !== safeAddress) {
-    errorLog(`ProxyAdmin owner is not the team multisig!`)
+    errorLog(`ProxyAdmin owner is not the team multisig`)
   }
 
   let nbOwners
   try {
     nbOwners = (await getOwners({ safeAddress: unlockOwner })).length
   } catch (error) {
-    errorLog(`Unlock owner is not the team multisig!`)
+    errorLog(`Unlock owner is not the team multisig`)
   }
 
   if (nbOwners && !isMultisig) {
-    errorLog(`Multisig in networks package does not match with Unlock owner!`)
+    errorLog(`Multisig in networks package does not match with Unlock owner`)
   }
 
   if (!quiet) {

--- a/governance/scripts/getters/unlock-info.js
+++ b/governance/scripts/getters/unlock-info.js
@@ -1,9 +1,5 @@
 const { ethers } = require('hardhat')
-const {
-  getNetwork,
-  getUnlock,
-  getProxyAdminAddress,
-} = require('@unlock-protocol/hardhat-helpers')
+const { getNetwork, getUnlock } = require('@unlock-protocol/hardhat-helpers')
 const {
   abi: proxyAdminABI,
 } = require('@unlock-protocol/hardhat-helpers/dist/ABIs/ProxyAdmin.json')
@@ -12,7 +8,7 @@ const getOwners = require('../multisig/owners')
 
 async function main({ unlockAddress, quiet = false }) {
   let safeAddress
-  const { id: chainId, name } = await getNetwork()
+  const { name } = await getNetwork()
   if (!unlockAddress) {
     ;({ unlockAddress, multisig: safeAddress } = await getNetwork())
   }
@@ -23,20 +19,13 @@ async function main({ unlockAddress, quiet = false }) {
   const unlockOwner = await unlock.owner()
   const isMultisig = safeAddress === unlockOwner
 
-  let proxyAdminAddress, proxyAdminOwner
-  try {
-    proxyAdminAddress = await getProxyAdminAddress({ chainId })
-  } catch (error) {
-    errorLog(`ERROR: Failed to fetch ProxyAdmin address`)
-  }
+  const proxyAdminAddress = await unlock.getAdmin()
 
-  if (proxyAdminAddress) {
-    const proxyAdmin = await ethers.getContractAt(
-      proxyAdminABI,
-      proxyAdminAddress
-    )
-    proxyAdminOwner = await proxyAdmin.owner()
-  }
+  const proxyAdmin = await ethers.getContractAt(
+    proxyAdminABI,
+    proxyAdminAddress
+  )
+  const proxyAdminOwner = await proxyAdmin.owner()
 
   if (proxyAdminOwner !== unlockOwner) {
     errorLog(`Unlock contract and ProxyAdmin have different owners!`)

--- a/governance/scripts/getters/unlock-info.js
+++ b/governance/scripts/getters/unlock-info.js
@@ -30,12 +30,15 @@ async function main({ unlockAddress, quiet = false }) {
   if (proxyAdminOwner !== unlockOwner) {
     errorLog(`Unlock contract and ProxyAdmin have different owners!`)
   }
+  if (proxyAdminOwner !== safeAddress) {
+    errorLog(`ProxyAdmin owner is not the team multisig!`)
+  }
 
   let nbOwners
   try {
     nbOwners = (await getOwners({ safeAddress: unlockOwner })).length
   } catch (error) {
-    errorLog(`Unlock owner is not the team multisig (${safeAddress})!`)
+    errorLog(`Unlock owner is not the team multisig!`)
   }
 
   if (nbOwners && !isMultisig) {
@@ -49,7 +52,8 @@ async function main({ unlockAddress, quiet = false }) {
       `-  unlockVersion: ${await unlock.unlockVersion()} \n`,
       `-  publicLockVersion: ${await unlock.publicLockLatestVersion()} \n`,
       `-  owner: ${unlockOwner} ${nbOwners ? `(${nbOwners} owners)` : ''}\n`,
-      `-  proxyAdminAddress: ${proxyAdminAddress} \n`
+      `-  proxyAdminAddress: ${proxyAdminAddress} \n`,
+      `-  multisig: ${safeAddress} \n`
     )
   }
 }

--- a/packages/hardhat-helpers/src/networks.js
+++ b/packages/hardhat-helpers/src/networks.js
@@ -17,6 +17,9 @@ const networks = require('@unlock-protocol/networks')
  * @returns
  */
 const { DEPLOYER_PRIVATE_KEY } = process.env
+console.error(
+  `⚠️ Missing DEPLOYER_PRIVATE_KEY environment variable. Please set one. In the meantime, we will use default settings`
+)
 const getAccounts = () => {
   if (process.env.CI === 'true') {
     return {
@@ -28,9 +31,6 @@ const getAccounts = () => {
     return [DEPLOYER_PRIVATE_KEY]
   }
 
-  console.error(
-    `Missing DEPLOYER_PRIVATE_KEY environment variable. Please set one. In the meantime, we will use default settings`
-  )
   return {
     mnemonic: 'test test test test test test test test test test test junk',
     initialIndex: 0,

--- a/packages/hardhat-helpers/src/networks.js
+++ b/packages/hardhat-helpers/src/networks.js
@@ -17,9 +17,17 @@ const networks = require('@unlock-protocol/networks')
  * @returns
  */
 const { DEPLOYER_PRIVATE_KEY } = process.env
-console.error(
-  `⚠️ Missing DEPLOYER_PRIVATE_KEY environment variable. Please set one. In the meantime, we will use default settings`
-)
+
+if (!DEPLOYER_PRIVATE_KEY) {
+  console.error(
+    `⚠️ Missing DEPLOYER_PRIVATE_KEY environment variable. Please set one. In the meantime, we will use default settings`
+  )
+} else {
+  console.error(
+    `⚠️ Using account from DEPLOYER_PRIVATE_KEY environment variable.`
+  )
+}
+
 const getAccounts = () => {
   if (process.env.CI === 'true') {
     return {


### PR DESCRIPTION
# Description

This improves the way the proxy admin is fetched (now directly from Unlock). Also some addition, reducing the annoying warning for deployer private key

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
