### PR TITLE
chore(subgraph): refactoring tests and logic for OZ native role events

### DIFF
--- a/subgraph/introspection.json
+++ b/subgraph/introspection.json
@@ -1823,6 +1823,12 @@
               "deprecationReason": null
             },
             {
+              "name": "lock__lastKeyRenewedAt",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "lock__deployer",
               "description": null,
               "isDeprecated": false,
@@ -2178,6 +2184,18 @@
               "deprecationReason": null
             },
             {
+              "name": "lastKeyRenewedAt",
+              "description": "The timestamp of the block in which the last key was renewed",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "deployer",
               "description": "Address of the lock deployer",
               "args": [],
@@ -2292,6 +2310,30 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "ReferrerFee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "keyGranters",
+              "description": "Key Granters role for key.\nThe lock creator is the default KeyGranter.\nThe primary reason for this role is to support additional purchase mechanisms beyond direct key purchases like credit-card purchases.\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Bytes",
                       "ofType": null
                     }
                   }
@@ -4384,6 +4426,102 @@
               "defaultValue": null
             },
             {
+              "name": "lastKeyRenewedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_not",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "BigInt",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastKeyRenewedAt_not_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "BigInt",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "deployer",
               "description": null,
               "type": {
@@ -4702,6 +4840,114 @@
               "defaultValue": null
             },
             {
+              "name": "keyGranters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "keyGranters_not",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "keyGranters_contains",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "keyGranters_contains_nocase",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "keyGranters_not_contains",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "keyGranters_not_contains_nocase",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Bytes",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "_change_block",
               "description": "Filter for the block changed event.",
               "type": {
@@ -4843,6 +5089,12 @@
               "deprecationReason": null
             },
             {
+              "name": "lastKeyRenewedAt",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "deployer",
               "description": null,
               "isDeprecated": false,
@@ -4862,6 +5114,12 @@
             },
             {
               "name": "referrerFees",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "keyGranters",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -8583,6 +8841,12 @@
             },
             {
               "name": "lock__lastKeyMintedAt",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lock__lastKeyRenewedAt",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -283,9 +283,7 @@ export function handleRenewKeyPurchase(event: RenewKeyPurchaseEvent): void {
   createReceipt(event)
 }
 
-// NB: Up to PublicLock v8, we handle the addition of a new lock managers and key granters
-// with our custom events `LockManagerAdded` and `KeyGranterAdded`. Starting from v9,
-// we use OpenZeppelin native `RoleGranted` event.
+// we use OpenZeppelin native `RoleGranted` event since v8
 export function handleRoleGranted(event: RoleGrantedEvent): void {
   if (
     event.params.role.toHexString() ==
@@ -303,6 +301,7 @@ export function handleRoleGranted(event: RoleGrantedEvent): void {
         lock.lockManagers = [event.params.account]
       }
       lock.save()
+      log.debug('New lock manager', [event.params.account.toHexString()])
     }
   } else if (
     event.params.role.toHexString() ==
@@ -341,13 +340,29 @@ export function handleRoleRevoked(event: RoleRevokedEvent): void {
       lock.keyGranters = newKeyGranters
       lock.save()
     }
+  } else if (
+    event.params.role.toHexString() ==
+    Bytes.fromHexString(LOCK_MANAGER).toHexString()
+  ) {
+    const lock = Lock.load(event.address.toHexString())
+    if (lock && lock.lockManagers) {
+      const newManagers: Bytes[] = []
+      for (let i = 0; i < lock.lockManagers.length; i++) {
+        const managerAddress = lock.lockManagers[i]
+        if (managerAddress != event.params.account) {
+          newManagers.push(managerAddress)
+        }
+      }
+      lock.lockManagers = newManagers
+      lock.save()
+    }
   }
 }
 
 export function handleKeyGranterAdded(event: KeyGranterAddedEvent): void {
   const lock = Lock.load(event.address.toHexString())
-
-  if (lock && lock.keyGranters) {
+  // custom events used only for version prior to v8
+  if (lock && lock.version.le(BigInt.fromI32(8)) && lock.keyGranters) {
     const keyGranters = lock.keyGranters
     keyGranters.push(event.params.account)
     lock.keyGranters = keyGranters
@@ -361,7 +376,8 @@ export function handleKeyGranterAdded(event: KeyGranterAddedEvent): void {
 
 export function handleKeyGranterRemoved(event: KeyGranterRemovedEvent): void {
   const lock = Lock.load(event.address.toHexString())
-  if (lock && lock.keyGranters) {
+  // custom events used only for version prior to v8
+  if (lock && lock.version.le(BigInt.fromI32(8)) && lock.keyGranters) {
     const newKeyGranters: Bytes[] = []
     for (let i = 0; i < lock.keyGranters.length; i++) {
       const keyGranterAddress = lock.keyGranters[i]
@@ -374,7 +390,7 @@ export function handleKeyGranterRemoved(event: KeyGranterRemovedEvent): void {
   }
 }
 
-// `LockManagerAdded` event is used only until v8
+// `LockManagerAdded` event is replaced by OZ native Roles event
 export function handleLockManagerAdded(event: LockManagerAddedEvent): void {
   const lock = Lock.load(event.address.toHexString())
 
@@ -392,7 +408,7 @@ export function handleLockManagerAdded(event: LockManagerAddedEvent): void {
 
 export function handleLockManagerRemoved(event: LockManagerRemovedEvent): void {
   const lock = Lock.load(event.address.toHexString())
-  if (lock && lock.lockManagers) {
+  if (lock && lock.lockManagers && lock.version.le(BigInt.fromI32(8))) {
     const newManagers: Bytes[] = []
     for (let i = 0; i < lock.lockManagers.length; i++) {
       const managerAddress = lock.lockManagers[i]

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -87,7 +87,7 @@ export function handleNewLock(event: NewLock): void {
 
   // maxKeysPerAddress set to 1 prior to lock v10
   lock.maxKeysPerAddress = BigInt.fromI32(1)
-  if (version.ge(BigInt.fromI32(9))) {
+  if (version.ge(BigInt.fromI32(10))) {
     let maxKeysPerAddress = lockContract.try_maxKeysPerAddress()
     if (!maxKeysPerAddress.reverted) {
       lock.maxKeysPerAddress = maxKeysPerAddress.value

--- a/subgraph/tests/keys-utils.ts
+++ b/subgraph/tests/keys-utils.ts
@@ -42,12 +42,12 @@ import { newCancelKeyTransactionReceipt } from './mockTxReceipt'
 import { KEY_GRANTER } from '../src/helpers'
 
 export function mockDataSourceV8(): void {
-  const V8context = new DataSourceContext()
-  V8context.set(
+  const v8Context = new DataSourceContext()
+  v8Context.set(
     'lockAddress',
     Value.fromAddress(Address.fromString(lockAddressV8))
   )
-  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', V8context)
+  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', v8Context)
 }
 
 export function mockDataSourceV11(): void {

--- a/subgraph/tests/keys-utils.ts
+++ b/subgraph/tests/keys-utils.ts
@@ -42,12 +42,12 @@ import { newCancelKeyTransactionReceipt } from './mockTxReceipt'
 import { KEY_GRANTER } from '../src/helpers'
 
 export function mockDataSourceV8(): void {
-  const v8context = new DataSourceContext()
-  v8context.set(
+  const V8context = new DataSourceContext()
+  V8context.set(
     'lockAddress',
     Value.fromAddress(Address.fromString(lockAddressV8))
   )
-  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', v8context)
+  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', V8context)
 }
 
 export function mockDataSourceV11(): void {

--- a/subgraph/tests/keys-v8.test.ts
+++ b/subgraph/tests/keys-v8.test.ts
@@ -39,8 +39,8 @@ import './mocks'
 
 const keyIDV8 = `${lockAddressV8}-${tokenId}`
 
-describe('Key transfers (v8)', () => {
-  test('Creation of a new key (v8)', () => {
+describe('Key transfers (V8)', () => {
+  test('Creation of a new key (V8)', () => {
     mockDataSourceV8()
     const newTransferEvent = createTransferEvent(
       Address.fromString(nullAddress),
@@ -67,7 +67,7 @@ describe('Key transfers (v8)', () => {
 })
 
 describe('Change in expiration timestamp', () => {
-  test('should increase key timestamp (v8)', () => {
+  test('should increase key timestamp (V8)', () => {
     mockDataSourceV8()
     // create a key
     const newTransferEvent = createTransferEvent(
@@ -92,7 +92,7 @@ describe('Change in expiration timestamp', () => {
 })
 
 describe('Key is expired by lock manager', () => {
-  test('should update the key expiration (v8)', () => {
+  test('should update the key expiration (V8)', () => {
     mockDataSourceV8()
     // create a key
     const newTransferEvent = createTransferEvent(
@@ -115,7 +115,7 @@ describe('Key is expired by lock manager', () => {
 describe('Key managers', () => {
   const newKeyManagerAddress = '0x0000000000000000000000000000000000000132'
 
-  test('key manager changed (v8)', () => {
+  test('key manager changed (V8)', () => {
     mockDataSourceV8()
 
     // create a key
@@ -138,7 +138,7 @@ describe('Key managers', () => {
 })
 
 describe('RenewKeyPurchase (lock <v10)', () => {
-  test('extend a key by the correct time (v8)', () => {
+  test('extend a key by the correct time (V8)', () => {
     mockDataSourceV8()
 
     // create a key

--- a/subgraph/tests/keys-v8.test.ts
+++ b/subgraph/tests/keys-v8.test.ts
@@ -39,8 +39,8 @@ import './mocks'
 
 const keyIDV8 = `${lockAddressV8}-${tokenId}`
 
-describe('Key transfers (V8)', () => {
-  test('Creation of a new key (V8)', () => {
+describe('Key transfers (v8)', () => {
+  test('Creation of a new key (v8)', () => {
     mockDataSourceV8()
     const newTransferEvent = createTransferEvent(
       Address.fromString(nullAddress),
@@ -67,7 +67,7 @@ describe('Key transfers (V8)', () => {
 })
 
 describe('Change in expiration timestamp', () => {
-  test('should increase key timestamp (V8)', () => {
+  test('should increase key timestamp (v8)', () => {
     mockDataSourceV8()
     // create a key
     const newTransferEvent = createTransferEvent(
@@ -92,7 +92,7 @@ describe('Change in expiration timestamp', () => {
 })
 
 describe('Key is expired by lock manager', () => {
-  test('should update the key expiration (V8)', () => {
+  test('should update the key expiration (v8)', () => {
     mockDataSourceV8()
     // create a key
     const newTransferEvent = createTransferEvent(
@@ -115,7 +115,7 @@ describe('Key is expired by lock manager', () => {
 describe('Key managers', () => {
   const newKeyManagerAddress = '0x0000000000000000000000000000000000000132'
 
-  test('key manager changed (V8)', () => {
+  test('key manager changed (v8)', () => {
     mockDataSourceV8()
 
     // create a key
@@ -138,7 +138,7 @@ describe('Key managers', () => {
 })
 
 describe('RenewKeyPurchase (lock <v10)', () => {
-  test('extend a key by the correct time (V8)', () => {
+  test('extend a key by the correct time (v8)', () => {
     mockDataSourceV8()
 
     // create a key

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -21,12 +21,12 @@ import { KEY_GRANTER, LOCK_MANAGER } from '../src/helpers'
 import { PricingChanged } from '../generated/templates/PublicLock/PublicLock'
 
 export function mockDataSourceV8(): void {
-  const V8context = new DataSourceContext()
-  V8context.set(
+  const v8Context = new DataSourceContext()
+  v8Context.set(
     'lockAddress',
     Value.fromAddress(Address.fromString(lockAddressV8))
   )
-  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', V8context)
+  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', v8Context)
 }
 
 export function createNewLockEvent(

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -21,12 +21,12 @@ import { KEY_GRANTER, LOCK_MANAGER } from '../src/helpers'
 import { PricingChanged } from '../generated/templates/PublicLock/PublicLock'
 
 export function mockDataSourceV8(): void {
-  const v8context = new DataSourceContext()
-  v8context.set(
+  const V8context = new DataSourceContext()
+  V8context.set(
     'lockAddress',
     Value.fromAddress(Address.fromString(lockAddressV8))
   )
-  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', v8context)
+  dataSourceMock.setReturnValues(lockAddressV8, 'rinkeby', V8context)
 }
 
 export function createNewLockEvent(
@@ -213,4 +213,31 @@ export function createRoleRevokedKeyGranterRemovedEvent(
   )
 
   return newRoleRevokedEvent
+}
+
+export function createRoleRevokedLockManagerRemovedEvent(
+  lockManager: Address
+): RoleRevoked {
+  const newLockManagerRevoked = changetype<RoleRevoked>(newMockEvent())
+
+  // set existing lock address
+  newLockManagerRevoked.address = Address.fromString(lockAddress)
+
+  newLockManagerRevoked.parameters = []
+  newLockManagerRevoked.parameters.push(
+    new ethereum.EventParam(
+      'role',
+      ethereum.Value.fromBytes(Bytes.fromHexString(LOCK_MANAGER))
+    )
+  )
+
+  newLockManagerRevoked.parameters.push(
+    new ethereum.EventParam('account', ethereum.Value.fromAddress(lockManager))
+  )
+
+  newLockManagerRevoked.parameters.push(
+    new ethereum.EventParam('sender', ethereum.Value.fromString(lockAddress))
+  )
+
+  return newLockManagerRevoked
 }

--- a/subgraph/tests/locks-v11.test.ts
+++ b/subgraph/tests/locks-v11.test.ts
@@ -143,47 +143,6 @@ describe('Describe Locks events', () => {
     )
   })
 
-  // event should be ignored in v11 as we use `RoleGranted` instead
-  test('Lock manager added (using `LockManagerAdded`)', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-    const newLockManagerAdded = createLockManagerAddedEvent(
-      Address.fromString(lockManagers[1])
-    )
-    handleLockManagerAdded(newLockManagerAdded)
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-  })
-
-  test('Lock manager removed', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-
-    const newLockManagerRemoved = createLockManagerRemovedEvent(
-      Address.fromString(lockManagers[0])
-    )
-    handleLockManagerRemoved(newLockManagerRemoved)
-
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-  })
-
   test('key granter added (using `RoleGranted`)', () => {
     assert.fieldEquals('Lock', lockAddress, 'keyGranters', `[]`)
     const newKeyGranterAdded = createRoleGrantedKeyGranterAddedEvent(
@@ -223,54 +182,12 @@ describe('Describe Locks events', () => {
     )
   })
 
-  // event should be ignored in v11 as we use `RoleGranted` instead
-  test('Key granter added (using `KeyGranterAdded`)', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-    const newKeyGranterAdded = createKeyGranterAddedEvent(
-      Address.fromString(keyOwnerAddress)
-    )
-
-    handleKeyGranterAdded(newKeyGranterAdded)
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-  })
-
-  test('Key granter removed', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-
-    const newKeyGranterRemoved = createKeyGranterRemovedEvent(
-      Address.fromString(keyGranters[0])
-    )
-    handleKeyGranterRemoved(newKeyGranterRemoved)
-
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-  })
-
   test('key granter removed (using `RoleRevoked`)', () => {
     assert.fieldEquals(
       'Lock',
       lockAddress,
       'keyGranters',
-      `[${keyGranters[1]}, ${keyGranters[2]}]`
+      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
     )
 
     handleRoleRevoked(
@@ -282,7 +199,7 @@ describe('Describe Locks events', () => {
       'Lock',
       lockAddress,
       'keyGranters',
-      `[${keyGranters[2]}]`
+      `[${keyGranters[0]}, ${keyGranters[2]}]`
     )
   })
 
@@ -321,5 +238,90 @@ describe('Describe Locks events', () => {
     assert.fieldEquals('Lock', lockAddress, 'name', name)
     assert.fieldEquals('Lock', lockAddress, 'symbol', symbol)
     // assert.fieldEquals('Lock', lockAddress, 'baseTokenURI', `12`)
+  })
+
+  describe('[Deprecation] Custom events replaced by OZ native role events in v8', () => {
+    // event should be ignored in v11 as we use `RoleGranted` instead
+    test('The `KeyGranterAdded` event does not create a record', () => {
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'keyGranters',
+        `[${keyGranters[0]}, ${keyGranters[2]}]`
+      )
+      const newKeyGranterAdded = createKeyGranterAddedEvent(
+        Address.fromString(keyOwnerAddress)
+      )
+
+      handleKeyGranterAdded(newKeyGranterAdded)
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'keyGranters',
+        `[${keyGranters[0]}, ${keyGranters[2]}]`
+      )
+    })
+
+    test('The `KeyGranterRemoved` event does not create a record', () => {
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'keyGranters',
+        `[${keyGranters[0]}, ${keyGranters[2]}]`
+      )
+
+      const newKeyGranterRemoved = createKeyGranterRemovedEvent(
+        Address.fromString(keyGranters[0])
+      )
+      handleKeyGranterRemoved(newKeyGranterRemoved)
+
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'keyGranters',
+        `[${keyGranters[0]}, ${keyGranters[2]}]`
+      )
+    })
+
+    // event should be ignored in v11 as we use `RoleGranted` instead
+    test('The `LockManagerAdded` does not create a record', () => {
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'lockManagers',
+        `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
+      )
+      const newLockManagerAdded = createLockManagerAddedEvent(
+        Address.fromString(lockManagers[1])
+      )
+      handleLockManagerAdded(newLockManagerAdded)
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'lockManagers',
+        `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
+      )
+    })
+
+    test('the `LockManagerRemoved` does not affect existing records', () => {
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'lockManagers',
+        `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
+      )
+
+      const newLockManagerRemoved = createLockManagerRemovedEvent(
+        Address.fromString(lockManagers[0])
+      )
+      handleLockManagerRemoved(newLockManagerRemoved)
+
+      assert.fieldEquals(
+        'Lock',
+        lockAddress,
+        'lockManagers',
+        `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
+      )
+    })
   })
 })

--- a/subgraph/tests/locks-v8.test.ts
+++ b/subgraph/tests/locks-v8.test.ts
@@ -46,7 +46,7 @@ describe('Describe Locks events (v8)', () => {
     assert.entityCount('Lock', 1)
     assert.fieldEquals('Lock', lockAddressV8, 'address', lockAddressV8)
     assert.fieldEquals('Lock', lockAddressV8, 'createdAtBlock', '1')
-    assert.fieldEquals('Lock', lockAddressV8, 'version', '8')
+    assert.fieldEquals('Lock', lockAddressV8, 'version', '9')
     assert.fieldEquals('Lock', lockAddressV8, 'price', '1000')
     assert.fieldEquals('Lock', lockAddressV8, 'name', 'My lock v8')
     assert.fieldEquals(
@@ -56,8 +56,8 @@ describe('Describe Locks events (v8)', () => {
       `${duration}`
     )
     assert.fieldEquals('Lock', lockAddressV8, 'tokenAddress', nullAddress)
-    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
-    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[${lockOwner}]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
 
     assert.fieldEquals('Lock', lockAddressV8, 'totalKeys', '0')
     assert.fieldEquals('Lock', lockAddressV8, 'numberOfReceipts', '0')
@@ -70,36 +70,28 @@ describe('Describe Locks events (v8)', () => {
     assert.fieldEquals('Lock', lockAddressV8, 'maxKeysPerAddress', '1')
   })
 
-  test('Lock manager added (v8)', () => {
-    mockDataSourceV8()
-    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
-    const newLockManagerAdded = createLockManagerAddedEvent(
-      Address.fromString(lockManagers[0])
-    )
-    handleLockManagerAdded(newLockManagerAdded)
+  describe('[Deprecation] Custom events replaced by OZ native role events in v8', () => {
+    test('The `LockManagerAdded` event is not used', () => {
+      mockDataSourceV8()
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+      const newLockManagerAdded = createLockManagerAddedEvent(
+        Address.fromString(lockManagers[0])
+      )
+      handleLockManagerAdded(newLockManagerAdded)
 
-    assert.fieldEquals(
-      'Lock',
-      lockAddressV8,
-      'lockManagers',
-      `[${lockOwner}, ${lockManagers[0]}]`
-    )
-  })
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    })
 
-  test('Key granter added (v8)', () => {
-    mockDataSourceV8()
-    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[${lockOwner}]`)
-    const newKeyGranterAdded = createKeyGranterAddedEvent(
-      Address.fromString(keyGranters[0])
-    )
-    handleKeyGranterAdded(newKeyGranterAdded)
+    test('The `KeyGranterAdded` event is not used', () => {
+      mockDataSourceV8()
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+      const newKeyGranterAdded = createKeyGranterAddedEvent(
+        Address.fromString(keyGranters[0])
+      )
+      handleKeyGranterAdded(newKeyGranterAdded)
 
-    assert.fieldEquals(
-      'Lock',
-      lockAddressV8,
-      'keyGranters',
-      `[${lockOwner}, ${keyGranters[0]}]`
-    )
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+    })
   })
 
   afterAll(() => {

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -31,6 +31,7 @@ import {
   createLockMetadata,
   mockDataSourceV8,
   createRoleRevokedKeyGranterRemovedEvent,
+  createRoleRevokedLockManagerRemovedEvent,
 } from './locks-utils'
 import {
   createKeyExtendedEvent,
@@ -154,48 +155,7 @@ describe('Describe Locks events', () => {
     )
   })
 
-  // event should be ignored in v11 as we use `RoleGranted` instead
-  test('Lock manager added (using `LockManagerAdded`)', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-    const newLockManagerAdded = createLockManagerAddedEvent(
-      Address.fromString(lockManagers[1])
-    )
-    handleLockManagerAdded(newLockManagerAdded)
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-  })
-
-  test('Lock manager removed', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-
-    const newLockManagerRemoved = createLockManagerRemovedEvent(
-      Address.fromString(lockManagers[0])
-    )
-    handleLockManagerRemoved(newLockManagerRemoved)
-
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'lockManagers',
-      `[${lockManagers[1]}, ${lockManagers[2]}]`
-    )
-  })
-
-  test('key granter added (using `RoleGranted`)', () => {
+  test('Key granter added (using `RoleGranted`)', () => {
     assert.fieldEquals('Lock', lockAddress, 'keyGranters', `[]`)
     const newKeyGranterAdded = createRoleGrantedKeyGranterAddedEvent(
       Address.fromString(keyGranters[0])
@@ -234,54 +194,12 @@ describe('Describe Locks events', () => {
     )
   })
 
-  // event should be ignored in v11 as we use `RoleGranted` instead
-  test('Key granter added (using `KeyGranterAdded`)', () => {
+  test('Key granter removed (using `RoleRevoked`)', () => {
     assert.fieldEquals(
       'Lock',
       lockAddress,
       'keyGranters',
       `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-    const newKeyGranterAdded = createKeyGranterAddedEvent(
-      Address.fromString(keyOwnerAddress)
-    )
-
-    handleKeyGranterAdded(newKeyGranterAdded)
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-  })
-
-  test('Key granter removed', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[0]}, ${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-
-    const newKeyGranterRemoved = createKeyGranterRemovedEvent(
-      Address.fromString(keyGranters[0])
-    )
-    handleKeyGranterRemoved(newKeyGranterRemoved)
-
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[1]}, ${keyGranters[2]}]`
-    )
-  })
-
-  test('key granter removed (using `RoleRevoked`)', () => {
-    assert.fieldEquals(
-      'Lock',
-      lockAddress,
-      'keyGranters',
-      `[${keyGranters[1]}, ${keyGranters[2]}]`
     )
 
     handleRoleRevoked(
@@ -293,7 +211,28 @@ describe('Describe Locks events', () => {
       'Lock',
       lockAddress,
       'keyGranters',
-      `[${keyGranters[2]}]`
+      `[${keyGranters[0]}, ${keyGranters[2]}]`
+    )
+  })
+
+  test('Lock managers removed (using `RoleRevoked`)', () => {
+    assert.fieldEquals(
+      'Lock',
+      lockAddress,
+      'lockManagers',
+      `[${lockManagers[0]}, ${lockManagers[1]}, ${lockManagers[2]}]`
+    )
+
+    handleRoleRevoked(
+      createRoleRevokedLockManagerRemovedEvent(
+        Address.fromString(lockManagers[1])
+      )
+    )
+    assert.fieldEquals(
+      'Lock',
+      lockAddress,
+      'lockManagers',
+      `[${lockManagers[0]}, ${lockManagers[2]}]`
     )
   })
 
@@ -384,11 +323,12 @@ describe('Describe Locks events (v8)', () => {
     )
     handleNewLock(newLockEvent)
   })
+
   test('Creation of a new lock (v8)', () => {
     assert.entityCount('Lock', 1)
     assert.fieldEquals('Lock', lockAddressV8, 'address', lockAddressV8)
     assert.fieldEquals('Lock', lockAddressV8, 'createdAtBlock', '1')
-    assert.fieldEquals('Lock', lockAddressV8, 'version', '8')
+    assert.fieldEquals('Lock', lockAddressV8, 'version', '9')
     assert.fieldEquals('Lock', lockAddressV8, 'price', '1000')
     assert.fieldEquals('Lock', lockAddressV8, 'name', 'My lock v8')
     assert.fieldEquals(
@@ -398,8 +338,8 @@ describe('Describe Locks events (v8)', () => {
       `${duration}`
     )
     assert.fieldEquals('Lock', lockAddressV8, 'tokenAddress', nullAddress)
-    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
-    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[${lockOwner}]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
 
     assert.fieldEquals('Lock', lockAddressV8, 'totalKeys', '0')
     assert.fieldEquals('Lock', lockAddressV8, 'numberOfReceipts', '0')
@@ -412,36 +352,67 @@ describe('Describe Locks events (v8)', () => {
     assert.fieldEquals('Lock', lockAddressV8, 'maxKeysPerAddress', '1')
   })
 
-  test('Lock manager added (v8)', () => {
-    mockDataSourceV8()
-    assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[${lockOwner}]`)
-    const newLockManagerAdded = createLockManagerAddedEvent(
-      Address.fromString(lockManagers[0])
-    )
-    handleLockManagerAdded(newLockManagerAdded)
+  describe('[Deprecation] Custom events replaced by OZ native role events in v8', () => {
+    test('The `LockManagerAdded` does not create a record', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+      const newLockManagerAdded = createLockManagerAddedEvent(
+        Address.fromString(lockManagers[0])
+      )
+      handleLockManagerAdded(newLockManagerAdded)
+      // remains unchanged
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    })
 
-    assert.fieldEquals(
-      'Lock',
-      lockAddressV8,
-      'lockManagers',
-      `[${lockOwner}, ${lockManagers[0]}]`
-    )
-  })
+    test('the `LockManagerRemoved` does not affect existing records', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
 
-  test('Key granter added (v8)', () => {
-    mockDataSourceV8()
-    assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[${lockOwner}]`)
-    const newKeyGranterAdded = createKeyGranterAddedEvent(
-      Address.fromString(keyGranters[0])
-    )
-    handleKeyGranterAdded(newKeyGranterAdded)
+      const newLockManagerRemoved = createLockManagerRemovedEvent(
+        Address.fromString(lockManagers[0])
+      )
+      handleLockManagerRemoved(newLockManagerRemoved)
 
-    assert.fieldEquals(
-      'Lock',
-      lockAddressV8,
-      'keyGranters',
-      `[${lockOwner}, ${keyGranters[0]}]`
-    )
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    })
+
+    test('The `KeyGranterAdded` event does not create a record', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+      const newKeyGranterAdded = createKeyGranterAddedEvent(
+        Address.fromString(keyGranters[0])
+      )
+      handleKeyGranterAdded(newKeyGranterAdded)
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+    })
+
+    test('The `KeyGranterRemoved` event does not create a record', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+
+      const newKeyGranterRemoved = createKeyGranterRemovedEvent(
+        Address.fromString(keyGranters[0])
+      )
+      handleKeyGranterRemoved(newKeyGranterRemoved)
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+    })
+
+    // event should be ignored in v11 as we use `RoleGranted` instead
+    test('Lock manager added (using `LockManagerAdded`)', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+      const newLockManagerAdded = createLockManagerAddedEvent(
+        Address.fromString(lockManagers[1])
+      )
+      handleLockManagerAdded(newLockManagerAdded)
+      assert.fieldEquals('Lock', lockAddressV8, 'lockManagers', `[]`)
+    })
+
+    // event should be ignored in v11 as we use `RoleGranted` instead
+    test('Key granter added (using `KeyGranterAdded`)', () => {
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+      const newKeyGranterAdded = createKeyGranterAddedEvent(
+        Address.fromString(keyOwnerAddress)
+      )
+
+      handleKeyGranterAdded(newKeyGranterAdded)
+      assert.fieldEquals('Lock', lockAddressV8, 'keyGranters', `[]`)
+    })
   })
 
   afterAll(() => {

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -328,7 +328,7 @@ describe('Describe Locks events (v8)', () => {
     assert.entityCount('Lock', 1)
     assert.fieldEquals('Lock', lockAddressV8, 'address', lockAddressV8)
     assert.fieldEquals('Lock', lockAddressV8, 'createdAtBlock', '1')
-    assert.fieldEquals('Lock', lockAddressV8, 'version', '8')
+    assert.fieldEquals('Lock', lockAddressV8, 'version', '9')
     assert.fieldEquals('Lock', lockAddressV8, 'price', '1000')
     assert.fieldEquals('Lock', lockAddressV8, 'name', 'My lock v8')
     assert.fieldEquals(

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -328,7 +328,7 @@ describe('Describe Locks events (v8)', () => {
     assert.entityCount('Lock', 1)
     assert.fieldEquals('Lock', lockAddressV8, 'address', lockAddressV8)
     assert.fieldEquals('Lock', lockAddressV8, 'createdAtBlock', '1')
-    assert.fieldEquals('Lock', lockAddressV8, 'version', '9')
+    assert.fieldEquals('Lock', lockAddressV8, 'version', '8')
     assert.fieldEquals('Lock', lockAddressV8, 'price', '1000')
     assert.fieldEquals('Lock', lockAddressV8, 'name', 'My lock v8')
     assert.fieldEquals(

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -143,7 +143,7 @@ createMockedFunction(
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(tokenId))])
 
 /**
- * Mocks function for V8 locks
+ * Mocks function for v8 locks
  */
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -151,7 +151,7 @@ createMockedFunction(
   'publicLockVersion():(uint16)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -159,7 +159,7 @@ createMockedFunction(
   'publicLockVersion():(uint256)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -151,7 +151,7 @@ createMockedFunction(
   'publicLockVersion():(uint16)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -159,7 +159,7 @@ createMockedFunction(
   'publicLockVersion():(uint256)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),

--- a/subgraph/tests/mocks.ts
+++ b/subgraph/tests/mocks.ts
@@ -143,7 +143,7 @@ createMockedFunction(
   .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromU32(tokenId))])
 
 /**
- * Mocks function for v8 locks
+ * Mocks function for V8 locks
  */
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -151,7 +151,7 @@ createMockedFunction(
   'publicLockVersion():(uint16)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),
@@ -159,7 +159,7 @@ createMockedFunction(
   'publicLockVersion():(uint256)'
 )
   .withArgs([])
-  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('8'))])
+  .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString('9'))])
 
 createMockedFunction(
   Address.fromString(lockAddressV8),


### PR DESCRIPTION
# Description

The parsing of roles in subgraph was not really consistent as we were using both our own events and the OZ native role events. This clarifies what is happening by refactoring the tests and logic and using only OZ native events

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
