### PR TITLE
feature(unlock-app): Remove individual events in event detail view

### DIFF
--- a/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
+++ b/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
@@ -18,14 +18,17 @@ import { FaExternalLinkAlt } from 'react-icons/fa'
 import Link from 'next/link'
 import PastEvent from '../event/Layout/PastEvent'
 import { language } from '~/utils/eventCollections'
+import RemoveFromCollectionButton from './RemoveFromCollectionButton'
 
 interface EventDetailDrawerProps {
+  collectionSlug: string | undefined
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   event: Event | null
 }
 
 export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
+  collectionSlug,
   isOpen,
   setIsOpen,
   event,
@@ -104,10 +107,22 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
   const hasLocation = (parsedEvent?.ticket?.event_address || '')?.length > 0
   const hasDate = startDate || startTime || endDate || endTime
 
+  // close drawer when the event is removed
+  const handleEventRemove = () => {
+    setIsOpen(false)
+  }
+
   return (
     <Drawer isOpen={isOpen} setIsOpen={setIsOpen}>
       {event && (
         <div className="space-y-4">
+          <div className="flex justify-end">
+            <RemoveFromCollectionButton
+              collectionSlug={collectionSlug}
+              eventSlug={event.slug!}
+              onRemove={handleEventRemove}
+            />
+          </div>
           {/* Event Image */}
           <img
             src={image}

--- a/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
+++ b/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
@@ -25,6 +25,7 @@ interface EventDetailDrawerProps {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   event: Event | null
+  isManager: boolean
 }
 
 export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
@@ -32,6 +33,7 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
   isOpen,
   setIsOpen,
   event,
+  isManager,
 }) => {
   const { data: checkoutConfig, isPending: isCheckoutConfigPending } =
     useCheckoutConfig({
@@ -116,13 +118,16 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
     <Drawer isOpen={isOpen} setIsOpen={setIsOpen}>
       {event && (
         <div className="space-y-4">
-          <div className="flex justify-end">
-            <RemoveFromCollectionButton
-              collectionSlug={collectionSlug}
-              eventSlug={event.slug!}
-              onRemove={handleEventRemove}
-            />
-          </div>
+          {isManager && (
+            <div className="flex justify-end">
+              <RemoveFromCollectionButton
+                collectionSlug={collectionSlug}
+                eventSlug={event.slug!}
+                onRemove={handleEventRemove}
+              />
+            </div>
+          )}
+
           {/* Event Image */}
           <img
             src={image}

--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -266,6 +266,7 @@ export default function EventsCollectionDetailContent({
           isOpen={isEventDetailDrawerOpen}
           setIsOpen={setIsEventDetailDrawerOpen}
           event={selectedEvent}
+          isManager={isManager}
         />
       )}
     </div>

--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -16,7 +16,7 @@ import { isCollectionManager } from '~/utils/eventCollections'
 import { FaGithub, FaGlobe, FaTwitter, FaYoutube } from 'react-icons/fa'
 import { SiFarcaster as FarcasterIcon } from 'react-icons/si'
 import AddEventsToCollectionDrawer from './AddEventsToCollectionDawer'
-import { EventDetailDrawer } from './EventDetailDawer'
+import { EventDetailDrawer } from './EventDetailDrawer'
 import { Metadata } from '@unlock-protocol/core'
 import CopyUrlButton from '../event/CopyUrlButton'
 import TweetItButton from '../event/TweetItButton'
@@ -260,11 +260,14 @@ export default function EventsCollectionDetailContent({
         existingEventSlugs={existingEventSlugs}
       />
       {/* Event Detail Drawer */}
-      <EventDetailDrawer
-        isOpen={isEventDetailDrawerOpen}
-        setIsOpen={setIsEventDetailDrawerOpen}
-        event={selectedEvent}
-      />
+      {eventCollection?.slug && (
+        <EventDetailDrawer
+          collectionSlug={eventCollection?.slug}
+          isOpen={isEventDetailDrawerOpen}
+          setIsOpen={setIsEventDetailDrawerOpen}
+          event={selectedEvent}
+        />
+      )}
     </div>
   )
 }

--- a/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
+++ b/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
@@ -1,0 +1,81 @@
+import { Modal, Tooltip, Button } from '@unlock-protocol/ui'
+import { useState } from 'react'
+import { FiTrash } from 'react-icons/fi'
+import { useRemoveEventFromCollection } from '~/hooks/useEventCollection'
+
+interface RemoveFromCollectionButtonProps {
+  collectionSlug: string | undefined
+  eventSlug: string
+  onRemove: () => void
+}
+
+export const RemoveFromCollectionButton = ({
+  collectionSlug,
+  eventSlug,
+  onRemove,
+}: RemoveFromCollectionButtonProps) => {
+  const [isOpen, setOpen] = useState(false)
+  const { removeEventFromCollection, isRemovingEventFromCollection } =
+    useRemoveEventFromCollection(collectionSlug!)
+
+  const handleRemoveEvent = async () => {
+    await removeEventFromCollection({
+      collectionSlug: collectionSlug!,
+      eventSlug,
+    })
+    setOpen(false)
+    onRemove()
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} setIsOpen={setOpen}>
+        <div className="w-full">
+          <h2 className="text-lg font-bold mb-4">Remove Event</h2>
+          <p className="mb-6">
+            Are you sure you want to remove this event from the collection?
+          </p>
+          <div className="flex justify-end space-x-4">
+            <Button
+              size="small"
+              onClick={() => setOpen(false)}
+              variant="outlined-primary"
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={handleRemoveEvent}
+              variant="primary"
+              loading={isRemovingEventFromCollection}
+            >
+              {isRemovingEventFromCollection ? 'Removing' : 'Remove'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <Tooltip
+        delay={0}
+        label="Remove from Collection"
+        tip="Remove from Collection"
+        side="bottom"
+      >
+        <div className="flex flex-col-reverse px-4 md:px-0 md:flex-row-reverse gap-2">
+          <Button
+            onClick={() => setOpen(true)}
+            size="small"
+            variant="outlined-primary"
+          >
+            <div className="flex items-center gap-2">
+              <FiTrash />
+              <span>Remove</span>
+            </div>
+          </Button>
+        </div>
+      </Tooltip>
+    </>
+  )
+}
+
+export default RemoveFromCollectionButton


### PR DESCRIPTION
# Description
This PR introduces changes that enable collection managers to remove an event directly from its detail drawer/view

## ScreenGrabs
![Screenshot 2024-10-01 at 19 50 40](https://github.com/user-attachments/assets/2642169c-0a51-4ebb-b7ab-e140f3bfa2d9)

<br />

![Screenshot 2024-10-01 at 19 50 49](https://github.com/user-attachments/assets/cc102ebc-c1a4-46e2-9349-80e222d3fac6)


## Flow
[Loom](https://www.loom.com/share/c2b7ea0e00aa473cadc1ef5e99fdf18a?sid=04857fce-c2d1-430a-9607-85ace4e177e8)


# Issues
Fixes #14776
Refs #14776

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread
