### PR TITLE
fix(locksmith): Event collections link migration

### DIFF
--- a/locksmith/migrations/20240923145846-migrate-event-collection-link-attribute.js
+++ b/locksmith/migrations/20240923145846-migrate-event-collection-link-attribute.js
@@ -1,0 +1,49 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Update each link object: rename 'name' to 'type'
+      await queryInterface.sequelize.query(
+        `
+        UPDATE "EventCollections"
+        SET "links" = (
+          SELECT jsonb_agg(
+            jsonb_set(
+              link - 'name', -- Remove the 'name' key
+              '{type}',       -- Path to set the new key
+              to_jsonb(link->'name') -- Value for 'type' is the original 'name'
+            )
+          )
+          FROM jsonb_array_elements("links") AS link
+        )
+        WHERE "links" IS NOT NULL
+      `,
+        { transaction }
+      )
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Revert each link object: rename 'type' back to 'name'
+      await queryInterface.sequelize.query(
+        `
+        UPDATE "EventCollections"
+        SET "links" = (
+          SELECT jsonb_agg(
+            jsonb_set(
+              link - 'type', -- Remove the 'type' key
+              '{name}',       -- Path to set the original key
+              to_jsonb(link->'type') -- Value for 'name' is the original 'type'
+            )
+          )
+          FROM jsonb_array_elements("links") AS link
+        )
+        WHERE "links" IS NOT NULL
+      `,
+        { transaction }
+      )
+    })
+  },
+}


### PR DESCRIPTION
# Description
This PR introduces a migration that updates the `links` field within the `EventCollections` table by renaming the `name` property of each link object to `type`.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread