### PR TITLE
fix(unlock-js): replace `_signTypedData` by `signTypedData`

### DIFF
--- a/packages/unlock-js/src/CardPurchaser.ts
+++ b/packages/unlock-js/src/CardPurchaser.ts
@@ -101,12 +101,7 @@ export class CardPurchaser {
       expiration: now + 60 * 60, // 1 hour!
     }
 
-    // @ts-expect-error Property '_signTypedData' does not exist on type 'Signer'.ts(2339)
-    const signature = await signer._signTypedData(
-      domain,
-      PurchaseTypes,
-      message
-    )
+    const signature = await signer.signTypedData(domain, PurchaseTypes, message)
     return { signature, message }
   }
 

--- a/packages/unlock-js/src/KeyManager.ts
+++ b/packages/unlock-js/src/KeyManager.ts
@@ -119,8 +119,7 @@ export class KeyManager {
     network,
   }: CreateTransferSignatureOptions) {
     const domain = this.getDomain(network)
-    // @ts-expect-error Property '_signTypedData' does not exist on type 'Signer'. (https://docs.ethers.org/v5/api/signer/#Signer-signTypedData)
-    const signature = await signer._signTypedData(domain, TransferTypes, params)
+    const signature = await signer.signTypedData(domain, TransferTypes, params)
     return signature
   }
 

--- a/packages/unlock-js/src/erc20.ts
+++ b/packages/unlock-js/src/erc20.ts
@@ -169,8 +169,7 @@ export async function signTransferAuthorization(
 ) {
   const { chainId } = await provider.getNetwork()
   const domain = await getDomain(chainId, erc20ContractAddress, provider)
-  // @ts-expect-error Property '_signTypedData' does not exist on type 'Signer'.ts(2339)
-  return signer._signTypedData(domain, TransferWithAuthorizationTypes, message)
+  return signer.signTypedData(domain, TransferWithAuthorizationTypes, message)
 }
 
 export async function recoverTransferAuthorization(

--- a/smart-contracts/test/CardPurchaser/purchase.mainnet.js
+++ b/smart-contracts/test/CardPurchaser/purchase.mainnet.js
@@ -66,7 +66,7 @@ const signUSDCTransfer = async ({
     nonce: ethers.hexlify(ethers.randomBytes(32)), // 32 byte hex string
   }
 
-  const signature = await signer._signTypedData(domain, types, message)
+  const signature = await signer.signTypedData(domain, types, message)
   return { signature, message }
 }
 
@@ -102,7 +102,7 @@ const signLockPurchase = async ({
     expiration: expiration ? expiration : now + 60 * 60 * 24, // 1 hour!
   }
 
-  const signature = await signer._signTypedData(domain, types, message)
+  const signature = await signer.signTypedData(domain, types, message)
   return { signature, message, domain, types }
 }
 


### PR DESCRIPTION
# Description

In Ethers 6, `signer._signTypedData` has  `signer.signTypedData` (see https://docs.ethers.org/v6/api/providers/#Signer-signTypedData). This PR updates unlock-js accordingly

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
