### PR TITLE
fix(ci): ignore index file when adding a new network

### DIFF
--- a/packages/networks/bin/validate.ts
+++ b/packages/networks/bin/validate.ts
@@ -16,7 +16,9 @@ const run = async () => {
   const results = {}
 
   const fileList = process.env.ALL_CHANGED_FILES
-    ? process.env.ALL_CHANGED_FILES.split(' ')
+    ? process.env.ALL_CHANGED_FILES.split(' ').filter(
+        (f) => !f.includes(`networks/index.ts`)
+      )
     : []
 
   for (const filePath of fileList) {


### PR DESCRIPTION
# Description

Fixes a parsing error that causes the CI to fail when adding a new network

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs see https://github.com/unlock-protocol/unlock/issues/13533

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
