### PR TITLE
feature: ask organizers to setup the reply to email when they create the event

### DIFF
--- a/locksmith/src/controllers/v2/eventsController.ts
+++ b/locksmith/src/controllers/v2/eventsController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express'
 import {
   getEventBySlug,
-  getEventDataForLock,
+  getEventMetadataForLock,
   saveEvent,
 } from '../../operations/eventOperations'
 import normalizer from '../../utils/normalizer'
@@ -19,7 +19,7 @@ export const getEventDetailsByLock: RequestHandler = async (
 ) => {
   const network = Number(request.params.network)
   const lockAddress = normalizer.ethereumAddress(request.params.lockAddress)
-  const eventDetails = await getEventDataForLock(lockAddress, network)
+  const eventDetails = await getEventMetadataForLock(lockAddress, network)
   return response.status(200).send(eventDetails)
 }
 

--- a/locksmith/src/controllers/v2/rsvpController.ts
+++ b/locksmith/src/controllers/v2/rsvpController.ts
@@ -6,7 +6,7 @@ import { KeyManager } from '@unlock-protocol/unlock-js'
 import { UserMetadata } from './metadataController'
 import { Rsvp } from '../../models'
 import { sendEmail } from '../../operations/wedlocksOperations'
-import { getEventDataForLock } from '../../operations/eventOperations'
+import { getEventMetadataForLock } from '../../operations/eventOperations'
 
 const RsvpBody = z.object({
   data: z.record(z.string(), z.string()),
@@ -76,7 +76,7 @@ export const rsvp = async (request: Request, response: Response) => {
   })
 
   // Then, send email
-  const eventDetail = await getEventDataForLock(lockAddress, network)
+  const eventDetail = await getEventMetadataForLock(lockAddress, network)
   sendEmail({
     network,
     template: 'eventRsvpSubmitted',

--- a/locksmith/src/operations/lockSettingOperations.ts
+++ b/locksmith/src/operations/lockSettingOperations.ts
@@ -52,6 +52,8 @@ export async function getSettings({
     },
   })
 
+  // Also check if this is part of an event and then let the event take precedence!
+
   const res = settings || DEFAULT_LOCK_SETTINGS
   attributesExcludes.forEach((attr) => {
     // @ts-expect-error Element implicitly has an 'any' type because expression of type 'string' can't be used to index type

--- a/locksmith/src/operations/lockSettingOperations.ts
+++ b/locksmith/src/operations/lockSettingOperations.ts
@@ -4,6 +4,7 @@ import {
 } from '../controllers/v2/lockSettingController'
 import { LockSetting } from '../models/lockSetting'
 import * as Normalizer from '../utils/normalizer'
+import { getEventForLock } from './eventOperations'
 
 interface SendEmailProps {
   lockAddress: string
@@ -52,15 +53,24 @@ export async function getSettings({
     },
   })
 
-  // Also check if this is part of an event and then let the event take precedence!
+  const lockSettings = settings || DEFAULT_LOCK_SETTINGS
 
-  const res = settings || DEFAULT_LOCK_SETTINGS
+  const eventDetails = await getEventForLock(lockAddress, network)
+  if (eventDetails?.data) {
+    if (eventDetails?.data.replyTo) {
+      lockSettings.replyTo = eventDetails.data.replyTo
+    }
+    if (eventDetails?.data.emailSender) {
+      lockSettings.emailSender = eventDetails.data.emailSender
+    }
+  }
+
   attributesExcludes.forEach((attr) => {
     // @ts-expect-error Element implicitly has an 'any' type because expression of type 'string' can't be used to index type
-    delete res[attr]
+    delete lockSettings[attr]
   })
 
-  return res
+  return lockSettings
 }
 
 export async function getLockSettingsBySlug(

--- a/locksmith/src/operations/metadataOperations.ts
+++ b/locksmith/src/operations/metadataOperations.ts
@@ -10,9 +10,7 @@ import * as lockOperations from './lockOperations'
 import { Attribute } from '../types'
 import metadata from '../config/metadata'
 import { getDefaultLockData } from '../utils/metadata'
-import { CheckoutConfig, EventData } from '../models'
 import { getEventUrl } from '../utils/eventHelpers'
-import { Op } from 'sequelize'
 import { getEventForLock } from './eventOperations'
 
 interface IsKeyOrLockOwnerOptions {

--- a/locksmith/src/operations/metadataOperations.ts
+++ b/locksmith/src/operations/metadataOperations.ts
@@ -13,6 +13,7 @@ import { getDefaultLockData } from '../utils/metadata'
 import { CheckoutConfig, EventData } from '../models'
 import { getEventUrl } from '../utils/eventHelpers'
 import { Op } from 'sequelize'
+import { getEventForLock } from './eventOperations'
 
 interface IsKeyOrLockOwnerOptions {
   userAddress?: string
@@ -290,27 +291,8 @@ export const getLockMetadata = async ({
     }
   }
 
-  // Now let's see if there is an event data that needs to be attached
-  // find checkout URLs that include this lock
-  // We look for both cases... because I am not sure how to look for
-  // keys in an insensitive way!
-  const checkoutConfigs = await CheckoutConfig.findAll({
-    where: {
-      [Op.or]: [
-        { [`config.locks.${lockAddress}.network`]: network },
-        { [`config.locks.${lockAddress.toLowerCase()}.network`]: network },
-      ],
-    },
-    order: [['updatedAt', 'DESC']],
-  })
-
-  // If there are checkout configs, let's see if an even exists with them!
-  // Let's now find any event that uses this checkout config!
-  const event = await EventData.findOne({
-    where: {
-      checkoutConfigId: checkoutConfigs.map((record) => record.id),
-    },
-  })
+  // Now let's see if there is an event data that needs to be attached to this lock!
+  const event = await getEventForLock(lockAddress, network)
 
   // Add the event data!
   if (event) {

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -11,7 +11,7 @@ import * as emailOperations from './emailOperations'
 import * as lockSettingOperations from './lockSettingOperations'
 import * as userMetadataOperations from './userMetadataOperations'
 import { createEventIcs } from '../utils/calendar'
-import { EventProps, getEventDataForLock } from './eventOperations'
+import { EventProps, getEventMetadataForLock } from './eventOperations'
 import { LockSetting } from '../models/lockSetting'
 import {
   DEFAULT_LOCK_SETTINGS,
@@ -412,7 +412,7 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
 
     // get event details only when lock is event
     if (isEvent) {
-      eventDetail = await getEventDataForLock(lockAddress, network)
+      eventDetail = await getEventMetadataForLock(lockAddress, network)
     }
 
     if (isCertification && tokenId) {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -326,6 +326,8 @@ export const EventObject = z.object({
   image: z.string().url(),
   description: z.string(),
   requiresApproval: z.boolean(),
+  emailSender: z.string(),
+  replyTo: z.string(),
   ticket: z.object({
     event_cover_image: z.string(),
     event_start_date: z.string(),

--- a/unlock-app/src/components/content/event/CoverImageDrawer.tsx
+++ b/unlock-app/src/components/content/event/CoverImageDrawer.tsx
@@ -50,7 +50,7 @@ export const CoverImageDrawer = ({
   }
 
   return (
-    <div className="relative inset-0 z-[1]">
+    <div className="relative inset-0 z-[1] hidden sm:block sm:overflow-hidden">
       {isOrganizer && (
         <Button
           className="absolute bottom-3 right-3 md:bottom-8 nd:right-9"

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -25,8 +25,6 @@ import {
   PaywallConfigType,
   formDataToMetadata,
 } from '@unlock-protocol/core'
-import useClipboard from 'react-use-clipboard'
-import { ToastHelper } from '~/components/helpers/toast.helper'
 import { CoverImageDrawer } from './CoverImageDrawer'
 import { EventDetail } from './EventDetail'
 import { EventLocation } from './EventLocation'
@@ -106,10 +104,6 @@ export const EventDetails = ({
     }
     migrateAndRedirect()
   }, [router, event, eventUrl])
-
-  const [_, setCopied] = useClipboard(eventUrl, {
-    successDuration: 1000,
-  })
 
   const eventDate = getEventDate(event.ticket) // Full date + time of event
   const eventEndDate = getEventEndDate(event.ticket)

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -363,30 +363,6 @@ export const EventDetails = ({
               Tools for you, the event organizer
             </span>
             <div className="grid gap-4">
-              <Card className="grid grid-cols-1 gap-2 md:items-center md:grid-cols-3">
-                <div className="md:col-span-2">
-                  <Card.Label
-                    title="Promote your event"
-                    description="Share your event's URL with your community and start selling tickets!"
-                  />
-                  <pre className="">{eventUrl}</pre>
-                </div>
-                <div className="md:col-span-1">
-                  <Button
-                    variant="black"
-                    className="button border w-full"
-                    size="small"
-                    onClick={(event) => {
-                      event.preventDefault()
-                      setCopied()
-                      ToastHelper.success('Copied!')
-                    }}
-                  >
-                    Copy URL
-                  </Button>
-                </div>
-              </Card>
-
               <Disclosure
                 label="Emails"
                 description="Customize the emails your attendees will receive."

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -404,41 +404,6 @@ export const EventDetails = ({
                 </div>
               </Disclosure>
 
-              {/* <Card className="grid grid-cols-1 gap-2 md:items-center md:grid-cols-3">
-                <div className="md:col-span-2">
-                  <Card.Label
-                    title="Manage Attendees"
-                    description="See who is attending your event, invite people with airdrops and more!"
-                  />
-                </div>
-                <div className="md:col-span-1">
-                  {Object.keys(checkoutConfig.config.locks).map(
-                    (lockAddress: string) => {
-                      const network =
-                        checkoutConfig.config.locks[lockAddress].network
-                      let label = 'Manage attendees'
-                      if (Object.keys(checkoutConfig.config.locks).length > 1) {
-                        label = `Manage attendees for ${minifyAddress(
-                          lockAddress
-                        )}`
-                      }
-                      return (
-                        <Button
-                          key={lockAddress}
-                          as={Link}
-                          variant="black"
-                          className="button border mb-2"
-                          size="small"
-                          href={`/locks/lock?address=${lockAddress}&network=${network}`}
-                        >
-                          {label}
-                        </Button>
-                      )
-                    }
-                  )}
-                </div>
-              </Card> */}
-
               <Disclosure
                 label="Verifiers"
                 description="Add and manage trusted users at the event to help check-in attendees as they arrive."

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -463,23 +463,23 @@ export const Form = ({ onSubmit }: FormProps) => {
             <div className="grid md:grid-cols-2 gap-2 justify-items-stretch">
               <Input
                 label="Name:"
-                {...register('metadata.organizerName', {
+                {...register('metadata.emailSender', {
                   required: true,
                 })}
                 autoComplete="off"
                 placeholder="Satoshi Nakamoto"
-                error={errors.metadata?.organizerName}
+                error={errors.metadata?.emailSender}
                 description={`Used on confirmation emails sent to attendees.`}
               />
               <Input
                 label="Email address:"
-                {...register('metadata.organizerEmail', {
+                {...register('metadata.replyTo', {
                   required: true,
                 })}
                 type="email"
                 autoComplete="off"
                 placeholder="your@email.com"
-                error={errors.metadata?.organizerName}
+                error={errors.metadata?.replyTo}
                 description={`Used when users respond to automated emails.`}
               />
             </div>

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -59,7 +59,6 @@ export const GoogleMapsAutoComplete = ({
   return (
     <Input
       defaultValue={defaultValue}
-      // @ts-expect-error Type 'RefObject<null>' is not assignable to type 'Ref<HTMLInputElement> | undefined'.
       ref={ref}
       type="text"
       placeholder="123 1st street, 11217 Springfield, US"
@@ -113,6 +112,7 @@ export const Form = ({ onSubmit }: FormProps) => {
         },
         image: '',
         requiresApproval: false,
+        emailSender: '',
       },
     },
   })
@@ -462,24 +462,30 @@ export const Form = ({ onSubmit }: FormProps) => {
           <Disclosure label="Organizer" defaultOpen>
             <div className="grid md:grid-cols-2 gap-2 justify-items-stretch">
               <Input
-                label="Name:"
                 {...register('metadata.emailSender', {
-                  required: true,
+                  required: {
+                    value: true,
+                    message: 'A name is required',
+                  },
                 })}
-                autoComplete="off"
+                type="text"
                 placeholder="Satoshi Nakamoto"
-                error={errors.metadata?.emailSender}
-                description={`Used on confirmation emails sent to attendees.`}
+                label="Name:"
+                description="Used on confirmation emails sent to attendees."
+                error={errors.metadata?.emailSender?.message as string}
               />
               <Input
                 label="Email address:"
                 {...register('metadata.replyTo', {
-                  required: true,
+                  required: {
+                    value: true,
+                    message: 'A name is required',
+                  },
                 })}
                 type="email"
                 autoComplete="off"
                 placeholder="your@email.com"
-                error={errors.metadata?.replyTo}
+                error={errors.metadata?.replyTo?.message as string}
                 description={`Used when users respond to automated emails.`}
               />
             </div>

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -459,6 +459,32 @@ export const Form = ({ onSubmit }: FormProps) => {
             </div>
           </Disclosure>
 
+          <Disclosure label="Organizer" defaultOpen>
+            <div className="grid md:grid-cols-2 gap-2 justify-items-stretch">
+              <Input
+                label="Name:"
+                {...register('metadata.organizerName', {
+                  required: true,
+                })}
+                autoComplete="off"
+                placeholder="Satoshi Nakamoto"
+                error={errors.metadata?.organizerName}
+                description={`Used on confirmation emails sent to attendees.`}
+              />
+              <Input
+                label="Email address:"
+                {...register('metadata.organizerEmail', {
+                  required: true,
+                })}
+                type="email"
+                autoComplete="off"
+                placeholder="your@email.com"
+                error={errors.metadata?.organizerName}
+                description={`Used when users respond to automated emails.`}
+              />
+            </div>
+          </Disclosure>
+
           <Disclosure label="Attendee Screening" defaultOpen>
             <div className="flex ">
               <p>

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -59,6 +59,7 @@ export const GoogleMapsAutoComplete = ({
   return (
     <Input
       defaultValue={defaultValue}
+      // @ts-expect-error Type 'RefObject<null>' is not assignable to type 'Ref<HTMLInputElement> | undefined'.
       ref={ref}
       type="text"
       placeholder="123 1st street, 11217 Springfield, US"

--- a/unlock-app/src/components/content/event/Settings/Emails.tsx
+++ b/unlock-app/src/components/content/event/Settings/Emails.tsx
@@ -1,0 +1,99 @@
+import { SettingCard } from '~/components/interface/locks/Settings/elements/SettingCard'
+import { useForm } from 'react-hook-form'
+
+import {
+  Event,
+  PaywallConfigType,
+  formDataToMetadata,
+} from '@unlock-protocol/core'
+import { storage } from '~/config/storage'
+import { Button, Input } from '@unlock-protocol/ui'
+import { ToastHelper } from '~/components/helpers/toast.helper'
+
+interface EmailsProps {
+  event: Event
+  checkoutConfig: {
+    id?: string
+    config: PaywallConfigType
+  }
+}
+
+export const Emails = ({ event, checkoutConfig }: EmailsProps) => {
+  console.log(event)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    mode: 'onSubmit',
+    reValidateMode: 'onSubmit',
+    defaultValues: {
+      replyTo: event.replyTo,
+      emailSender: event.emailSender,
+    },
+  })
+  const save = async (values: { replyTo: string; emailSender: string }) => {
+    await ToastHelper.promise(
+      storage.saveEventData({
+        data: {
+          ...formDataToMetadata({
+            ...event,
+          }),
+          ...values,
+        },
+        // @ts-expect-error
+        checkoutConfig,
+      }),
+      {
+        success: 'Event saved!',
+        error:
+          'We could not save your event. Please try again and report if the issue persists.',
+        loading: `Updating your event's properties.`,
+      }
+    )
+  }
+
+  return (
+    <form className="grid grid-cols-1 gap-6" onSubmit={handleSubmit(save)}>
+      <SettingCard
+        label="Emails"
+        description="Configure and send emails to the attendees of your event."
+      >
+        <div className="grid md:grid-cols-2 gap-2 justify-items-stretch">
+          <Input
+            {...register('emailSender', {
+              required: {
+                value: true,
+                message: 'A name is required',
+              },
+            })}
+            type="text"
+            placeholder="Satoshi Nakamoto"
+            label="Name:"
+            description="Used on confirmation emails sent to attendees."
+            error={errors.emailSender?.message as string}
+          />
+          <Input
+            label="Email address:"
+            {...register('replyTo', {
+              required: {
+                value: true,
+                message: 'A name is required',
+              },
+            })}
+            type="email"
+            autoComplete="off"
+            placeholder="your@email.com"
+            error={errors.replyTo?.message as string}
+            description={`Used when users respond to automated emails.`}
+          />
+        </div>
+        <div className="flex flex-end w-full pt-8 flex-row-reverse">
+          <Button loading={isSubmitting} type="submit" className="w-48">
+            Save
+          </Button>
+        </div>
+      </SettingCard>
+    </form>
+  )
+}

--- a/unlock-app/src/components/content/event/Settings/EventSettings.tsx
+++ b/unlock-app/src/components/content/event/Settings/EventSettings.tsx
@@ -9,6 +9,7 @@ import { SettingTab } from '~/pages/locks/settings'
 import { PaywallConfigType, Event } from '@unlock-protocol/core'
 import { General } from './General'
 import { Referrals } from './Referrals'
+import { Emails } from './Emails'
 import Link from 'next/link'
 
 interface EventSettingsProps {
@@ -42,6 +43,12 @@ export const EventSettings = ({
       label: 'Referrals',
       description: `Create referral links to share with your community and reward them.`,
       children: <Referrals event={event} checkoutConfig={checkoutConfig} />,
+    },
+    {
+      id: 'emails',
+      label: 'Emails',
+      description: `Configure and send emails to the attendees of your event.`,
+      children: <Emails event={event} checkoutConfig={checkoutConfig} />,
     },
     // {
     //   id: 'checkout',


### PR DESCRIPTION
# Description

We now require organizers to submit their email address and name when they are preparing a new event.

# Issues

Fixes #13188

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
