### PR TITLE
feat(governance): reset nonce on Cross chain simulations

### DIFF
--- a/governance/helpers/crossChain.js
+++ b/governance/helpers/crossChain.js
@@ -55,7 +55,7 @@ async function simulateDelayCall({ rpcUrl, projectURL, network, moduleCall }) {
 
   // 0ter. make sure we bypass pending txs in delay mod
   const delayModInstance = new Contract(delayMod, delayABI, signer)
-  const currentNonce = await delayMod.txNonce()
+  const currentNonce = await delayModInstance.txNonce()
   const nextNonce = await delayModInstance.queueNonce()
   if (currentNonce != nextNonce) {
     await signer.sendTransaction({

--- a/governance/helpers/crossChain.js
+++ b/governance/helpers/crossChain.js
@@ -1,5 +1,5 @@
 const { default: networks } = require('@unlock-protocol/networks')
-const { ethers } = require('ethers')
+const { ethers, Contract } = require('ethers')
 const { createFork } = require('./tenderly')
 const { delayABI } = require('./bridge')
 
@@ -52,6 +52,19 @@ async function simulateDelayCall({ rpcUrl, projectURL, network, moduleCall }) {
     data: delayInterface.encodeFunctionData('enableModule', [signerAddress]),
     gasLimit: 800000,
   })
+
+  // 0ter. make sure we bypass pending txs in delay mod
+  const delayModInstance = new Contract(delayMod, delayABI, signer)
+  const currentNonce = await delayMod.txNonce()
+  const nextNonce = await delayModInstance.queueNonce()
+  if (currentNonce != nextNonce) {
+    await signer.sendTransaction({
+      from: signerAddress,
+      to: delayMod,
+      data: delayInterface.encodeFunctionData('setTxNonce', [nextNonce]),
+      gasLimit: 800000,
+    })
+  }
 
   // 1. add tx to delay module
   await signer.sendTransaction({


### PR DESCRIPTION
# Description

Adds a Delay module nonce reset to the simulation to prevent call from failing when there is already a tx there

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
