### PR TITLE
fix(unlock-app): Enable Editable Image URL Inputs in Event Settings

### DIFF
--- a/unlock-app/src/components/content/event/Settings/DefaultLayoutSkeleton.tsx
+++ b/unlock-app/src/components/content/event/Settings/DefaultLayoutSkeleton.tsx
@@ -7,7 +7,6 @@ export const DefaultLayoutSkeleton = ({
   selectedLayout,
   handleSelect,
 }: DefaultLayoutSkeletonProps) => {
-  console.log('DefaultLayoutSkeleton', selectedLayout)
   return (
     <div className="flex flex-col">
       <p>Default</p>

--- a/unlock-app/src/components/content/event/Settings/General.tsx
+++ b/unlock-app/src/components/content/event/Settings/General.tsx
@@ -123,22 +123,37 @@ export const General = ({ event, checkoutConfig }: GeneralProps) => {
       >
         <div className="flex gap-4 flex-col md:flex-row">
           <div className="order-2 md:order-1">
-            <ImageUpload
-              description="This illustration will be used for the event page. Use 512 by 512 pixels for best results."
-              isUploading={isUploading}
-              preview={getValues('image') || event.image}
-              onChange={async (fileOrFileUrl: any) => {
-                if (typeof fileOrFileUrl === 'string') {
-                  setValue('image', fileOrFileUrl)
-                } else {
-                  const items = await uploadImage(fileOrFileUrl[0])
-                  const image = items?.[0]?.publicUrl
-                  if (!image) {
-                    return
-                  }
-                  setValue('image', image)
-                }
+            <Controller
+              name="image"
+              control={control}
+              rules={{
+                required: 'Image is required',
+                validate: (value) => {
+                  if (!value) return 'Image is required'
+                  return true
+                },
               }}
+              render={({
+                field: { onChange, value },
+                fieldState: { error },
+              }) => (
+                <ImageUpload
+                  description="This illustration will be used for the event page. Use 512 by 512 pixels for best results."
+                  isUploading={isUploading}
+                  preview={value || event.image}
+                  onChange={async (fileOrFileUrl: any) => {
+                    if (typeof fileOrFileUrl === 'string') {
+                      onChange(fileOrFileUrl)
+                    } else {
+                      const items = await uploadImage(fileOrFileUrl[0])
+                      const image = items?.[0]?.publicUrl
+                      if (!image) return
+                      onChange(image)
+                    }
+                  }}
+                  error={error?.message}
+                />
+              )}
             />
           </div>
           <div className="flex flex-col order-1 gap-4 md:order-2 grow">


### PR DESCRIPTION
# Description
This PR introduces a fix for editable image URL inputs in an event's settings.

# Issues
Fixes #14678
Refs #14678

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread