### PR TITLE
feature(unlock-app): Wallet connection prompt for submitting events

### DIFF
--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -25,6 +25,7 @@ import CastItButton from '../event/CastItButton'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import { useConnectModal } from '~/hooks/useConnectModal'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -73,6 +74,7 @@ export default function EventsCollectionDetailContent({
 
   const { account } = useAuth()
   const router = useRouter()
+  const { openConnectModal } = useConnectModal()
 
   const [isAddEventDrawerOpen, setIsAddEventDrawerOpen] = useState(false)
 
@@ -94,8 +96,13 @@ export default function EventsCollectionDetailContent({
   )
 
   const handleAddEvent = () => {
-    setIsAddEventDrawerOpen(true)
+    if (!account) {
+      openConnectModal()
+    } else {
+      setIsAddEventDrawerOpen(true)
+    }
   }
+
   const handleEventDetailClick = (event: Event) => {
     setSelectedEvent(event)
     setIsEventDetailDrawerOpen(true)
@@ -263,11 +270,7 @@ export default function EventsCollectionDetailContent({
             <div className="flex flex-col gap-6 lg:col-span-10">
               <div className="flex flex-col sm:flex-row items-center space-y-2 justify-between my-5">
                 <h2 className="text-3xl font-bold">Events</h2>
-                <Button
-                  onClick={handleAddEvent}
-                  className="w-full sm:w-auto"
-                  disabled={!account}
-                >
+                <Button onClick={handleAddEvent} className="w-full sm:w-auto">
                   <div className="flex items-center gap-2">
                     <Icon icon={TbPlus} size={20} />
                     {isManager ? 'Add Event' : 'Submit Event'}


### PR DESCRIPTION
# Description
This PR introduces an improved user experience for submitting events to collections. Instead of disabling the "Submit Event" button for users who haven't connected their wallets, it now triggers the connect wallet modal. Once a user connects their wallet, the button reverts to its original function of opening the drawer to add an event.

## ScreenGrab
![Screenshot 2024-10-02 at 13 32 39](https://github.com/user-attachments/assets/63a93a00-a23a-47bf-8fc0-0428f6c47ced)

<br/>

![Screenshot 2024-10-02 at 13 32 45](https://github.com/user-attachments/assets/3b5f4b98-4d2a-4c33-a6ad-726924d1aeec)


## Flow
[Loom](https://www.loom.com/share/09f4255f75864a9498be6eeb716e59a7?sid=cd423ce5-1bc4-4d25-8f72-5d485a41f791)


# Issues
Fixes #14778
Refs #14778

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread