### PR TITLE
feature(locksmith): token-gated huddle calls

### DIFF
--- a/locksmith/src/config/config.ts
+++ b/locksmith/src/config/config.ts
@@ -86,6 +86,9 @@ const config = {
   */
   gitcoinApiKey: process.env.GITCOIN_API_KEY,
   gitcoinScorerId: process.env.GITCOIN_SCORER_ID,
+  /* The Huddle API key is necessary to create token-gated rooms that are tied to events. To utilise this functionality, an API key has to be obtained and set it in the HUDDLE_API_KEY env variable. To obtain one, refer to the Huddle01 API documentation: https://docs.huddle01.com/docs/api-keys
+   */
+  huddleApiKey: process.env.HUDDLE_API_KEY,
   logtailSourceToken: process.env.LOGTAIL,
   sessionDuration: Number(process.env.SESSION_DURATION || 86400 * 60), // 60 days
   requestTimeout: '25s',

--- a/locksmith/src/operations/eventOperations.ts
+++ b/locksmith/src/operations/eventOperations.ts
@@ -231,13 +231,6 @@ export const saveEvent = async (
 // Retrieve Huddle API key from project's configuration
 const huddleApiKey = config.huddleApiKey
 
-interface TokenGatedResponseSuccess {
-  message: string
-  data: {
-    roomId: string
-  }
-}
-
 /**
  * Creates a token-gated room for an event on the Huddle01 platform.
  * This function constructs a POST request to create a room that's accessible to only event attendees.

--- a/locksmith/src/routes/v2/events.ts
+++ b/locksmith/src/routes/v2/events.ts
@@ -4,6 +4,7 @@ import {
   saveEventDetails,
   getEvent,
   getAllEvents,
+  createEventTokenGatedRoom,
 } from '../../controllers/v2/eventsController'
 import { authenticatedMiddleware } from '../../utils/middlewares/auth'
 import { eventOrganizerMiddleware } from '../../utils/middlewares/eventOrganizerMiddleware'
@@ -18,5 +19,6 @@ router.post(
   eventOrganizerMiddleware,
   saveEventDetails
 )
+router.post('/create-room', createEventTokenGatedRoom)
 
 export default router

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -3738,6 +3738,41 @@ paths:
 
         500:
           $ref: '#/components/responses/500.InternalError'
+  /v2/events/create-room:
+    post:
+      operationId: createEventTokenGatedRoom
+      security:
+        - User: []
+      description: Create token gated room for an event
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                chain:
+                  type: string
+                contractAddress:
+                  type: string
+
+      responses:
+        201:
+          description: Successfully created token-gated room for the event
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  eventRoomUrl:
+                    type: string
+
+        400:
+          $ref: '#/components/responses/400.Invalid'
+
+        500:
+          $ref: '#/components/responses/500.InternalError'
 
   /v2/rsvp/{network}/{lockAddress}:
     post:


### PR DESCRIPTION
# Description
This PR lays the groundwork for creating token-gated huddle calls for events, via the Huddle01 platform.

### Changes:
- Implemented `createTokenGatedRoom` function to facilitate the creation of token-gated rooms via the Huddle01 API.
- Introduction of Huddle's credentials within the project's configuration module
- Added a controller to consume token-gated room creation operations.
- Established a route for accessing it via a frontend.

### Setup:
This new additions require `HUDDLE_API_KEY` to be added as an environment variable. Credentials and setup instructions are provided here: [Huddle Docs](https://docs.huddle01.com/docs/api-keys).

# Issues
Fixes #13296
Refs #13296

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

## Release Note Draft Snippet