### PR TITLE
fix(unlock-app): Fix Incorrect Usage of `isPending` and `mutate` Methods

### DIFF
--- a/unlock-app/src/components/content/EventContent.tsx
+++ b/unlock-app/src/components/content/EventContent.tsx
@@ -18,7 +18,7 @@ export const EventContent = () => {
     network,
     isLoading: isLoadingQuery,
   } = useRouterQueryForLockAddressAndNetworks()
-  const { data: metadata, isPending: isMetadataLoading } = useMetadata({
+  const { data: metadata, isLoading: isMetadataLoading } = useMetadata({
     lockAddress,
     network,
   })

--- a/unlock-app/src/components/content/certification/CertificationDetails.tsx
+++ b/unlock-app/src/components/content/certification/CertificationDetails.tsx
@@ -51,7 +51,7 @@ const CertificationManagerOptions = ({
     network,
   })
 
-  const { isLoading, data: transferFeeBasisPoints } = useQuery({
+  const { isPending, data: transferFeeBasisPoints } = useQuery({
     queryKey: ['getTransferFeeBasisPoints', lockAddress, network],
     queryFn: async () => getTransferFeeBasisPoints(),
   })
@@ -66,7 +66,7 @@ const CertificationManagerOptions = ({
         Tools for you, the certificate issuer
       </p>
       <div className="grid gap-4">
-        {certificationIsTransferable && !isLoading && (
+        {certificationIsTransferable && !isPending && (
           <div className="flex flex-col gap-2">
             <WarningBar>
               Your certification is transferable! disable it to prevent transfer
@@ -134,7 +134,7 @@ export const CertificationDetails = ({
     network,
   })
 
-  const { data: metadata, isPending: isMetadataLoading } = useMetadata({
+  const { data: metadata, isLoading: isMetadataLoading } = useMetadata({
     lockAddress,
     network,
     keyId: tokenId,

--- a/unlock-app/src/components/content/event/Settings/StakeRefund.tsx
+++ b/unlock-app/src/components/content/event/Settings/StakeRefund.tsx
@@ -98,7 +98,7 @@ export const StakeRefund = ({ event, checkoutConfig }: StakeRefundProps) => {
       </p>
       <Button
         loading={approveRefundsMutation.isPending}
-        onClick={() => approveRefundsMutation.mutate()}
+        onClick={() => approveRefundsMutation.mutateAsync()}
       >
         Prepare Refunds
       </Button>


### PR DESCRIPTION
# Description
This PR introduces corrections to a few components where `isPending` was incorrectly used instead of `isLoading` when replacing the deprecated `isInitialLoading` flag, and replaces `mutate` with `mutateAsync` where necessary. 

# Issues
Fixes #14436
Refs #14436

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet