### PR TITLE
chore(unlock-js) update `ethers` peer dep to v6

### DIFF
--- a/packages/unlock-js/CHANGELOG.md
+++ b/packages/unlock-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+# 0.48.0
+
+- update `peerDependencies` to require `ethers` v6.
+
 # 0.47.0
 
 - using `purchasePriceFor` when possible in `getPurchaseKeysArguments`

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "peerDependencies": {
     "axios": "1.7.4",
-    "ethers": "5.7.2"
+    "ethers": "^6.13.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.2",

--- a/packages/unlock-js/package.json
+++ b/packages/unlock-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlock-protocol/unlock-js",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "This module provides libraries to include Unlock APIs inside a Javascript application.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20677,7 +20677,7 @@ __metadata:
     vitest: "npm:1.6.0"
   peerDependencies:
     axios: 1.7.4
-    ethers: 5.7.2
+    ethers: ^6.13.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# Description

Require ethers v6 as peer dependency in unlock js

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #14387

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
