### PR TITLE
feat(email-templates): adding a template for event invites

### DIFF
--- a/packages/email-templates/README.md
+++ b/packages/email-templates/README.md
@@ -13,7 +13,7 @@ Let's say we need to add a new `demo` template, there is the following steps:
 
 ```
 type Template =
-  | 'keyMinde'
+  | 'keyMined'
   | 'demo'
 ```
 

--- a/packages/email-templates/src/index.ts
+++ b/packages/email-templates/src/index.ts
@@ -12,6 +12,7 @@ import eventRsvpSubmitted from './templates/eventRsvpSubmitted'
 import eventKeyAirdropped from './templates/eventKeyAirdropped'
 import certificationKeyMined from './templates/certificationKeyMined'
 import certificationKeyAirdropped from './templates/certificationKeyAirdropped'
+import inviteEvent from './templates/inviteEvent'
 import LockTemplates from './templates/locks'
 import bases from './templates/base/index'
 import custom from './templates/custom'
@@ -31,6 +32,7 @@ type Template =
   | 'transferCode'
   | 'keyExpiring'
   | 'keyExpired'
+  | 'inviteEvent'
   | 'eventKeyMined'
   | 'eventRsvpSubmitted'
   | 'eventKeyAirdropped'
@@ -54,6 +56,7 @@ export const EmailTemplates: Record<string, EmailTemplateProps> = {
   certificationKeyMined,
   certificationKeyAirdropped,
   custom,
+  inviteEvent,
 }
 
 const templates: Record<string, EmailTemplateProps> = {}

--- a/packages/email-templates/src/templates/base/default.ts
+++ b/packages/email-templates/src/templates/base/default.ts
@@ -427,7 +427,7 @@ export const base = `<!DOCTYPE html>
                               href="https://unlock-protocol.com/grants"
                               target="_blank"
                               style="color: #373a3e; text-decoration: none"
-                              >Grant</a
+                              >Grants</a
                             >
                           </td>
                         </tr>

--- a/packages/email-templates/src/templates/inviteEvent.ts
+++ b/packages/email-templates/src/templates/inviteEvent.ts
@@ -1,0 +1,24 @@
+import Handlebars from 'handlebars'
+
+import { formattedCustomContent } from './helpers/customContent'
+
+Handlebars.registerHelper('formattedCustomContent', formattedCustomContent)
+
+export default {
+  subject: 'You are invited to RSVP for {{eventName}}',
+  html: `<h1>You are invited to {{eventName}}!</h1>
+
+<p>The organizer of {{eventName}} is inviting you to RSVP for their event.</p>
+
+{{eventDetailsLight 
+  eventName
+  eventDate
+  eventTime
+  eventUrl
+}}
+
+<p>If you do not want to receive emails for this person, you can <a href="{{unsubscribeLink}}">unsubscribe</a>.</p>
+
+
+`,
+}


### PR DESCRIPTION
# Description

<img width="595" alt="Screenshot 2024-04-19 at 3 53 26 PM" src="https://github.com/unlock-protocol/unlock/assets/17735/5ed7f016-7e37-4d09-bf97-cbe0def6f225">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread
