### PR TITLE
feature(locksmith): Event associations explicit foreign key references

### DIFF
--- a/locksmith/migrations/20240921213830-event-collection-association-constraints.js
+++ b/locksmith/migrations/20240921213830-event-collection-association-constraints.js
@@ -1,0 +1,45 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // Add foreign key for eventSlug referencing EventData.slug
+    await queryInterface.addConstraint('EventCollectionAssociations', {
+      fields: ['eventSlug'],
+      type: 'foreign key',
+      name: 'fk_EventCollectionAssociations_eventSlug',
+      references: {
+        table: 'EventData',
+        field: 'slug',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    })
+
+    // Add foreign key for collectionSlug referencing EventCollections.slug
+    await queryInterface.addConstraint('EventCollectionAssociations', {
+      fields: ['collectionSlug'],
+      type: 'foreign key',
+      name: 'fk_EventCollectionAssociations_collectionSlug',
+      references: {
+        table: 'EventCollections',
+        field: 'slug',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // Remove foreign key for eventSlug
+    await queryInterface.removeConstraint(
+      'EventCollectionAssociations',
+      'fk_EventCollectionAssociations_eventSlug'
+    )
+
+    // Remove foreign key for collectionSlug
+    await queryInterface.removeConstraint(
+      'EventCollectionAssociations',
+      'fk_EventCollectionAssociations_collectionSlug'
+    )
+  },
+}

--- a/locksmith/src/models/EventCollectionAssociation.ts
+++ b/locksmith/src/models/EventCollectionAssociation.ts
@@ -29,10 +29,18 @@ EventCollectionAssociation.init(
     eventSlug: {
       type: DataTypes.STRING,
       allowNull: false,
+      references: {
+        model: 'EventData',
+        key: 'slug',
+      },
     },
     collectionSlug: {
       type: DataTypes.STRING,
       allowNull: false,
+      references: {
+        model: 'EventCollections',
+        key: 'slug',
+      },
     },
     isApproved: {
       type: DataTypes.BOOLEAN,


### PR DESCRIPTION
# Description
This PR introduces explicit foreign key references in the `EventCollectionAssociation` model, ensuring robust associations between `EventData` and `EventCollections` via their `slug` fields. It specifically ensures that each association links to valid and existing entries in the `EventData` and `EventCollections` tables.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread