### PR TITLE
chore(actions): Add Cloudflare Workers deployment workflow for RPC provider and Graph service

### DIFF
--- a/.github/workflows/cloudflare-workers.yml
+++ b/.github/workflows/cloudflare-workers.yml
@@ -1,0 +1,70 @@
+name: Deploy Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'provider/**'
+      - 'graph-service/**'
+  pull_request:
+    paths:
+      - 'provider/**'
+      - 'graph-service/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [provider, graph-service]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: cd ${{ matrix.service }} && yarn install
+      - run: cd ${{ matrix.service }} && yarn test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    strategy:
+      matrix:
+        service: [provider, graph-service]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: cd ${{ matrix.service }} && yarn install
+      - name: Set environment variables
+        run: |
+          if [ "${{ matrix.service }}" = "provider" ]; then
+            op run --env-file=${{ matrix.service }}/.op.env -- ./${{ matrix.service }}/scripts/set-provider-urls.sh
+          else
+            op run --env-file=${{ matrix.service }}/.op.env -- ./${{ matrix.service }}/scripts/set-graph-urls.sh
+          fi
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      - name: Deploy to Cloudflare Workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: cd ${{ matrix.service }} && yarn deploy


### PR DESCRIPTION
# Description

This PR introduces a new GitHub Actions workflow to automate the deployment of our RPC Provider and Graph Service to Cloudflare Workers. Key features include:

1. Combined workflow for both services in a single file.
2. Automated tests and deployment trigger on pushes to master and PRs in relevant directories.
3. Matrix strategy enables parallel processing for both services.
4. Secure environment variables managed via 1Password CLI.
5. Deploys to Cloudflare Workers using Wrangler.

A birds-eye view of the workflow:
- Tests both services
- Sets environment variables via 1Password
- Deploys to Cloudflare Workers on successful tests and pushes to master

Required secrets:
- `CLOUDFLARE_API_TOKEN`: Cloudflare API token for deployment



# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet