### PR TITLE
feat(governance): check status of Uniswap oracle for all tokens

### DIFF
--- a/governance/package.json
+++ b/governance/package.json
@@ -36,6 +36,7 @@
     "test": "hardhat test",
     "ci": "yarn lint && yarn test",
     "check": "node ./all_networks unlock:info --quiet",
+    "check:oracles": "node ./all_networks run scripts/uniswap/checkOracles.js",
     "check:multisig": "yarn hardhat run scripts/multisig/check-all.js",
     "check:verify": "yarn hardhat run scripts/verify/check-all.js",
     "lint:code": "eslint --resolve-plugins-relative-to ../packages/eslint-config .",

--- a/governance/scripts/uniswap/checkOracles.js
+++ b/governance/scripts/uniswap/checkOracles.js
@@ -1,27 +1,81 @@
+const { ethers } = require('hardhat')
 const checkOracle = require('./oracle')
-const { getNetwork } = require('@unlock-protocol/hardhat-helpers')
+const {
+  getNetwork,
+  getUnlock,
+  ADDRESS_ZERO,
+} = require('@unlock-protocol/hardhat-helpers')
 
-const logError = (name, chainId, msg) =>
-  console.log(`[${name} (${chainId})]: ${msg}`)
+const logError = (name, chainId, token, msg) =>
+  console.log(
+    `[${name} (${chainId})]: ${msg} ${token.symbol} (${token.address})`
+  )
+
+// helper to check rate
+const checkOracleRate = async ({ oracleAddress, token }) => {
+  try {
+    const rate = await checkOracle({
+      tokenIn: token.symbol,
+      quiet: true,
+      oracleAddress,
+    })
+    if (rate === 0n) {
+      return {
+        token,
+        msg: `Missing Uniswap Pool - oracle: ${oracleAddress}`,
+      }
+    }
+  } catch (error) {
+    return {
+      token,
+      msg: `Failed to fetch rate:  ${error.message} - oracle: ${oracleAddress}`,
+    }
+  }
+}
 
 async function main() {
-  const { name, id, uniswapV3, tokens } = await getNetwork()
+  const {
+    name,
+    id,
+    uniswapV3,
+    unlockAddress,
+    tokens,
+    nativeCurrency: { wrapped },
+  } = await getNetwork()
+
+  const oracleErrors = []
+  const missingOracles = []
+
   if (uniswapV3 && uniswapV3.oracle) {
     for (let i in tokens) {
       const token = tokens[i]
-      const info = `${token.symbol} (${token.address}) - oracle: ${uniswapV3.oracle}`
-      if (token.symbol !== 'WETH') {
-        try {
-          const rate = await checkOracle({ tokenIn: token.symbol, quiet: true })
-          if (rate === 0n) {
-            logError(name, id, `Missing Uniswap Pool: ${info}`)
-          }
-        } catch (error) {
-          logError(name, id, `Failed to fetch: ${info} - ${error.message}`)
-        }
+
+      // check if oracle is set in Unlock
+      const unlock = await getUnlock(unlockAddress)
+      const oracleAddress = await unlock.uniswapOracles(token.address)
+      if (oracleAddress === ADDRESS_ZERO) {
+        missingOracles.push({ token })
+      } else {
+        // if oracle is set in Unlock, make sure it works
+        const error = await checkOracleRate({ oracleAddress, token })
+        if (error) oracleErrors.push(error)
       }
+
+      // check if uniswap oracle in networks package works
+      const error = await checkOracleRate({
+        oracleAddress: uniswapV3.oracle,
+        token,
+      })
+      if (error) oracleErrors.push(error)
     }
+    // log all errors
+    oracleErrors.forEach(({ msg, token }) => logError(name, id, token, msg))
+    missingOracles.forEach(({ token }) =>
+      logError(name, id, token, `Oracle not set in Unlock for:`)
+    )
   }
+
+  //
 }
 
 // execute as standalone

--- a/governance/scripts/uniswap/checkOracles.js
+++ b/governance/scripts/uniswap/checkOracles.js
@@ -57,7 +57,7 @@ const checkOracleRate = async ({
   }
 }
 
-async function main({ chainId = 137 } = {}) {
+async function main({ chainId } = {}) {
   if (!chainId) {
     ;({ chainId } = await ethers.provider.getNetwork())
   }

--- a/governance/scripts/uniswap/checkOracles.js
+++ b/governance/scripts/uniswap/checkOracles.js
@@ -58,7 +58,11 @@ async function main() {
       } else {
         // if oracle is set in Unlock, make sure it works
         const error = await checkOracleRate({ oracleAddress, token })
-        if (error) oracleErrors.push(error)
+        if (error)
+          oracleErrors.push({
+            ...error,
+            msg: `(already in Unlock) ${error.msg}`,
+          })
       }
 
       // check if uniswap oracle in networks package works

--- a/governance/scripts/uniswap/checkOracles.js
+++ b/governance/scripts/uniswap/checkOracles.js
@@ -1,0 +1,37 @@
+const checkOracle = require('./oracle')
+const { getNetwork } = require('@unlock-protocol/hardhat-helpers')
+
+async function main() {
+  const {
+    uniswapV3: { oracle: oracleAddress },
+    tokens,
+  } = await getNetwork()
+  if (oracleAddress) {
+    console.log(`checking oracle at ${oracleAddress}`)
+    for (let i in tokens) {
+      const token = tokens[i]
+      if (token.symbol !== 'WETH') {
+        try {
+          const rate = await checkOracle({ tokenIn: token.symbol })
+          if (rate === 0n) {
+            console.log(`Missing: ${token.symbol}`)
+          }
+        } catch (error) {
+          console.log(`Failing: ${token.symbol} (oracle: ${oracleAddress})`)
+        }
+      }
+    }
+  }
+}
+
+// execute as standalone
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}
+
+module.exports = main

--- a/governance/scripts/uniswap/checkOracles.js
+++ b/governance/scripts/uniswap/checkOracles.js
@@ -1,23 +1,23 @@
 const checkOracle = require('./oracle')
 const { getNetwork } = require('@unlock-protocol/hardhat-helpers')
 
+const logError = (name, chainId, msg) =>
+  console.log(`[${name} (${chainId})]: ${msg}`)
+
 async function main() {
-  const {
-    uniswapV3: { oracle: oracleAddress },
-    tokens,
-  } = await getNetwork()
-  if (oracleAddress) {
-    console.log(`checking oracle at ${oracleAddress}`)
+  const { name, id, uniswapV3, tokens } = await getNetwork()
+  if (uniswapV3 && uniswapV3.oracle) {
     for (let i in tokens) {
       const token = tokens[i]
+      const info = `${token.symbol} (${token.address}) - oracle: ${uniswapV3.oracle}`
       if (token.symbol !== 'WETH') {
         try {
-          const rate = await checkOracle({ tokenIn: token.symbol })
+          const rate = await checkOracle({ tokenIn: token.symbol, quiet: true })
           if (rate === 0n) {
-            console.log(`Missing: ${token.symbol}`)
+            logError(name, id, `Missing Uniswap Pool: ${info}`)
           }
         } catch (error) {
-          console.log(`Failing: ${token.symbol} (oracle: ${oracleAddress})`)
+          logError(name, id, `Failed to fetch: ${info} - ${error.message}`)
         }
       }
     }

--- a/governance/scripts/uniswap/oracle.js
+++ b/governance/scripts/uniswap/oracle.js
@@ -1,4 +1,7 @@
 const { ethers } = require('hardhat')
+const { Contract } = require('ethers')
+const { getProvider } = require('../../helpers/multisig')
+
 const {
   getNetwork,
   getUnlock,
@@ -14,8 +17,14 @@ async function main({
   oracleAddress,
   fee = 500,
   quiet = false,
+  chainId,
 } = {}) {
-  const network = await getNetwork()
+  if (!chainId) {
+    ;({ chainId } = await ethers.provider.getNetwork())
+  }
+  const network = await getNetwork(chainId)
+  const provider = await getProvider(chainId)
+
   const {
     nativeCurrency: { wrapped: wrappedNativeAddress },
     tokens,
@@ -31,7 +40,11 @@ async function main({
         `Wrapped native is not defined in the networks package, please add.`
       )
     }
-    const wrapped = await getERC20Contract(wrappedNativeAddress)
+    const wrapped = new Contract(
+      wrappedNativeAddress,
+      ['function symbol() external view returns (string memory)'],
+      provider
+    )
     const wrappedSymbol = await wrapped.symbol()
     tokenTo = { address: wrappedNativeAddress, symbol: wrappedSymbol }
   } else {
@@ -58,8 +71,6 @@ async function main({
     throw new Error(`Token ${tokenIn} is not defined in the networks package.`)
   }
 
-  const pair = `${tokenFrom.symbol}/${tokenTo.symbol}`
-
   // check from unlock directly
   if (!oracleAddress) {
     const unlock = await getUnlock(network.unlockAddress)
@@ -82,7 +93,7 @@ async function main({
   }
 
   // check if token can be retrieved through Uniswap V3 oracle
-  const oracle = await ethers.getContractAt(UniswapOracleV3.abi, oracleAddress)
+  const oracle = new Contract(oracleAddress, UniswapOracleV3.abi, provider)
   log(`Checking oracle for ${tokenFrom.symbol}/${tokenTo.symbol} (${amount})`)
   const rate = await oracle.consult(
     tokenFrom.address,

--- a/governance/scripts/uniswap/oracle.js
+++ b/governance/scripts/uniswap/oracle.js
@@ -113,6 +113,7 @@ async function main({
       )} ${tokenTo.symbol} for ${amount} ${tokenFrom.symbol}`
     )
   }
+  return rate
 }
 
 // execute as standalone

--- a/packages/networks/src/networks/arbitrum.ts
+++ b/packages/networks/src/networks/arbitrum.ts
@@ -150,6 +150,8 @@ export const arbitrum: NetworkConfig = {
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
     oracle: {
+      100: '0x1dA6c13515362B42ACb1Ad24a713f74f925F3AEB',
+      3000: '0xa55F8Ba16C5Bb580967f7dD94f927B21d0acF86c',
       500: '0x9DC6a328C1200f5b247425DDeA538f70335C6a50',
     },
     positionManager: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',

--- a/packages/networks/src/networks/celo.ts
+++ b/packages/networks/src/networks/celo.ts
@@ -93,6 +93,8 @@ export const celo: NetworkConfig = {
   uniswapV3: {
     factoryAddress: '0xAfE208a311B21f13EF87E33A90049fC17A7acDEc',
     oracle: {
+      100: '0xaB82D702A4e0cD165072C005dc504A21c019718F',
+      3000: '0x5c67AD0CAfe61aF3706347aBc695D7ACcb38EFb3',
       500: '0x5108412Dd50A6ea79d2F13D5d1A23FDD9bF532db',
     },
     quoterAddress: '0x82825d0554fA07f7FC52Ab63c961F330fdEFa8E8',

--- a/packages/networks/src/networks/mainnet.ts
+++ b/packages/networks/src/networks/mainnet.ts
@@ -162,6 +162,8 @@ export const mainnet: NetworkConfig = {
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
     oracle: {
+      100: '0x92C9b3A4FFD7D2046132732FedC9f9f25E316F0B',
+      3000: '0x584c5af22DB79a13F4Fb45c66E0ff2311D58d9B2',
       500: '0x951A807b523cF6e178e0ab80fBd2C9B035521931',
     },
     positionManager: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',

--- a/packages/networks/src/networks/polygon.ts
+++ b/packages/networks/src/networks/polygon.ts
@@ -155,6 +155,8 @@ export const polygon: NetworkConfig = {
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
     oracle: {
+      100: '0x8c0AC149FabEeC9b759a43fC7d301B1a1D8DE0d0',
+      3000: '0x86399725a83bB14C47bB5ce8311Ed25378BAa162',
       500: '0x35c6b8761c7D9af75Fa193daC09d5b7B5b34981d',
     },
     positionManager: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',

--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -122,6 +122,7 @@ export const sepolia: NetworkConfig = {
   uniswapV3: {
     factoryAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',
     oracle: {
+      100: '0x5D7109aF116eF9D95f107B25c401bCF3965b4027',
       3000: '0x59E399647F12bDec93875B32376dfBcA2E69d955',
       500: '0x3A691355348DDC549515A7b538f3e85bCCdFe0B5',
     },


### PR DESCRIPTION
# Description

Adds a scripts to check the status of uniswap oracle for all tokens and output what/how to set in Unlock 

```
yarn workspace @unlock-protocol/governance check:oracles
```

```
Running task for the following networks: arbitrum,avalanche,base,baseSepolia,bsc,celo,gnosis,linea,mainnet,optimism,polygon,scroll,sepolia,zkevm,zksync
[Arbitrum (42161)]: oracle for USDC (0xaf88d065e77c8cC2239327C5EDb3A432268e5831)
        - `setOracle(0xaf88d065e77c8cC2239327C5EDb3A432268e5831,0x9DC6a328C1200f5b247425DDeA538f70335C6a50)` (500)
        - reason: Oracle was not set in Unlock
[Arbitrum (42161)]: oracle for USDT (0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9)
        - `setOracle(0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9,0xa55F8Ba16C5Bb580967f7dD94f927B21d0acF86c)` (3000)
        - reason: Oracle was not set in Unlock
[Arbitrum (42161)]: oracle for WBTC (0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f)
        - `setOracle(0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f,0x9DC6a328C1200f5b247425DDeA538f70335C6a50)` (500)
        - reason: Oracle was not set in Unlock
[Arbitrum (42161)]: oracle for ARB (0x912CE59144191C1204E64559FE8253a0e49E6548)
        - `setOracle(0x912CE59144191C1204E64559FE8253a0e49E6548,0x1dA6c13515362B42ACb1Ad24a713f74f925F3AEB)` (100)
        - reason: Oracle was not set in Unlock
[Base (8453)]: oracle for USDbC (0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA)
        - `setOracle(0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA,0xE9cb427dCde7090248016e87844658688E34e85F)` (500)
        - reason: Oracle was not set in Unlock
[Base (8453)]: oracle for USDC (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)
        - `setOracle(0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913,0x2411336105D4451713d23B5156038A48569EcE3a)` (100)
        - reason: Oracle was not set in Unlock
[Base (8453)]: oracle for DEGEN (0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed)
        - `setOracle(0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed,0xfa7AC1c24339f629826C419eC95961Df58563438)` (3000)
        - reason: Oracle was not set in Unlock
[Base (8453)] FAILED No working oracle for DAI 0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb with pool fees : 100,500,3000
[Celo (42220)] FAILED No working oracle for USDC 0xef4229c8c3250C675F21BCefa42f58EfbfF6002a with pool fees : 500
[Celo (42220)] FAILED No working oracle for DAI 0xE4fE50cdD716522A56204352f00AA110F731932d with pool fees : 500
[Ethereum (1)]: oracle for SHIB (0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE)
        - `setOracle(0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE,0x951A807b523cF6e178e0ab80fBd2C9B035521931)` (500)
        - reason: Oracle was not set in Unlock
[Ethereum (1)]: oracle for LINK (0x514910771AF9Ca656af840dff83E8264EcF986CA)
        - `setOracle(0x514910771AF9Ca656af840dff83E8264EcF986CA,0x951A807b523cF6e178e0ab80fBd2C9B035521931)` (500)
        - reason: Oracle was not set in Unlock
[Ethereum (1)]: oracle for UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984)
        - `setOracle(0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984,0x951A807b523cF6e178e0ab80fBd2C9B035521931)` (500)
        - reason: Oracle was not set in Unlock
[Ethereum (1)] FAILED No working oracle for BAT 0x0D8775F648430679A709E98d2b0Cb6250d2887EF with pool fees : 500
[Ethereum (1)] FAILED No working oracle for POINTS 0xd7C1EB0fe4A30d3B2a846C04aa6300888f087A5F with pool fees : 500
[Ethereum (1)] FAILED No working oracle for LPT 0x58b6A8A3302369DAEc383334672404Ee733aB239 with pool fees : 500
[Ethereum (1)] FAILED No working oracle for BNB 0xB8c77482e45F1F44dE1745F52C74426C631bDD52 with pool fees : 500
[Optimism (10)]: oracle for USDC (0x7F5c764cBc14f9669B88837ca1490cCa17c31607)
        - `setOracle(0x7F5c764cBc14f9669B88837ca1490cCa17c31607,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for USDC (0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85)
        - `setOracle(0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for USDT (0x94b008aA00579c1307B0EF2c499aD98a8ce58e58)
        - `setOracle(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for DAI (0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1)
        - `setOracle(0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for WLD (0xdC6fF44d5d932Cbd77B52E5612Ba0529DC6226F1)
        - `setOracle(0xdC6fF44d5d932Cbd77B52E5612Ba0529DC6226F1,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for OP (0x4200000000000000000000000000000000000042)
        - `setOracle(0x4200000000000000000000000000000000000042,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Optimism (10)]: oracle for WBTC (0x68f180fcCe6836688e9084f035309E29Bf0A2095)
        - `setOracle(0x68f180fcCe6836688e9084f035309E29Bf0A2095,0x5bb43b6c080A19d26df5769F7CA31405f26eADdE)` (500)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for WETH (0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619)
        - `setOracle(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619,0x35c6b8761c7D9af75Fa193daC09d5b7B5b34981d)` (500)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for DAI (0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063)
        - `setOracle(0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063,0x8c0AC149FabEeC9b759a43fC7d301B1a1D8DE0d0)` (100)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for USDT (0xc2132D05D31c914a87C6611C10748AEb04B58e8F)
        - `setOracle(0xc2132D05D31c914a87C6611C10748AEb04B58e8F,0x35c6b8761c7D9af75Fa193daC09d5b7B5b34981d)` (500)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for USDC (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359)
        - `setOracle(0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359,0x86399725a83bB14C47bB5ce8311Ed25378BAa162)` (3000)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for WBTC (0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6)
        - `setOracle(0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6,0x8c0AC149FabEeC9b759a43fC7d301B1a1D8DE0d0)` (100)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for USDC (0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174)
        - `setOracle(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174,0x86399725a83bB14C47bB5ce8311Ed25378BAa162)` (3000)
        - reason: Oracle was not set in Unlock
[Polygon (137)]: oracle for IXT (0xE06Bd4F5aAc8D0aA337D13eC88dB6defC6eAEefE)
        - `setOracle(0xE06Bd4F5aAc8D0aA337D13eC88dB6defC6eAEefE,0x86399725a83bB14C47bB5ce8311Ed25378BAa162)` (3000)
        - reason: Oracle was not set in Unlock
[Sepolia (11155111)] FAILED No working oracle for WETH 0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9 with pool fees : 500,3000
[Sepolia (11155111)] FAILED No working oracle for USDC 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 with pool fees : 500,3000

```

