### PR TITLE
feat(locksmith): no non-ascii char in slugs

### DIFF
--- a/locksmith/__tests__/operations/eventOperations.test.ts
+++ b/locksmith/__tests__/operations/eventOperations.test.ts
@@ -23,6 +23,12 @@ describe('eventOperations', () => {
       const anotherSlug = await createEventSlug('Exclusive event')
       expect(anotherSlug).toEqual('exclusive-event-1')
     })
+
+    it('should create the event with the correct slug without emoji ', async () => {
+      expect.assertions(1)
+      const slug = await createEventSlug('Exclusive 🔒 party')
+      expect(slug).toEqual('exclusive-party')
+    })
   })
 
   describe('saveEvent', () => {

--- a/locksmith/src/operations/eventOperations.ts
+++ b/locksmith/src/operations/eventOperations.ts
@@ -167,7 +167,10 @@ export const createEventSlug = async (
   name: string,
   index: number | undefined = undefined
 ): Promise<string> => {
-  const slug = index ? kebabCase([name, index].join('-')) : kebabCase(name)
+  const cleanName = name.replace(/[^\x20-\x7E]/g, '')
+  const slug = index
+    ? kebabCase([cleanName, index].join('-'))
+    : kebabCase(cleanName)
   const event = await getEventBySlug(slug)
   if (event) {
     return createEventSlug(name, index ? index + 1 : 1)


### PR DESCRIPTION
# Description

In order to keep URL cleans, we remove non-ascii characters.


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
