### PR TITLE
fix(smart-contracts): flaky test fixed!

### DIFF
--- a/smart-contracts/test/Lock/upgrades/v10.js
+++ b/smart-contracts/test/Lock/upgrades/v10.js
@@ -69,24 +69,22 @@ describe('PublicLock upgrade  v9 > v10', () => {
       const signers = await ethers.getSigners()
       buyers = signers.slice(1, 11)
 
-      // purchase many keys
-      await Promise.all(
-        buyers.map(async (keyOwner) => {
-          await lock
-            .connect(keyOwner)
-            .purchase(
-              0,
-              await keyOwner.getAddress(),
-              ADDRESS_ZERO,
-              ADDRESS_ZERO,
-              '0x',
-              {
-                value: keyPrice,
-              }
-            )
-        })
-      )
-
+      // purchase many keys (in the correct order to make sure we can check them later)
+      for (let i = 0; i < buyers.length; i++) {
+        const keyOwner = buyers[i]
+        await lock
+          .connect(keyOwner)
+          .purchase(
+            0,
+            await keyOwner.getAddress(),
+            ADDRESS_ZERO,
+            ADDRESS_ZERO,
+            '0x',
+            {
+              value: keyPrice,
+            }
+          )
+      }
       tokenIds = await Promise.all(
         buyers.map(async (b) => lock.getTokenIdFor(await b.getAddress()))
       )


### PR DESCRIPTION
# Description

I think I found why the flaky test is happening. We are buying all keys using Promise.all, but we can't really guarantee the order.
Moved to use a for loop with `await` for each transaction.

# Issues


Fixes https://github.com/unlock-protocol/unlock/issues/14005

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
