### PR TITLE
feat:lint ignore .next folder in nextjs packages

### DIFF
--- a/packages/eslint-config/src/next.js
+++ b/packages/eslint-config/src/next.js
@@ -29,4 +29,7 @@ module.exports = [
       '@typescript-eslint/no-unused-expressions': 'warn',
     },
   },
+  {
+    ignores: ['.next'],
+  },
 ]


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This pull request helps to fix the hanging issue that occurs in nextjs apps when lint is run.
The cause was that due to the way we changed the eslint command in all packages, we now have to specify blacklist instead of whitelisted folders. My last PR unfortunately did not cater for the .next folder and it caused eslint to hang when run on nextjs packages.
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #14564
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
