### PR TITLE
fix(unlock-app): gas/mint fee is missing from credit card purchases when using fixed price

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCard.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCard.tsx
@@ -191,7 +191,7 @@ export function ConfirmCard({ checkoutService, onConfirmed, onError }: Props) {
   })
 
   // show gas cost only when custom credit card price is present
-  const gasCosts = creditCardPrice ? undefined : totalPricing?.gasCost
+  const gasCosts = creditCardPrice ? totalPricing?.gasCost : undefined
 
   const { mutateAsync: capturePayment } = useCapturePayment({
     network: lock!.network,


### PR DESCRIPTION
# Description
<!--
Thank you for your contribution to Unlock Protocol!
-->
Total amount appears incorrect in checkout page for credit card purchases 
Show gas fee to make the total amount appear right when calculated 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #13449 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
