### PR TITLE
fix(governance): get proxy admin address from manifest

### DIFF
--- a/governance/tasks/unlock.js
+++ b/governance/tasks/unlock.js
@@ -28,12 +28,10 @@ task(
         ;({ unlockAddress } = networks[chainId])
       }
 
-      // eslint-disable-next-line no-console
       console.log(`Deploying new implementation of Unlock on ${chainId}.`)
 
       // deploy upgrade
       if (!impl) {
-        // eslint-disable-next-line global-require
         const prepareUpgrade = require('../scripts/upgrade/prepare')
         impl = await prepareUpgrade({
           proxyAddress: unlockAddress,
@@ -43,10 +41,9 @@ task(
       }
 
       if (!proxyAdminAddress) {
-        proxyAdminAddress = await getProxyAdminAddress({ network })
+        proxyAdminAddress = await getProxyAdminAddress({ chainId })
       }
 
-      // eslint-disable-next-line global-require
       const proposeUpgrade = require('../scripts/upgrade/propose')
       await proposeUpgrade({
         proxyAddress: unlockAddress,
@@ -70,7 +67,6 @@ task('unlock:prepare', 'Deploy an implementaton of the Unlock contract')
       ;({ unlockAddress } = networks[chainId])
     }
 
-    // eslint-disable-next-line no-console
     console.log(`Deploying new implementation of Unlock on ${chainId}.`)
 
     const prepareUpgrade = require('../scripts/upgrade/prepare')
@@ -86,7 +82,6 @@ task('unlock:info', 'Show the owner of the Unlock contract')
   .addOptionalParam('unlockAddress', 'The address of the Unlock contract')
   .addFlag('quiet', 'Show only errors')
   .setAction(async ({ unlockAddress, quiet }) => {
-    // eslint-disable-next-line global-require
     const unlockInfo = require('../scripts/getters/unlock-info')
     await unlockInfo({ unlockAddress, quiet })
   })

--- a/packages/hardhat-helpers/src/proxy.js
+++ b/packages/hardhat-helpers/src/proxy.js
@@ -2,9 +2,7 @@ const { Manifest } = require('@openzeppelin/upgrades-core')
 
 const getProxyAdminAddress = async ({ network, chainId }) => {
   // get proxy admin address from OZ manifest
-  const manifest = network
-    ? await Manifest(network.provider)
-    : new Manifest(chainId)
+  const manifest = new Manifest(chainId)
   const manifestAdmin = await manifest.getAdmin()
   const proxyAdminAddress = manifestAdmin.address
   if (proxyAdminAddress === undefined) {


### PR DESCRIPTION
# Description

Correctly fetch the proxy address admin from manifest when submitting a new version of unlock tx to multisig

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
