### PR TITLE
fix(unlock-app): Prevent users from registering for past events

### DIFF
--- a/unlock-app/src/utils/eventCollections.ts
+++ b/unlock-app/src/utils/eventCollections.ts
@@ -30,3 +30,11 @@ export const isCollectionManager = (
 ) => {
   return managerAddresses?.includes(account!) || false
 }
+
+// Utility function to get the language of the user
+export const language = () => {
+  if (typeof navigator === 'undefined') {
+    return 'en-US'
+  }
+  return navigator?.language || 'en-US'
+}


### PR DESCRIPTION
# Description
This PR introduces changes that restricts users from registering for events that have already occurred/passed.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread