### PR TITLE
feat(unlock-app): better loading UI for the Wallet-less registration block

### DIFF
--- a/packages/ui/lib/components/Placeholder/Card.tsx
+++ b/packages/ui/lib/components/Placeholder/Card.tsx
@@ -1,7 +1,7 @@
 import { classed } from '@tw-classed/react'
 
 export const Card = classed.div(
-  'w-full rounded-2xl animate-pulse bg-gray-100',
+  'w-full rounded-2xl animate-pulse bg-gray-200',
   {
     variants: {
       size: {

--- a/packages/ui/lib/components/Placeholder/Image.tsx
+++ b/packages/ui/lib/components/Placeholder/Image.tsx
@@ -1,6 +1,6 @@
 import { classed } from '@tw-classed/react'
 
-export const Image = classed.div('bg-gray-100 animate-pulse', {
+export const Image = classed.div('bg-gray-200 animate-pulse', {
   variants: {
     size: {
       sm: 'h-24 w-24',

--- a/packages/ui/lib/components/Placeholder/Line.tsx
+++ b/packages/ui/lib/components/Placeholder/Line.tsx
@@ -1,6 +1,6 @@
 import { classed } from '@tw-classed/react'
 
-export const Line = classed.div('bg-gray-100 rounded-xl animate-pulse', {
+export const Line = classed.div('bg-gray-200 rounded-xl animate-pulse', {
   variants: {
     size: {
       sm: 'h-4',

--- a/unlock-app/src/components/content/event/Registration/LoadingRegistrationCard.tsx
+++ b/unlock-app/src/components/content/event/Registration/LoadingRegistrationCard.tsx
@@ -1,0 +1,18 @@
+import { Placeholder } from '@unlock-protocol/ui'
+
+export const LoadingRegistrationCard = () => {
+  return (
+    <>
+      <Placeholder.Root>
+        <Placeholder.Line width="sm" />
+        <Placeholder.Line width="sm" />
+        <Placeholder.Line width="lg" />
+      </Placeholder.Root>
+      <Placeholder.Root inline>
+        <Placeholder.Line width="sm" />
+        <Placeholder.Line width="sm" />
+        <Placeholder.Line width="lg" />
+      </Placeholder.Root>
+    </>
+  )
+}

--- a/unlock-app/src/components/content/event/Registration/LockPriceDetails.tsx
+++ b/unlock-app/src/components/content/event/Registration/LockPriceDetails.tsx
@@ -98,9 +98,12 @@ export const LockPriceDetails = ({
 
   if (isLockLoading || !lock) {
     return (
-      <Placeholder.Root inline>
-        <Placeholder.Line width="sm" />
-        <Placeholder.Line width="sm" />
+      <Placeholder.Root>
+        <Placeholder.Line width="md" />
+        <Placeholder.Root inline>
+          <Placeholder.Line width="sm" />
+          <Placeholder.Line width="sm" />
+        </Placeholder.Root>
       </Placeholder.Root>
     )
   }

--- a/unlock-app/src/components/content/event/Registration/RegistrationCard.tsx
+++ b/unlock-app/src/components/content/event/Registration/RegistrationCard.tsx
@@ -1,4 +1,3 @@
-import { Placeholder } from '@unlock-protocol/ui'
 import { LockPriceDetails } from './LockPriceDetails'
 import { Card } from '@unlock-protocol/ui'
 import { PaywallConfigType } from '@unlock-protocol/core'
@@ -6,6 +5,7 @@ import { RegistrationCardSingleLock } from './SingleLock'
 import { useValidKeyBulk } from '~/hooks/useKey'
 import { HasTicket } from './HasTicket'
 import { EmbeddedCheckout } from './EmbeddedCheckout'
+import { LoadingRegistrationCard } from './LoadingRegistrationCard'
 
 export interface RegistrationCardProps {
   checkoutConfig: {
@@ -26,12 +26,16 @@ export const RegistrationCard = ({
   }
 
   const isLoadingValidKeys = queries?.some(
-    (query) => query.isInitialLoading || query.isRefetching
+    (query) => query.isInitialLoading || query.isRefetching || query.isLoading
   )
   const hasValidKey = queries?.map((query) => query.data).some((value) => value)
 
   if (isLoadingValidKeys) {
-    return <Placeholder.Card size="md" />
+    return (
+      <Card className="grid gap-4 mt-10 lg:mt-0">
+        <LoadingRegistrationCard />
+      </Card>
+    )
   }
 
   if (hasValidKey) {

--- a/unlock-app/src/components/content/event/Registration/SingleLock/index.tsx
+++ b/unlock-app/src/components/content/event/Registration/SingleLock/index.tsx
@@ -6,13 +6,13 @@ import {
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { ZERO } from '~/components/interface/locks/Create/modals/SelectCurrencyModal'
 import { LockPriceInternals } from '../LockPriceDetails'
-import { Placeholder } from '@unlock-protocol/ui'
 import { useGetLockCurrencySymbol } from '~/hooks/useSymbol'
 import { UNLIMITED_KEYS_COUNT } from '~/constants'
 import { useLockData } from '~/hooks/useLockData'
 import { EmbeddedCheckout } from '../EmbeddedCheckout'
 import { PaywallConfigType } from '@unlock-protocol/core'
 import { emailInput } from '~/components/interface/checkout/main/Metadata'
+import { LoadingRegistrationCard } from '../LoadingRegistrationCard'
 
 export interface RegistrationCardSingleLockProps {
   checkoutConfig: {
@@ -70,13 +70,7 @@ export const RegistrationCardSingleLock = ({
   const showApplication = requiresApproval || lock?.maxNumberOfKeys == 0
 
   if (isLockLoading || isClaimableLoading || !lock) {
-    return (
-      <Placeholder.Root inline>
-        <Placeholder.Line width="sm" />
-        <Placeholder.Line width="sm" />
-        <Placeholder.Line width="lg" />
-      </Placeholder.Root>
-    )
+    return <LoadingRegistrationCard />
   }
 
   const metadataInputs =


### PR DESCRIPTION
# Description

Increasing the side of the loader, but also its contrast. This will affect all Placeholders in the app!

<img width="589" alt="Screenshot 2024-04-01 at 5 11 48 PM" src="https://github.com/unlock-protocol/unlock/assets/17735/4f0055a7-b74b-4b71-90a9-e9195178b97f">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
