### PR TITLE
feature(unlock-app): Sort collection events into upcoming and past

### DIFF
--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -59,9 +59,7 @@ export interface EventData {
 
 export interface Event extends Metadata {
   eventUrl: string
-  data: {
-    ticket: EventTicket
-  }
+  ticket: EventTicket
 }
 
 interface EventsCollectionDetailContentProps {

--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -22,6 +22,12 @@ import CopyUrlButton from '../event/CopyUrlButton'
 import TweetItButton from '../event/TweetItButton'
 import { config } from '~/config/app'
 import CastItButton from '../event/CastItButton'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 export interface EventTicket {
   event_address: string
@@ -53,7 +59,9 @@ export interface EventData {
 
 export interface Event extends Metadata {
   eventUrl: string
-  ticket: EventTicket
+  data: {
+    ticket: EventTicket
+  }
 }
 
 interface EventsCollectionDetailContentProps {
@@ -81,6 +89,7 @@ export default function EventsCollectionDetailContent({
       ) ?? false
     )
   }, [eventCollection?.events])
+
   const isManager = isCollectionManager(
     eventCollection?.managerAddresses,
     account!
@@ -97,6 +106,55 @@ export default function EventsCollectionDetailContent({
   // Extract existing event slugs
   const existingEventSlugs = useMemo(() => {
     return eventCollection?.events?.map((event) => event.slug) || []
+  }, [eventCollection?.events])
+
+  // util to parse event date and time with timezone
+  const parseEventDateTime = (event: Event): dayjs.Dayjs | null => {
+    const ticket = event.data?.ticket
+    if (!ticket) return null
+
+    const { event_start_date, event_start_time, event_timezone } = ticket
+    // Combine date and time, default to "00:00" if time is missing
+    const dateTimeString = `${event_start_date}T${event_start_time || '00:00'}:00`
+    // Parse with Day.js considering the timezone
+    return dayjs.tz(dateTimeString, event_timezone)
+  }
+
+  // Sort and categorize events into upcoming and past
+  const { upcomingEvents, pastEvents } = useMemo(() => {
+    if (!eventCollection?.events) return { upcomingEvents: [], pastEvents: [] }
+
+    const now = dayjs()
+
+    const upcoming: Event[] = []
+    const past: Event[] = []
+
+    eventCollection.events.forEach((event: any) => {
+      const eventStartDate = parseEventDateTime(event)
+      if (eventStartDate && eventStartDate.isAfter(now)) {
+        upcoming.push(event)
+      } else {
+        past.push(event)
+      }
+    })
+
+    // Sort upcoming events in chronological order (soonest first)
+    upcoming.sort((a, b) => {
+      const aDate = parseEventDateTime(a)
+      const bDate = parseEventDateTime(b)
+      if (!aDate || !bDate) return 0
+      return aDate.valueOf() - bDate.valueOf()
+    })
+
+    // Sort past events in reverse chronological order (most recent first)
+    past.sort((a, b) => {
+      const aDate = parseEventDateTime(a)
+      const bDate = parseEventDateTime(b)
+      if (!aDate || !bDate) return 0
+      return bDate.valueOf() - aDate.valueOf()
+    })
+
+    return { upcomingEvents: upcoming, pastEvents: past }
   }, [eventCollection?.events])
 
   const getLinkIcon = (type: string) => {
@@ -203,8 +261,9 @@ export default function EventsCollectionDetailContent({
         <section className="mt-16">
           <div className="flex flex-col lg:grid lg:grid-cols-12 gap-14 mt-5">
             <div className="lg:col-span-1"></div>
+
             <div className="flex flex-col gap-6 lg:col-span-10">
-              <div className="flex flex-col sm:flex-row items-center space-y-2 justify-between mt-5">
+              <div className="flex flex-col sm:flex-row items-center space-y-2 justify-between my-5">
                 <h2 className="text-3xl font-bold">Events</h2>
                 <Button
                   onClick={handleAddEvent}
@@ -218,17 +277,43 @@ export default function EventsCollectionDetailContent({
                 </Button>
               </div>
               {hasValidEvents ? (
-                <div className="">
-                  <div className="space-y-6">
-                    {eventCollection?.events?.map((eventItem: any) => (
-                      <EventOverviewCard
-                        key={eventItem.slug}
-                        event={eventItem}
-                        onClick={handleEventDetailClick}
-                      />
-                    ))}
-                  </div>
-                </div>
+                <>
+                  {/* Upcoming Events */}
+                  {upcomingEvents.length > 0 && (
+                    <div className="mb-7 md:mb-10">
+                      <h3 className="text-2xl font-semibold mb-6">
+                        Upcoming Events
+                      </h3>
+                      <div className="space-y-6">
+                        {upcomingEvents.map((eventItem: Event) => (
+                          <EventOverviewCard
+                            key={eventItem.slug}
+                            event={eventItem}
+                            onClick={handleEventDetailClick}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Past Events */}
+                  {pastEvents.length > 0 && (
+                    <div>
+                      <h3 className="text-2xl font-semibold mb-6">
+                        Past Events
+                      </h3>
+                      <div className="space-y-6">
+                        {pastEvents.map((eventItem: Event) => (
+                          <EventOverviewCard
+                            key={eventItem.slug}
+                            event={eventItem}
+                            onClick={handleEventDetailClick}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
               ) : (
                 <ImageBar
                   src="/images/illustrations/no-locks.svg"


### PR DESCRIPTION
# Description
This PR introduces changes to an event collection's page that categorizes and sorts events into `upcoming` and `past` sections. Additionally, it ensures that newly added events are automatically sorted into the appropriate category.

## ScreenGrabs
![Screenshot 2024-10-01 at 22 11 17](https://github.com/user-attachments/assets/c8a4491a-fe31-4172-920d-59c4b0e5edb7)


# Issues
Fixes #14775
Refs #14775

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread