### PR TITLE
fix(unlock-app): Remove user events preview from landing page

### DIFF
--- a/unlock-app/src/components/content/event/EventLandingPage.tsx
+++ b/unlock-app/src/components/content/event/EventLandingPage.tsx
@@ -3,8 +3,6 @@
 import { Button } from '@unlock-protocol/ui'
 import Link from 'next/link'
 import { LockTypeLandingPage } from '~/components/interface/LockTypeLandingPage'
-import { useAuth } from '~/contexts/AuthenticationContext'
-import { PastEventsByManager } from './PastEventsByManager'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 
@@ -133,29 +131,15 @@ const faqs = [
 
 interface EventLandingPageCallToActionProps {
   handleCreateEvent: () => void
-  showManagerEvents?: boolean
 }
 
 export const EventLandingPageCallToAction = ({
   handleCreateEvent,
-  showManagerEvents = false,
 }: EventLandingPageCallToActionProps) => {
-  const { account } = useAuth()
-
-  if (!account) {
-    return (
-      <Button onClick={handleCreateEvent} className="my-8">
-        Get started for free
-      </Button>
-    )
-  }
   return (
-    <div className="flex flex-col">
-      {showManagerEvents && <PastEventsByManager manager={account} />}
-      <Button onClick={handleCreateEvent} className="my-8">
-        Get started for free
-      </Button>
-    </div>
+    <Button onClick={handleCreateEvent} className="my-8">
+      Get started for free
+    </Button>
   )
 }
 
@@ -190,10 +174,7 @@ export const EventLandingPage = ({ handleCreateEvent }: LandingPageProps) => {
           </h1>
         }
         actions={
-          <EventLandingPageCallToAction
-            handleCreateEvent={handleCreateEvent}
-            showManagerEvents={true}
-          />
+          <EventLandingPageCallToAction handleCreateEvent={handleCreateEvent} />
         }
         illustration={
           <Image

--- a/unlock-app/src/components/interface/LockTypeLandingPage.tsx
+++ b/unlock-app/src/components/interface/LockTypeLandingPage.tsx
@@ -95,7 +95,7 @@ export const LockTypeLandingPage = ({
 }: LockTypeLandingPageProps) => {
   return (
     <div className="w-full mt-8 flex flex-col gap-12 md:gap-24">
-      <section className="gap-2 flex flex-row">
+      <section className="gap-4 gap-x-5 flex flex-row">
         {/* masthead */}
         <div className="md:w-2/3  md:flex md:flex-col">
           {title}


### PR DESCRIPTION
# Description
This PR introduces changes that removes the direct preview of a user's past events in the landing page.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread