### PR TITLE
feat(networks): add WETH for Sepolia 

### DIFF
--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -77,6 +77,7 @@ export const sepolia: NetworkConfig = {
     decimals: 18,
     name: 'ETH',
     symbol: 'ETH',
+    wrapped: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
   },
 
   opensea: {

--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -77,7 +77,7 @@ export const sepolia: NetworkConfig = {
     decimals: 18,
     name: 'ETH',
     symbol: 'ETH',
-    wrapped: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    wrapped: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9',
   },
 
   opensea: {

--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -77,7 +77,7 @@ export const sepolia: NetworkConfig = {
     decimals: 18,
     name: 'ETH',
     symbol: 'ETH',
-    wrapped: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9',
+    wrapped: '0x5f207d42F869fd1c71d7f0f81a2A67Fc20FF7323',
   },
 
   opensea: {

--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -119,6 +119,12 @@ export const sepolia: NetworkConfig = {
       name: 'USDC',
       symbol: 'USDC',
     },
+    {
+      address: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+      decimals: 18,
+      name: 'Uniswap',
+      symbol: 'UNI',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',


### PR DESCRIPTION
# Description

Also added UNI to test Uniswap pools.
NB: there are many WETH deployed on Sepolia. I added the one I used to create the UDT Uniswap pool so we get a rate for UDT. The one used by Uniswap team is `0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14` but it does not have much pools deployed either

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
