### PR TITLE
chore(hardhat-helpers): add initialize step to import CLI hardhat tasks

### DIFF
--- a/governance/hardhat.config.js
+++ b/governance/hardhat.config.js
@@ -10,7 +10,11 @@ const {
   etherscan,
   networks,
   parseForkUrl,
+  initializeTasks,
 } = require('@unlock-protocol/hardhat-helpers')
+
+// add default tasks to CLI
+initializeTasks()
 
 // zksync
 if (process.env.ZK_SYNC) {

--- a/packages/hardhat-helpers/src/index.ts
+++ b/packages/hardhat-helpers/src/index.ts
@@ -6,7 +6,7 @@ import fork from './fork'
 import lock from './lock'
 import networks from './networks'
 import proxy from './proxy'
-const tasks = require('./tasks')
+import tasks from './tasks'
 import tokens from './tokens'
 import uniswap from './uniswap'
 import unlock from './unlock'
@@ -24,7 +24,7 @@ module.exports = {
   ...lock,
   networks,
   ...proxy,
-  tasks,
+  ...tasks,
   ...tokens,
   ...uniswap,
   ...unlock,

--- a/packages/hardhat-helpers/src/tasks/config.js
+++ b/packages/hardhat-helpers/src/tasks/config.js
@@ -1,8 +1,15 @@
 const { task } = require('hardhat/config')
 
-task('config', 'Show current config')
-  .addFlag('json', 'output as JSON')
-  .setAction(({ json }, { config }) => {
-    // eslint-disable-next-line no-console
-    console.log(json ? JSON.stringify(config) : config)
-  })
+const initializeConfigTask = () =>
+  task('config', 'Show current config')
+    .addFlag('json', 'output as JSON')
+    .setAction(({ json }, { config }) => {
+      // eslint-disable-next-line no-console
+      console.log(json ? JSON.stringify(config) : config)
+    })
+
+const initialize = () => {
+  initializeConfigTask()
+}
+
+module.exports = initialize

--- a/packages/hardhat-helpers/src/tasks/deploy.js
+++ b/packages/hardhat-helpers/src/tasks/deploy.js
@@ -2,36 +2,46 @@ const { task } = require('hardhat/config')
 const { deployContract, deployUpgradeableContract } = require('../deploy')
 const path = require('path')
 
-task('deploy:contract', 'Deploy any contract by name')
-  .addFlag('proxied', 'deploy using OZ Transparent Proxy')
-  .addParam('contract', 'the path of the contract to deploy')
-  .addOptionalParam(
-    'constructorArgs',
-    'the absolute path of a file with constructor args - ex. `pwd`/scripts/args.js'
-  )
-  .addOptionalVariadicPositionalParam(
-    'params',
-    'List of deployment args to pass to the constructor'
-  )
-  .setAction(async ({ contract, params, proxied, constructorArgs }) => {
-    const contractName = path
-      .basename(contract)
-      .replace('.sol', '')
-      .split('V')[0]
-    const qualified = `${contract}:${contractName}`
+const initializeDeployTask = () =>
+  task('deploy:contract', 'Deploy any contract by name')
+    .addFlag('proxied', 'deploy using OZ Transparent Proxy')
+    .addParam('contract', 'the path of the contract to deploy')
+    .addOptionalParam(
+      'constructorArgs',
+      'the absolute path of a file with constructor args - ex. `pwd`/scripts/args.js'
+    )
+    .addOptionalVariadicPositionalParam(
+      'params',
+      'List of deployment args to pass to the constructor'
+    )
+    .setAction(async ({ contract, params, proxied, constructorArgs }) => {
+      const contractName = path
+        .basename(contract)
+        .replace('.sol', '')
+        .split('V')[0]
+      const qualified = `${contract}:${contractName}`
 
-    let address, hash
+      let address, hash
 
-    if (constructorArgs) {
-      params = require(`${constructorArgs}`)
-      console.log(params)
-    }
+      if (constructorArgs) {
+        params = require(`${constructorArgs}`)
+        console.log(params)
+      }
 
-    if (proxied) {
-      ;({ address, hash } = await deployContract(qualified, params))
-    } else {
-      console.log(`Deploying using a Transparent proxy:`)
-      ;({ address, hash } = await deployUpgradeableContract(qualified, params))
-    }
-    console.log(`Contract ${qualified} deployed at ${address} (tx: ${hash})`)
-  })
+      if (proxied) {
+        ;({ address, hash } = await deployContract(qualified, params))
+      } else {
+        console.log(`Deploying using a Transparent proxy:`)
+        ;({ address, hash } = await deployUpgradeableContract(
+          qualified,
+          params
+        ))
+      }
+      console.log(`Contract ${qualified} deployed at ${address} (tx: ${hash})`)
+    })
+
+const initialize = () => {
+  initializeDeployTask()
+}
+
+module.exports = initialize

--- a/packages/hardhat-helpers/src/tasks/index.js
+++ b/packages/hardhat-helpers/src/tasks/index.js
@@ -1,7 +1,9 @@
 const config = require('./config')
 const deploy = require('./deploy')
 
-module.exports = {
-  config,
-  deploy,
+const initializeTasks = () => {
+  config()
+  deploy()
 }
+
+module.exports = { initializeTasks }

--- a/smart-contracts/hardhat.config.js
+++ b/smart-contracts/hardhat.config.js
@@ -3,9 +3,13 @@ const {
   networks,
   etherscan,
   parseForkUrl,
+  initializeTasks,
 } = require('@unlock-protocol/hardhat-helpers')
 
 require('@nomicfoundation/hardhat-ethers')
+
+//
+initializeTasks()
 
 // full stack trace if needed
 // require('hardhat-tracer')


### PR DESCRIPTION
# Description

This adds an initialize step to the import of hardhat cli tasks so the library can be imported without the hardhat context (otherwise it will throw)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
