### PR TITLE
feat(unlock-app): resolve `.cb.id` domains

### DIFF
--- a/packages/ui/lib/components/Form/AddressInput.tsx
+++ b/packages/ui/lib/components/Form/AddressInput.tsx
@@ -3,7 +3,7 @@ import { ForwardedRef, useState, useEffect } from 'react'
 import { forwardRef } from 'react'
 import { FaWallet, FaSpinner } from 'react-icons/fa'
 import { IconBaseProps } from 'react-icons'
-import { isAddress, isEns, minifyAddress } from '../../utils'
+import { isAddress, isValidEnsName, minifyAddress } from '../../utils'
 import {
   useMutation,
   QueryClient,
@@ -130,7 +130,7 @@ export const WrappedAddressInput = ({
           if (typeof onChange === 'function') {
             onChange(value as any)
           }
-        } else if (isEns(value)) {
+        } else if (isValidEnsName(value)) {
           try {
             const res = await handleResolver(value)
             if (typeof onChange === 'function' && res) {

--- a/packages/ui/lib/utils.ts
+++ b/packages/ui/lib/utils.ts
@@ -1,4 +1,4 @@
-import { isAddress as ethersIsAddress } from 'ethers'
+import { isAddress as ethersIsAddress, isValidName } from 'ethers'
 
 export const minifyAddress = (address: string) => {
   const checked = ethersIsAddress(address)
@@ -14,6 +14,10 @@ export const isAddress = (address = '') => {
 // TODO: support other TLDs
 export const isEns = (address = '') => {
   return address?.toLowerCase()?.includes('.eth')
+}
+
+export const isValidEnsName = (name = '') => {
+  return isValidName(name.trim())
 }
 
 export const isAddressOrEns = (addressOrEns = '') => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
ethers supports wildcard resolution natively. This PR changes the address input validation to match any valid ens name.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #13205 
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->

https://www.loom.com/share/47e9b240a9e0493db0267f56a52d375e?sid=68393a13-dcae-4902-8153-30db8d5fe1b8

Interesting that this brings up a cors error when I try resolving that address from `localhost:3000` , but `localhost:3001` works fine
![airdrop](https://github.com/unlock-protocol/unlock/assets/76876702/ce86b6a1-6474-42e4-97b8-1183eb8c40e2)

