### PR TITLE
fix(unlock-app): skipping recipients if all fields are hidden

### DIFF
--- a/unlock-app/src/__tests__/components/interface/checkout/main/utils.test.ts
+++ b/unlock-app/src/__tests__/components/interface/checkout/main/utils.test.ts
@@ -1,0 +1,89 @@
+import { it, describe, expect } from 'vitest'
+import { shouldSkip } from '~/components/interface/checkout/main/utils'
+
+describe('shouldSkip', () => {
+  it('it should skip if skipRecipient is set at the root level', () => {
+    expect(
+      shouldSkip({
+        lock: { maxRecipients: 1 },
+        paywallConfig: {
+          skipRecipient: true,
+          locks: {
+            '0x123': { maxRecipients: 1 },
+          },
+        },
+      }).skipRecipient
+    ).toBe(true)
+  })
+  it('it should not skip if skipRecipient is set to true but if there are metadataInputs', () => {
+    expect(
+      shouldSkip({
+        lock: { maxRecipients: 1 },
+        paywallConfig: {
+          skipRecipient: true,
+          metadataInputs: [
+            {
+              type: 'email',
+              name: 'email',
+              required: true,
+              public: false,
+            },
+          ],
+          locks: {
+            '0x123': { maxRecipients: 1 },
+          },
+        },
+      }).skipRecipient
+    ).toBe(false)
+  })
+
+  it('it should skip if skipRecipient is set to true and if there are only hidden metadataInputs', () => {
+    expect(
+      shouldSkip({
+        lock: { maxRecipients: 1 },
+        paywallConfig: {
+          skipRecipient: true,
+          metadataInputs: [
+            {
+              type: 'hidden',
+              name: 'email',
+              required: true,
+              public: false,
+            },
+          ],
+          locks: {
+            '0x123': { maxRecipients: 1 },
+          },
+        },
+      }).skipRecipient
+    ).toBe(true)
+  })
+
+  it('it should not skip if skipRecipient is set to true and if there are non-hidden metadataInputs', () => {
+    expect(
+      shouldSkip({
+        lock: { maxRecipients: 1 },
+        paywallConfig: {
+          skipRecipient: true,
+          metadataInputs: [
+            {
+              type: 'hidden',
+              name: 'email',
+              required: true,
+              public: false,
+            },
+            {
+              type: 'text',
+              name: 'name',
+              required: true,
+              public: false,
+            },
+          ],
+          locks: {
+            '0x123': { maxRecipients: 1 },
+          },
+        },
+      }).skipRecipient
+    ).toBe(false)
+  })
+})

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -35,6 +35,7 @@ import {
 } from '@unlock-protocol/core'
 import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import Disconnect from './Disconnect'
+import { shouldSkip } from './utils'
 
 interface Props {
   checkoutService: CheckoutService
@@ -116,7 +117,7 @@ export const MetadataInputs = ({
   )
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account
-  const hideRecipient = shouldHideRecipient(paywallConfig, lock)
+  const hideRecipient = shouldSkip({ paywallConfig, lock }).skipRecipient
 
   return (
     <div className="grid gap-2">
@@ -467,13 +468,4 @@ const recipientFromConfig = (
     return lockRecipient
   }
   return ''
-}
-
-const shouldHideRecipient = (
-  paywall: PaywallConfigType,
-  lock: Lock | LockState | undefined
-): boolean => {
-  return !!(
-    paywall.skipRecipient || paywall?.locks[lock!.address].skipRecipient
-  )
 }

--- a/unlock-app/src/components/interface/checkout/main/Returning.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Returning.tsx
@@ -16,6 +16,7 @@ import { ReturningButton } from '../ReturningButton'
 import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 import { useGetTokenIdForOwner } from '~/hooks/useGetTokenIdForOwner'
 import { Platform } from '~/services/passService'
+import { shouldSkip } from './utils'
 
 interface Props {
   checkoutService: CheckoutService
@@ -156,16 +157,17 @@ export function Returning({ checkoutService, onClose, communication }: Props) {
                 returnLabel="Return"
                 checkoutService={checkoutService}
               />
-              {!lock?.isSoldOut && !paywallConfig.skipRecipient && (
-                <Button
-                  className="w-full"
-                  onClick={() =>
-                    checkoutService.send({ type: 'MAKE_ANOTHER_PURCHASE' })
-                  }
-                >
-                  Buy more
-                </Button>
-              )}
+              {!lock?.isSoldOut &&
+                !shouldSkip({ paywallConfig, lock }).skipRecipient && (
+                  <Button
+                    className="w-full"
+                    onClick={() =>
+                      checkoutService.send({ type: 'MAKE_ANOTHER_PURCHASE' })
+                    }
+                  >
+                    Buy more
+                  </Button>
+                )}
             </div>
           )}
         </div>

--- a/unlock-app/src/components/interface/checkout/main/utils.ts
+++ b/unlock-app/src/components/interface/checkout/main/utils.ts
@@ -72,11 +72,15 @@ export const shouldSkip = ({ lock, paywallConfig }: Options) => {
   const skipQuantity = !(hasMaxRecipients || hasMinRecipients)
 
   const skip = lock?.skipRecipient || paywallConfig?.skipRecipient
+
+  const metadataInputs = lock?.metadataInputs || paywallConfig?.metadataInputs
+
+  const hasMetadataInputs =
+    metadataInputs &&
+    metadataInputs.filter((input) => input.type !== 'hidden').length > 0
+
   const collectsMetadadata =
-    lock?.metadataInputs ||
-    paywallConfig?.metadataInputs ||
-    paywallConfig?.emailRequired ||
-    lock?.emailRequired
+    hasMetadataInputs || paywallConfig?.emailRequired || lock?.emailRequired
   const skipRecipient = Boolean(skip && !collectsMetadadata)
 
   return {


### PR DESCRIPTION
# Description

Skipping the recipient step if/when configured to hide and all metadata inputs are hidden!


# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
