### PR TITLE
fix(unlock-app): use eip1193 when recreating wallet provider for wallet connect

### DIFF
--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -34,6 +34,7 @@ export const useProvider = (config: any) => {
     getCurrentNetwork() || 1
   )
   const [connected, setConnected] = useState<string | undefined>()
+  const [eip1193, setEip1193] = useState<any | undefined>()
   const { setStorage, clearStorage, getStorage } = useAppStorage()
   const { addNetworkToWallet } = useAddToNetwork(connected)
   const { session: account, refetchSession } = useSession()
@@ -96,7 +97,11 @@ export const useProvider = (config: any) => {
         )) as unknown as ethers.BrowserProvider
       } else {
         await switchBrowserProviderNetwork(networkId)
-        walletServiceProvider = new ethers.BrowserProvider(window.ethereum!)
+        if (getStorage('provider') === 'WALLET_CONNECT') {
+          walletServiceProvider = new ethers.BrowserProvider(eip1193)
+        } else {
+          walletServiceProvider = new ethers.BrowserProvider(window.ethereum!)
+        }
       }
     }
     return walletServiceProvider
@@ -161,6 +166,7 @@ export const useProvider = (config: any) => {
 
   const connectProvider = async (provider: any) => {
     setLoading(true)
+    setEip1193(provider)
     let auth
     if (provider instanceof ethers.AbstractProvider) {
       auth = await resetProvider(provider)
@@ -182,7 +188,11 @@ export const useProvider = (config: any) => {
         })
 
         provider.on('chainChanged', async () => {
-          await resetProvider(new ethers.BrowserProvider(window.ethereum!))
+          if (getStorage('provider') === 'WALLET_CONNECT') {
+            await resetProvider(new ethers.BrowserProvider(eip1193))
+          } else {
+            await resetProvider(new ethers.BrowserProvider(window.ethereum!))
+          }
         })
       }
       auth = await resetProvider(ethersProvider)


### PR DESCRIPTION
# Description

This fixes a bug introduced with the upgrade to ethers 6 that made the wallet connect flow fails

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
