### PR TITLE
feature(unlock-app): Disable button to transfer on expired keys

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/elements/MemberCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MemberCard.tsx
@@ -77,6 +77,9 @@ export const MemberCard = ({
 
   const { token: tokenId, lockName } = metadata ?? {}
 
+  // boolean to check if the membership/key is expired
+  const isExpired = expirationAsDate(expiration) === 'Expired'
+
   const MemberInfoDefault = () => {
     return (
       <>
@@ -179,6 +182,7 @@ export const MemberCard = ({
           owner={owner}
           network={network}
           lockSettings={lockSettings}
+          isExpired={isExpired}
         />
       )}
     </Collapse>

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -38,6 +38,7 @@ interface MetadataCardProps {
   network: number
   expirationDuration?: string
   lockSettings?: Record<string, any>
+  isExpired?: boolean
 }
 
 const keysToIgnore = [
@@ -245,6 +246,7 @@ export const MetadataCard = ({
   network,
   expirationDuration,
   lockSettings,
+  isExpired,
 }: MetadataCardProps) => {
   const [showTransferKey, setShowTransferKey] = useState(false)
   const [data, setData] = useState(metadata)
@@ -549,13 +551,32 @@ export const MetadataCard = ({
                   <div className="md:ml-auto">
                     <div className="flex flex-col gap-2 md:flex-row md:items-center">
                       {isLockManager && (
-                        <Button
-                          size="small"
-                          onClick={() => setShowTransferKey(true)}
-                          className="w-full md:w-auto"
-                        >
-                          Transfer
-                        </Button>
+                        <>
+                          {isExpired ? (
+                            // conditionally render Tooltip if membership is expired
+                            <Tooltip
+                              tip="Expired memberships can't be transferred"
+                              label="Expired memberships can't be transferred."
+                            >
+                              <Button
+                                size="small"
+                                className="w-full md:w-auto"
+                                disabled={isExpired}
+                              >
+                                Transfer
+                              </Button>
+                            </Tooltip>
+                          ) : (
+                            <Button
+                              size="small"
+                              onClick={() => setShowTransferKey(true)}
+                              className="w-full md:w-auto"
+                              disabled={isExpired}
+                            >
+                              Transfer
+                            </Button>
+                          )}
+                        </>
                       )}
                       {ownerIsManager && (
                         <div className="md:ml-auto">


### PR DESCRIPTION
# Description
This PR introduces the necessary logic to disable the transfer button and display a message upon hover when a membership is expired.

## Screen Grabs
- Membership Expired: Displays the disabled transfer button with a message indicating transfers can't be made on expired memberships.
<img width="1139" alt="Screenshot 2024-05-04 at 12 56 00 AM" src="https://github.com/unlock-protocol/unlock/assets/46839250/292b3597-c436-4a57-b2eb-3905bc6d3d55">

---

- Active Membership: Shows the enabled transfer button for a membership that hasn't expired.
<img width="1141" alt="Screenshot 2024-05-04 at 12 48 26 AM" src="https://github.com/unlock-protocol/unlock/assets/46839250/24db9bbe-0aea-4d55-b422-5a19a3a859d6">



# Issues

Fixes #13494
Refs #13494

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

## Release Note Draft Snippet