### PR TITLE
feature(unlock-app): Handle Apple Wallet downloads

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Returning.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Returning.tsx
@@ -125,9 +125,6 @@ export function Returning({ checkoutService, onClose, communication }: Props) {
                     network={lock!.network}
                     lockAddress={lock!.address}
                     tokenId={tokenId}
-                    handlePassUrl={(url: string) => {
-                      window.location.assign(url)
-                    }}
                   />
                 </li>
               )}

--- a/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
+++ b/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
@@ -1,5 +1,4 @@
-import { Box, Modal, Size } from '@unlock-protocol/ui'
-import QRCode from 'qrcode.react'
+import { Box, Size } from '@unlock-protocol/ui'
 import {
   generateAppleWalletPass,
   generateGoogleWalletPass,
@@ -8,44 +7,13 @@ import {
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import Image from 'next/image'
 
-interface ApplePassModalProps {
-  isOpen: boolean
-  setIsOpen: (state: boolean) => void
-  applePassUrl?: string
-}
-
-export const ApplePassModal = ({
-  isOpen,
-  setIsOpen,
-  applePassUrl,
-}: ApplePassModalProps) => {
-  return (
-    <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
-      {applePassUrl ? (
-        <div className="flex flex-col items-center">
-          <p>
-            Please scan this QR code with your phone or{' '}
-            <a href={applePassUrl} className="underline">
-              click here to download it
-            </a>
-            .
-          </p>
-          <QRCode value={applePassUrl} size={256} includeMargin />
-        </div>
-      ) : (
-        <p>Generating your pass...</p>
-      )}
-    </Modal>
-  )
-}
-
 interface AddToWalletProps {
   platform: Platform
   as: React.ElementType
   network: number
   lockAddress: string
   tokenId: string
-  handlePassUrl: (url: string) => void
+  handlePassUrl?: (url: string) => void
   disabled?: boolean
   active?: boolean
   minimised?: boolean
@@ -87,7 +55,7 @@ export const AddToPhoneWallet = ({
   const handleClick = async () => {
     const generate = async () => {
       const passUrl = await config.generatePass(lockAddress, network, tokenId)
-      if (passUrl) {
+      if (platform === Platform.GOOGLE && handlePassUrl && passUrl) {
         handlePassUrl(passUrl)
       }
     }

--- a/unlock-app/src/components/interface/keychain/AddToWallet.tsx
+++ b/unlock-app/src/components/interface/keychain/AddToWallet.tsx
@@ -92,9 +92,6 @@ export const AddToWallet = ({ network, lockAddress, tokenId }: AddToWallet) => {
                     network={network}
                     lockAddress={lockAddress}
                     tokenId={tokenId}
-                    handlePassUrl={(url: string) => {
-                      window.location.assign(url)
-                    }}
                   />
                 </div>
               </Tooltip.Trigger>

--- a/unlock-app/src/components/interface/keychain/Key.tsx
+++ b/unlock-app/src/components/interface/keychain/Key.tsx
@@ -368,9 +368,6 @@ function Key({ ownedKey, owner, network }: Props) {
                             network={network}
                             lockAddress={lock.address}
                             tokenId={tokenId}
-                            handlePassUrl={(url: string) => {
-                              window.location.assign(url)
-                            }}
                           />
                         )}
                       </Menu.Item>

--- a/unlock-app/src/components/interface/keychain/Key.tsx
+++ b/unlock-app/src/components/interface/keychain/Key.tsx
@@ -48,8 +48,7 @@ import { ExtendMembershipModal } from './Extend'
 import { Key as HookKey } from '~/hooks/useKeys'
 import { TbReceipt as ReceiptIcon } from 'react-icons/tb'
 import { useGetReceiptsPageUrl } from '~/hooks/useReceipts'
-import { AddToPhoneWallet, ApplePassModal } from './AddToPhoneWallet'
-import { isIOS } from 'react-device-detect'
+import { AddToPhoneWallet } from './AddToPhoneWallet'
 import { useRouter } from 'next/router'
 import { Platform } from '~/services/passService'
 
@@ -83,8 +82,6 @@ function Key({ ownedKey, owner, network }: Props) {
   const [showCancelModal, setShowCancelModal] = useState(false)
   const [expireAndRefunded, setExpireAndRefunded] = useState(false)
   const [showExtendMembershipModal, setShowExtendMembership] = useState(false)
-  const [showApplePassModal, setShowApplePassModal] = useState(false)
-  const [applePassUrl, setPassUrl] = useState<string>()
   const videoRef = useRef(null)
   const [canPlayImageAsVideo, setCanPlayImageAsVideo] = useState(false)
   const isKeyExpired = isExpired || expireAndRefunded
@@ -253,11 +250,6 @@ function Key({ ownedKey, owner, network }: Props) {
         network={network}
         ownedKey={ownedKey}
       />
-      <ApplePassModal
-        isOpen={showApplePassModal}
-        setIsOpen={setShowApplePassModal}
-        applePassUrl={applePassUrl}
-      />
       <div className="flex items-center justify-between">
         <div>
           {isKeyExpired ? (
@@ -377,12 +369,7 @@ function Key({ ownedKey, owner, network }: Props) {
                             lockAddress={lock.address}
                             tokenId={tokenId}
                             handlePassUrl={(url: string) => {
-                              if (isIOS) {
-                                window.location.assign(url)
-                              } else {
-                                setPassUrl(url)
-                                setShowApplePassModal(true)
-                              }
+                              window.location.assign(url)
                             }}
                           />
                         )}

--- a/unlock-app/src/services/passService.ts
+++ b/unlock-app/src/services/passService.ts
@@ -27,7 +27,7 @@ export const generateGoogleWalletPass = async (
     return response?.data?.passObjectUrl
   } catch (error) {
     console.error('Error generating Google wallet pass:', error)
-    throw new Error('Failed to generate Apple wallet pass')
+    throw new Error('Failed to generate Google wallet pass')
   }
 }
 
@@ -48,10 +48,31 @@ export const generateAppleWalletPass = async (
     const response = await locksmith.generateAppleWalletPass(
       network,
       lockAddress,
-      keyId
+      keyId,
+      {
+        // Ensure the response is treated as binary data
+        responseType: 'arraybuffer',
+      }
     )
+    // Convert the received data into a Blob
+    const blob = new Blob([response.data], {
+      type: 'application/vnd.apple.pkpass',
+    })
 
-    return response.data
+    // Generate a URL for the Blob and trigger the download
+    const downloadUrl = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = downloadUrl
+
+    // Construct filename based on the lock data and ensure the .pkpass extension is included
+    link.download = `Unlock-Pass-${keyId}.pkpass`
+
+    document.body.appendChild(link)
+    // Trigger download using the filename specified
+    link.click()
+    document.body.removeChild(link)
+
+    return downloadUrl
   } catch (error) {
     console.error('Error generating Apple wallet pass:', error)
     throw new Error('Failed to generate Apple wallet pass')


### PR DESCRIPTION
# Description
This PR introduces direct downloading of Apple Wallet passes to a user's device. They are streamed directly from the server with the appropriate filename.

# Issues
Fixes #13855
Refs #13855

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet