### PR TITLE
fix(unlock-app): Attendees specific view

### DIFF
--- a/unlock-app/src/components/content/event/attendees/MetadataCard.tsx
+++ b/unlock-app/src/components/content/event/attendees/MetadataCard.tsx
@@ -2,12 +2,18 @@ import { Badge, Button, Detail } from '@unlock-protocol/ui'
 import React, { useState } from 'react'
 import { useMarkAsCheckInMutation } from '~/hooks/useMarkAsCheckImMutation'
 import { getCheckInTime } from '~/utils/getCheckInTime'
+import { locksmith } from '~/config/locksmith'
 import { FaCheckCircle as CheckIcon } from 'react-icons/fa'
+import { useMutation } from '@tanstack/react-query'
+import { ToastHelper } from '~/components/helpers/toast.helper'
+import { UpdateEmailModal } from './UpdateEmailModal'
+import { FieldValues } from 'react-hook-form'
 
 interface MetadataCardProps {
   metadata: Record<string, any>
   network: number
   data: { lockAddress: string; token: string }
+  lockSettings?: Record<string, any>
 }
 
 const MetadataCard: React.FC<MetadataCardProps> = ({
@@ -18,10 +24,16 @@ const MetadataCard: React.FC<MetadataCardProps> = ({
   const [checkInTimestamp, setCheckedInTimestamp] = useState<string | null>(
     null
   )
+  const [addEmailModalOpen, setAddEmailModalOpen] = useState(false)
+  const [cardData, setCardData] = useState(metadata)
 
   const isCheckedIn =
-    typeof getCheckInTime(checkInTimestamp, metadata) === 'string' ||
+    typeof getCheckInTime(checkInTimestamp, cardData) === 'string' ||
     !!checkInTimestamp
+
+  const hasEmail = Object.entries(cardData || {})
+    .map(([key]) => key.toLowerCase())
+    .includes('email')
 
   const markAsCheckInMutation = useMarkAsCheckInMutation({
     network,
@@ -29,56 +41,144 @@ const MetadataCard: React.FC<MetadataCardProps> = ({
     setCheckedInTimestamp,
   })
 
-  return (
-    <div>
-      {!isCheckedIn && (
-        <Button
-          variant="outlined-primary"
-          size="small"
-          onClick={() => markAsCheckInMutation.mutate()}
-          disabled={markAsCheckInMutation.isPending}
-          loading={markAsCheckInMutation.isPending}
-        >
-          Mark as checked-in
-        </Button>
-      )}
-      <div className="pt-6">
-        {isCheckedIn && (
-          <Badge
-            size="tiny"
-            variant="green"
-            iconRight={<CheckIcon size={11} />}
-            className="mb-4"
-          >
-            <span className="text-sm font-semibold">Checked-in</span>
-          </Badge>
-        )}
+  const onSendQrCode = async () => {
+    if (!network) return
+    ToastHelper.promise(sendEmailMutation.mutateAsync(), {
+      success: 'Email sent',
+      loading: 'Sending email...',
+      error: 'We could not send email.',
+    })
+  }
 
-        <div className="flex flex-col divide-y divide-gray-400">
+  const sendEmail = async () => {
+    return locksmith.emailTicket(
+      network,
+      cardData?.lockAddress,
+      cardData?.token
+    )
+  }
+
+  const sendEmailMutation = useMutation({
+    mutationFn: sendEmail,
+  })
+
+  const onEmailChange = (values: FieldValues) => {
+    setCardData((prevData) => ({
+      ...prevData,
+      ...values,
+    }))
+  }
+
+  const formatLabel = (key: string) => {
+    if (key === 'fullname') {
+      return 'Full name'
+    }
+    return key
+      .replace(/([A-Z])/g, ' $1')
+      .toLowerCase()
+      .replace(/^./, (str) => str.toUpperCase())
+  }
+
+  return (
+    <>
+      <UpdateEmailModal
+        isOpen={addEmailModalOpen}
+        setIsOpen={setAddEmailModalOpen}
+        isLockManager={true}
+        userAddress={metadata?.keyholderAddress}
+        lockAddress={metadata?.lockAddress}
+        network={network}
+        hasEmail={hasEmail}
+        onEmailChange={onEmailChange}
+      />
+      <div>
+        {!isCheckedIn && (
+          <Button
+            variant="outlined-primary"
+            size="small"
+            onClick={() => markAsCheckInMutation.mutate()}
+            disabled={markAsCheckInMutation.isPending}
+            loading={markAsCheckInMutation.isPending}
+          >
+            Mark as checked-in
+          </Button>
+        )}
+        <div className="pt-6">
           {isCheckedIn && (
+            <Badge
+              size="tiny"
+              variant="green"
+              iconRight={<CheckIcon size={11} />}
+              className="mb-4"
+            >
+              <span className="text-sm font-semibold">Checked-in</span>
+            </Badge>
+          )}
+
+          <div className="flex flex-col divide-y divide-gray-400">
+            {isCheckedIn && (
+              <Detail
+                className="py-2"
+                inline
+                justify={false}
+                label="Checked-in at:"
+              >
+                {getCheckInTime(checkInTimestamp, metadata)}
+              </Detail>
+            )}
+
             <Detail
               className="py-2"
-              inline
-              justify={false}
-              label="Checked-in at:"
-            >
-              {getCheckInTime(checkInTimestamp, metadata)}
-            </Detail>
-          )}
-          {Object.entries(metadata || {})
-            .filter(([key]) => {
-              return ![
-                'keyholderAddress',
-                'keyManager',
-                'lockAddress',
-              ].includes(key)
-            })
-            .map(([key, value]: any, index: number) => {
+              label={
+                <div className="flex flex-row w-full gap-2 items-center">
+                  <span>Email:</span>
+                  {hasEmail ? (
+                    <div className="flex flex-row w-full gap-3 items-center">
+                      <span className="text-base font-semibold text-black">
+                        {metadata?.email}
+                      </span>
+                      <Button
+                        size="tiny"
+                        variant="outlined-primary"
+                        onClick={() => setAddEmailModalOpen(true)}
+                      >
+                        Edit email
+                      </Button>
+
+                      <Button
+                        size="tiny"
+                        variant="outlined-primary"
+                        onClick={onSendQrCode}
+                        disabled={
+                          sendEmailMutation.isPending ||
+                          sendEmailMutation.isSuccess
+                        }
+                      >
+                        {sendEmailMutation.isSuccess
+                          ? 'Email sent'
+                          : 'Send QR-code by email'}
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      variant="outlined-primary"
+                      size="tiny"
+                      onClick={() => setAddEmailModalOpen(true)}
+                    >
+                      Add email
+                    </Button>
+                  )}
+                </div>
+              }
+            />
+
+            {['fullname', 'lockName'].map((key, index) => {
+              const value = metadata[key]
               return (
                 <Detail
                   className="py-2"
                   key={`${key}-${index}`}
-                  label={`${key}: `}
+                  label={`${formatLabel(key)}: `}
                   inline
                   justify={false}
                 >
@@ -86,9 +186,10 @@ const MetadataCard: React.FC<MetadataCardProps> = ({
                 </Detail>
               )
             })}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/unlock-app/src/components/content/event/attendees/UpdateEmailModal.tsx
+++ b/unlock-app/src/components/content/event/attendees/UpdateEmailModal.tsx
@@ -1,0 +1,112 @@
+import { Button, Input, Modal } from '@unlock-protocol/ui'
+import { useState } from 'react'
+import { FieldValues, useForm } from 'react-hook-form'
+import { ToastHelper } from '~/components/helpers/toast.helper'
+import { useUpdateUserMetadata } from '~/hooks/useUserMetadata'
+
+export const UpdateEmailModal = ({
+  isOpen,
+  setIsOpen,
+  isLockManager,
+  userAddress,
+  lockAddress,
+  network,
+  hasEmail,
+  onEmailChange,
+}: {
+  isOpen: boolean
+  isLockManager: boolean
+  userAddress: string
+  lockAddress: string
+  network: number
+  hasEmail: boolean
+  setIsOpen: (status: boolean) => void
+  onEmailChange: (values: FieldValues) => void
+}) => {
+  const [loading, setLoading] = useState(false)
+  const { register, handleSubmit, reset } = useForm({
+    defaultValues: {
+      email: '',
+    },
+  })
+  const { mutateAsync: updateUserMetadata } = useUpdateUserMetadata({
+    lockAddress,
+    userAddress,
+    network,
+  })
+
+  const updateData = (formFields: FieldValues) => {
+    reset() // reset form state
+    setLoading(false)
+    setIsOpen(false)
+    if (typeof onEmailChange === 'function') {
+      onEmailChange(formFields)
+    }
+  }
+
+  const updateMetadata = async (params: any, callback?: () => void) => {
+    const updateMetadataPromise = updateUserMetadata(params)
+    await ToastHelper.promise(updateMetadataPromise, {
+      loading: 'Updating email address',
+      success: 'Email successfully added to member',
+      error: `Can't update the email address.`,
+    })
+    if (typeof callback === 'function') {
+      callback()
+    }
+  }
+  /**
+   * Update metadata or create a new set when not exists
+   * @param {formFields} formFields - useForm data set, all data present in form will be saved as metadata
+   */
+  const onUpdateValue = async (formFields: FieldValues) => {
+    if (!isLockManager) return
+    try {
+      setLoading(true)
+
+      updateMetadata(
+        {
+          protected: {
+            email: formFields.email,
+          },
+          public: {},
+        },
+        () => {
+          updateData(formFields)
+        }
+      )
+    } catch (err) {
+      ToastHelper.error('There is some unexpected issue, please try again')
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
+      <div className="flex flex-col gap-3">
+        <span className="mr-0 font-semibold text-md">
+          {hasEmail ? 'Update email address' : 'Add email address to metadata'}
+        </span>
+        <form onSubmit={handleSubmit(onUpdateValue)}>
+          <Input
+            type="email"
+            {...register('email', {
+              required: true,
+            })}
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setIsOpen(false)}
+              disabled={loading}
+            >
+              Abort
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {hasEmail ? 'Update email' : 'Add email'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  )
+}

--- a/unlock-app/src/components/content/event/attendees/UpdateEmailModal.tsx
+++ b/unlock-app/src/components/content/event/attendees/UpdateEmailModal.tsx
@@ -22,6 +22,7 @@ export const UpdateEmailModal = ({
   hasEmail: boolean
   setIsOpen: (status: boolean) => void
   onEmailChange: (values: FieldValues) => void
+  extraDataItems?: [string, string | number][]
 }) => {
   const [loading, setLoading] = useState(false)
   const { register, handleSubmit, reset } = useForm({

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -22,7 +22,6 @@ import { addressMinify } from '~/utils/strings'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { onResolveName } from '~/utils/resolvers'
 import { useMetadata } from '~/hooks/metadata'
-import { LockType, getLockTypeByMetadata } from '@unlock-protocol/core'
 import { FiInfo as InfoIcon } from 'react-icons/fi'
 import { TransferKeyDrawer } from '~/components/interface/keychain/TransferKeyDrawer'
 import { WrappedAddress } from '~/components/interface/WrappedAddress'
@@ -254,10 +253,6 @@ export const MetadataCard = ({
     lockAddress: metadata.lockAddress,
     network,
   })
-
-  const types = getLockTypeByMetadata(lockMetadata)
-  const [eventType] =
-    Object.entries(types ?? {}).find(([, value]) => value === true) ?? []
 
   const { lockAddress, token: tokenId } = data ?? {}
 
@@ -526,10 +521,4 @@ export const MetadataCard = ({
       </div>
     </>
   )
-}
-
-const SendEmailMapping: Record<keyof LockType, string> = {
-  isCertification: 'Send Certificate by email',
-  isEvent: 'Send QR-code by email',
-  isStamp: 'Send Stamp by email',
 }

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  Badge,
-  Input,
   Modal,
   Detail,
   AddressInput,
@@ -9,8 +7,7 @@ import {
   Tooltip,
 } from '@unlock-protocol/ui'
 import { useEffect, useState } from 'react'
-import { Controller, FieldValues, useForm } from 'react-hook-form'
-import { FaCheckCircle as CheckIcon } from 'react-icons/fa'
+import { Controller, useForm } from 'react-hook-form'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import { useLockManager } from '~/hooks/useLockManager'
@@ -23,14 +20,11 @@ import Link from 'next/link'
 import { TbReceipt as ReceiptIcon } from 'react-icons/tb'
 import { addressMinify } from '~/utils/strings'
 import { useAuth } from '~/contexts/AuthenticationContext'
-import { useUpdateUserMetadata } from '~/hooks/useUserMetadata'
 import { onResolveName } from '~/utils/resolvers'
 import { useMetadata } from '~/hooks/metadata'
 import { LockType, getLockTypeByMetadata } from '@unlock-protocol/core'
 import { FiInfo as InfoIcon } from 'react-icons/fi'
 import { TransferKeyDrawer } from '~/components/interface/keychain/TransferKeyDrawer'
-import { useMarkAsCheckInMutation } from '~/hooks/useMarkAsCheckImMutation'
-import { getCheckInTime } from '~/utils/getCheckInTime'
 import { WrappedAddress } from '~/components/interface/WrappedAddress'
 
 interface MetadataCardProps {
@@ -247,15 +241,10 @@ export const MetadataCard = ({
   owner,
   network,
   expirationDuration,
-  lockSettings,
   isExpired,
 }: MetadataCardProps) => {
   const [showTransferKey, setShowTransferKey] = useState(false)
   const [data, setData] = useState(metadata)
-  const [addEmailModalOpen, setAddEmailModalOpen] = useState(false)
-  const [checkInTimestamp, setCheckedInTimestamp] = useState<string | null>(
-    null
-  )
 
   const items = Object.entries(data || {}).filter(([key]) => {
     return !keysToIgnore.includes(key)
@@ -299,45 +288,7 @@ export const MetadataCard = ({
     },
   })
 
-  const sendEmail = async () => {
-    return locksmith.emailTicket(network, lockAddress, tokenId)
-  }
-
-  const sendEmailMutation = useMutation({
-    mutationFn: sendEmail,
-  })
-
-  const onSendQrCode = async () => {
-    if (!network) return
-    ToastHelper.promise(sendEmailMutation.mutateAsync(), {
-      success: 'Email sent',
-      loading: 'Sending email...',
-      error: 'We could not send email.',
-    })
-  }
-
-  const isCheckedIn =
-    typeof getCheckInTime(checkInTimestamp, metadata) === 'string' ||
-    !!checkInTimestamp
-
-  const hasEmail = Object.entries(data || {})
-    .map(([key]) => key.toLowerCase())
-    .includes('email')
-
-  const onEmailChange = (values: FieldValues) => {
-    setData({
-      ...data,
-      ...values,
-    })
-  }
-
   const metadataPageUrl = `/locks/metadata?lockAddress=${lockAddress}&network=${network}&keyId=${tokenId}`
-
-  const markAsCheckInMutation = useMarkAsCheckInMutation({
-    network,
-    data,
-    setCheckedInTimestamp,
-  })
 
   const ownerIsManager = owner?.toLowerCase() === manager?.toLowerCase()
   const showManager = !ownerIsManager && manager !== ADDRESS_ZERO
@@ -353,33 +304,10 @@ export const MetadataCard = ({
         lockName={lockMetadata?.name}
         owner={data?.keyholderAddress}
       />
-      <UpdateEmailModal
-        isOpen={addEmailModalOpen ?? false}
-        setIsOpen={setAddEmailModalOpen}
-        isLockManager={isLockManager ?? false}
-        userAddress={owner}
-        lockAddress={lockAddress}
-        network={network!}
-        hasEmail={hasEmail}
-        extraDataItems={items as any}
-        onEmailChange={onEmailChange}
-      />
       <div className="flex flex-col gap-3 md:flex-row">
         <Button variant="outlined-primary" size="small">
           <Link href={metadataPageUrl}>Edit token properties</Link>
         </Button>
-
-        {!isCheckedIn && (
-          <Button
-            variant="outlined-primary"
-            size="small"
-            onClick={() => markAsCheckInMutation.mutate()}
-            disabled={markAsCheckInMutation.isPending}
-            loading={markAsCheckInMutation.isPending}
-          >
-            Mark as checked-in
-          </Button>
-        )}
 
         {receiptsPageUrl?.length && (
           <Button
@@ -397,81 +325,9 @@ export const MetadataCard = ({
           </Button>
         )}
       </div>
-
       <div className="pt-6">
         <div className="mt-6">
-          {isCheckedIn && (
-            <Badge
-              size="tiny"
-              variant="green"
-              iconRight={<CheckIcon size={11} />}
-              className="mb-4"
-            >
-              <span className="text-sm font-semibold">Checked-in</span>
-            </Badge>
-          )}
           <div className="flex flex-col divide-y divide-gray-400">
-            {isCheckedIn && (
-              <Detail
-                className="py-2"
-                inline
-                justify={false}
-                label="Checked-in at:"
-              >
-                {getCheckInTime(checkInTimestamp, metadata)}
-              </Detail>
-            )}
-            <Detail
-              className="py-2"
-              label={
-                <div className="flex flex-col w-full gap-2 md:items-center md:flex-row">
-                  <span>Email:</span>
-                  {hasEmail ? (
-                    <div className="flex flex-col w-full gap-3 md:flex-row">
-                      <span className="block text-base font-semibold text-black">
-                        {data?.email}
-                      </span>
-                      <Button
-                        size="tiny"
-                        variant="outlined-primary"
-                        onClick={() => setAddEmailModalOpen(true)}
-                      >
-                        Edit email
-                      </Button>
-                      {lockSettings?.sendEmail ? (
-                        SendEmailMapping[eventType as keyof LockType] && (
-                          <Button
-                            size="tiny"
-                            variant="outlined-primary"
-                            onClick={onSendQrCode}
-                            disabled={
-                              sendEmailMutation.isPending ||
-                              sendEmailMutation.isSuccess
-                            }
-                          >
-                            {sendEmailMutation.isSuccess
-                              ? 'Email sent'
-                              : SendEmailMapping[eventType as keyof LockType]}
-                          </Button>
-                        )
-                      ) : (
-                        <Button size="tiny" variant="outlined-primary" disabled>
-                          Email are disabled
-                        </Button>
-                      )}
-                    </div>
-                  ) : (
-                    <Button
-                      variant="outlined-primary"
-                      size="tiny"
-                      onClick={() => setAddEmailModalOpen(true)}
-                    >
-                      Add email
-                    </Button>
-                  )}
-                </div>
-              }
-            />
             {items?.map(([key, value]: any, index) => {
               return (
                 <Detail
@@ -676,111 +532,4 @@ const SendEmailMapping: Record<keyof LockType, string> = {
   isCertification: 'Send Certificate by email',
   isEvent: 'Send QR-code by email',
   isStamp: 'Send Stamp by email',
-}
-const UpdateEmailModal = ({
-  isOpen,
-  setIsOpen,
-  isLockManager,
-  userAddress,
-  lockAddress,
-  network,
-  hasEmail,
-  onEmailChange,
-}: {
-  isOpen: boolean
-  isLockManager: boolean
-  userAddress: string
-  lockAddress: string
-  network: number
-  hasEmail: boolean
-  extraDataItems: [string, string | number][]
-  setIsOpen: (status: boolean) => void
-  onEmailChange: (values: FieldValues) => void
-}) => {
-  const [loading, setLoading] = useState(false)
-  const { register, handleSubmit, reset } = useForm({
-    defaultValues: {
-      email: '',
-    },
-  })
-  const { mutateAsync: updateUserMetadata } = useUpdateUserMetadata({
-    lockAddress,
-    userAddress,
-    network,
-  })
-
-  const updateData = (formFields: FieldValues) => {
-    reset() // reset form state
-    setLoading(false)
-    setIsOpen(false)
-    if (typeof onEmailChange === 'function') {
-      onEmailChange(formFields)
-    }
-  }
-
-  const updateMetadata = async (params: any, callback?: () => void) => {
-    const updateMetadataPromise = updateUserMetadata(params)
-    await ToastHelper.promise(updateMetadataPromise, {
-      loading: 'Updating email address',
-      success: 'Email successfully added to member',
-      error: `Can't update the email address.`,
-    })
-    if (typeof callback === 'function') {
-      callback()
-    }
-  }
-  /**
-   * Update metadata or create a new set when not exists
-   * @param {formFields} formFields - useForm data set, all data present in form will be saved as metadata
-   */
-  const onUpdateValue = async (formFields: FieldValues) => {
-    if (!isLockManager) return
-    try {
-      setLoading(true)
-
-      updateMetadata(
-        {
-          protected: {
-            email: formFields.email,
-          },
-          public: {},
-        },
-        () => {
-          updateData(formFields)
-        }
-      )
-    } catch (err) {
-      ToastHelper.error('There is some unexpected issue, please try again')
-    }
-  }
-
-  return (
-    <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
-      <div className="flex flex-col gap-3">
-        <span className="mr-0 font-semibold text-md">
-          {hasEmail ? 'Update email address' : 'Add email address to metadata'}
-        </span>
-        <form onSubmit={handleSubmit(onUpdateValue)}>
-          <Input
-            type="email"
-            {...register('email', {
-              required: true,
-            })}
-          />
-          <div className="flex items-center justify-end gap-2">
-            <Button
-              variant="secondary"
-              onClick={() => setIsOpen(false)}
-              disabled={loading}
-            >
-              Abort
-            </Button>
-            <Button type="submit" disabled={loading}>
-              {hasEmail ? 'Update email' : 'Add email'}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </Modal>
-  )
 }


### PR DESCRIPTION
# Description
This PR refactors the `unlock-app` by moving attendee-specific actions from the lock details view to the attendee view, ensuring context-appropriate behavior.

---

**Screengrabs**:

1. **Attendee Detail View (with attendee-specific actions):**  
<img width="1014" alt="Screenshot 2024-09-10 at 9 18 14 PM" src="https://github.com/user-attachments/assets/43362987-7960-438b-8d03-9bf9650636be">


2. **Lock View (without attendee-specific actions):**  
<img width="941" alt="Screenshot 2024-09-10 at 9 19 03 PM" src="https://github.com/user-attachments/assets/5cc93f95-438b-439c-a2f9-cae552dcc66b">

# Issues
Fixes #14579
Refs #14579

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet