### PR TITLE
feature(unlock-app): 404 if queried event collection doesn't exist

### DIFF
--- a/unlock-app/app/events/[slug]/page.tsx
+++ b/unlock-app/app/events/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {
   QueryClient,
 } from '@tanstack/react-query'
 import { Event } from '@unlock-protocol/unlock-js'
+import { notFound } from 'next/navigation'
 import EventsCollectionDetailContent from '~/components/content/events-collection/EventsCollectionDetailContent'
 import { getEventCollection } from '~/utils/eventCollections'
 
@@ -36,6 +37,17 @@ const EventCollectionDetailPage = async ({
 }: EventCollectionDetailPageProps) => {
   const { slug } = params
   const queryClient = new QueryClient()
+
+  let eventCollection
+  try {
+    eventCollection = await getEventCollection(slug)
+  } catch (error) {
+    notFound()
+  }
+
+  if (!eventCollection) {
+    notFound()
+  }
 
   // prefetch the event collection details
   await queryClient.prefetchQuery({


### PR DESCRIPTION
# Description
This PR introduces changes that redirect a user to a 404 page if an event collection being queried, wasn't found


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread