### PR TITLE
fix(networks): always show error when contract verif checks fail

### DIFF
--- a/packages/networks/bin/validate.ts
+++ b/packages/networks/bin/validate.ts
@@ -66,15 +66,9 @@ const run = async () => {
           })
           // log results
           if (!verified?.isVerified) {
-            if (verified.result.includes('Error')) {
-              errors.push(
-                `❌ Verification failed for ${contractName} at ${contractAddress}: ${verified.result}`
-              )
-            } else {
-              errors.push(
-                `❌ Contract ${contractName} at ${contractAddress} is not verified`
-              )
-            }
+            errors.push(
+              `❌ Verification failed for ${contractName} at ${contractAddress}: ${verified.result}`
+            )
           } else {
             successes.push(
               `✅ Contract ${contractName} at ${contractAddress} is verified`


### PR DESCRIPTION
# Description

This complements #14620 by always showing the etherscan API error when a contract verification check fails

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
