### PR TITLE
fix(networks): avoid hitting etherscan api rate limit when checking contract on new networks 

### DIFF
--- a/packages/networks/bin/validate.ts
+++ b/packages/networks/bin/validate.ts
@@ -58,7 +58,8 @@ const run = async () => {
       if (!contractAddress || contractAddress === ZeroAddress) {
         warnings.push(`⚠️ Contract ${contractName} is missing`)
       } else {
-        await wait(100)
+        // make sure we dont reach max etherscan rate (5/sec)
+        await wait(250)
         try {
           const verified = await isVerified({
             chainId: network.id,


### PR DESCRIPTION
# Description

We wait a little longer between etherscan api calls to avoid hitting the limit rate

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
