### PR TITLE
fix(unlock-app): Prevent collection non-managers from directly creating new events

### DIFF
--- a/unlock-app/src/components/content/events-collection/AddEventsToCollectionDawer.tsx
+++ b/unlock-app/src/components/content/events-collection/AddEventsToCollectionDawer.tsx
@@ -49,7 +49,7 @@ export default function AddEventsToCollectionDrawer({
   const [isUrlValid, setIsUrlValid] = useState(false)
   const [isEventSelected, setIsEventSelected] = useState(false)
   const [isDuplicate, setIsDuplicate] = useState(false)
-  const [hasCheckedUrl, setHasCheckedUrl] = useState<boolean>(false) // New state
+  const [hasCheckedUrl, setHasCheckedUrl] = useState<boolean>(false)
 
   useEffect(() => {
     if (eventSlug.trim() !== '' && event) {
@@ -147,9 +147,11 @@ export default function AddEventsToCollectionDrawer({
           </p>
         )}
       </div>
-      <Button onClick={() => setAddMethod('form')} className="w-full">
-        Create a new event
-      </Button>
+      {isManager && (
+        <Button onClick={() => setAddMethod('form')} className="w-full">
+          Create a new event
+        </Button>
+      )}
     </div>
   )
 


### PR DESCRIPTION
# Description
This PR introduces changes that updates access control for submitting events. Non-manager users will no longer have access to create new events directly and submit.


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread