### PR TITLE
fix(ci): load env correctly on subgraph prod deploy 

### DIFF
--- a/.github/workflows/_subgraph.yml
+++ b/.github/workflows/_subgraph.yml
@@ -2,6 +2,9 @@ name: Subgraphs deployment
 
 on:
   workflow_call:
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
 
 jobs:
   coverage:

--- a/.github/workflows/_subgraph.yml
+++ b/.github/workflows/_subgraph.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           export-env: true
         env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SUBGRAPH_STUDIO_DEPLOY_KEY: op://secrets/subgraph/studio-deploy-key
       - name: Deploying the subgraphs
         run: yarn workspace @unlock-protocol/subgraph deploy-all

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,6 +9,8 @@ jobs:
   deploy-all-subgraphs:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
     uses: ./.github/workflows/_subgraph.yml
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   deploy-locksmith-production:
     if: ${{ github.repository_owner == 'unlock-protocol' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
 
 jobs:
+  # TODO: delete this task, just for testing
+  deploy-all-subgraphs:
+    uses: ./.github/workflows/_subgraph.yml
+
   # check which folder changed in the repo
   check-changes:
     uses: ./.github/workflows/_check.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
 
 jobs:
-  # TODO: delete this task, just for testing
-  deploy-all-subgraphs:
-    uses: ./.github/workflows/_subgraph.yml
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
   # check which folder changed in the repo
   check-changes:
     uses: ./.github/workflows/_check.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,8 @@ jobs:
   # TODO: delete this task, just for testing
   deploy-all-subgraphs:
     uses: ./.github/workflows/_subgraph.yml
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   # check which folder changed in the repo
   check-changes:


### PR DESCRIPTION
# Description

This corrects the way secrets are loaded from 1 password during subgraph CI deployment
 
<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #9637
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
