### PR TITLE
fix(ci): use proxy to post Github feedback comment when adding a new network

### DIFF
--- a/.github/workflows/_networks.yml
+++ b/.github/workflows/_networks.yml
@@ -64,3 +64,4 @@ jobs:
         with:
           message-path: results.txt
           refresh-message-position: true
+          proxy-url: "https://8080-cs-647313627692-default.cs-europe-west1-iuzs.cloudshell.dev"

--- a/.github/workflows/_networks.yml
+++ b/.github/workflows/_networks.yml
@@ -64,4 +64,6 @@ jobs:
         with:
           message-path: results.txt
           refresh-message-position: true
+          # We rely on a deployment of a proxy service to post comment from forked PRs
+          # see https://github.com/mshick/add-pr-comment-proxy for more info
           proxy-url: "https://8080-cs-647313627692-default.cs-europe-west1-iuzs.cloudshell.dev"


### PR DESCRIPTION
# Description

This adds a proxy (required to add a github comment on a forked pull request) - see #13533

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
