### PR TITLE
fix(unlock-app): Multiple link addition for collection creation

### DIFF
--- a/unlock-app/src/components/content/events-collection/Form.tsx
+++ b/unlock-app/src/components/content/events-collection/Form.tsx
@@ -152,7 +152,7 @@ export const EventCollectionForm = ({
 
   // Handlers for adding/canceling links
   const handleAddOrCancelLink = () => {
-    if (isAddingLink) {
+    if (isAddingLink && !isLastLinkFilled) {
       // Cancel adding: remove the last link field
       removeLink(linkFields.length - 1)
       setIsAddingLink(false)
@@ -175,10 +175,16 @@ export const EventCollectionForm = ({
 
   // reset isAddingLink when a link is successfully added
   useEffect(() => {
-    if (isAddingLink && links[linkFields.length - 1]?.url.trim()) {
-      setIsAddingLink(false)
+    if (isAddingLink) {
+      const lastLink = links[links.length - 1]
+      if (lastLink && lastLink.type && lastLink.url.trim() !== '') {
+        setIsAddingLink(false)
+      }
     }
-  }, [links, linkFields.length, isAddingLink])
+  }, [links, isAddingLink])
+
+  console.log('links', links)
+  console.log('managerAddresses', managerAddresses)
 
   return (
     <FormProvider {...methods}>
@@ -392,7 +398,7 @@ export const EventCollectionForm = ({
                   disabled={isAddingLink ? false : !isLastLinkFilled}
                   aria-label={isAddingLink ? 'Cancel adding link' : 'Add link'}
                 >
-                  {isAddingLink ? 'Cancel' : 'Add Link'}
+                  {isAddingLink && !isLastLinkFilled ? 'Cancel' : 'Add Link'}
                 </Button>
               </div>
             </Disclosure>

--- a/unlock-app/src/components/content/events-collection/Form.tsx
+++ b/unlock-app/src/components/content/events-collection/Form.tsx
@@ -183,9 +183,6 @@ export const EventCollectionForm = ({
     }
   }, [links, isAddingLink])
 
-  console.log('links', links)
-  console.log('managerAddresses', managerAddresses)
-
   return (
     <FormProvider {...methods}>
       <div className="relative p-5">


### PR DESCRIPTION
# Description
This PR introduces a fix for adding multiple links when creating an event collection


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread