### PR TITLE
feature(unlock-app): Enable event settings access for organizer-owned events in event collection

### DIFF
--- a/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
+++ b/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
@@ -99,11 +99,15 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
     <Drawer isOpen={isOpen} setIsOpen={setIsOpen}>
       {event && (
         <div className="space-y-4">
-          <div className="flex flex-col-reverse px-4 md:px-0 md:flex-row-reverse gap-2">
+          <div className="flex flex-col md:flex-row md:justify-end gap-2 md:gap-4 px-4 md:px-0">
             {isEventOrganizer && (
-              <Link target="_blank" href={`/event/${event.slug}/settings`}>
-                <Button variant="primary">
-                  <div className="flex items-center gap-2">
+              <Link
+                target="_blank"
+                href={`/event/${event.slug}/settings`}
+                className="w-full md:w-auto"
+              >
+                <Button variant="primary" className="w-full">
+                  <div className="flex items-center gap-2 justify-center">
                     <TbSettings />
                     <span>Settings</span>
                   </div>

--- a/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
+++ b/unlock-app/src/components/content/events-collection/EventDetailDrawer.tsx
@@ -16,6 +16,8 @@ import Link from 'next/link'
 import PastEvent from '../event/Layout/PastEvent'
 import RemoveFromCollectionButton from './RemoveFromCollectionButton'
 import { getEventAttributes } from '~/utils/eventCollections'
+import { useEventOrganizer } from '~/hooks/useEventOrganizer'
+import { TbSettings } from 'react-icons/tb'
 
 interface EventDetailDrawerProps {
   collectionSlug: string | undefined
@@ -36,6 +38,10 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
     useCheckoutConfig({
       id: event?.checkoutConfigId,
     })
+
+  const { data: isEventOrganizer } = useEventOrganizer({
+    checkoutConfig: checkoutConfig!,
+  })
 
   const { data: organizers } = useEventOrganizers({
     checkoutConfig: checkoutConfig!,
@@ -93,15 +99,25 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
     <Drawer isOpen={isOpen} setIsOpen={setIsOpen}>
       {event && (
         <div className="space-y-4">
-          {isManager && (
-            <div className="flex justify-end">
+          <div className="flex flex-col-reverse px-4 md:px-0 md:flex-row-reverse gap-2">
+            {isEventOrganizer && (
+              <Link target="_blank" href={`/event/${event.slug}/settings`}>
+                <Button variant="primary">
+                  <div className="flex items-center gap-2">
+                    <TbSettings />
+                    <span>Settings</span>
+                  </div>
+                </Button>
+              </Link>
+            )}
+            {isManager && (
               <RemoveFromCollectionButton
                 collectionSlug={collectionSlug}
                 eventSlug={event.slug!}
                 onRemove={handleEventRemove}
               />
-            </div>
-          )}
+            )}
+          </div>
 
           {/* Event Image */}
           <img
@@ -115,11 +131,11 @@ export const EventDetailDrawer: React.FC<EventDetailDrawerProps> = ({
               event={parsedEvent}
               eventUrl={event.eventUrl}
             />
-            <Button variant="borderless-primary">
-              <Link href={event.eventUrl} target="_blank">
+            <Link href={event.eventUrl} target="_blank">
+              <Button variant="borderless-primary">
                 <FaExternalLinkAlt size={20} width={1} className="mr-2" />
-              </Link>
-            </Button>
+              </Button>
+            </Link>
           </div>
 
           {/* Event Information */}

--- a/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
+++ b/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
@@ -66,7 +66,7 @@ export const RemoveFromCollectionButton = ({
           size="small"
           variant="outlined-primary"
         >
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 justify-center">
             <FiTrash />
             <span>Remove</span>
           </div>

--- a/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
+++ b/unlock-app/src/components/content/events-collection/RemoveFromCollectionButton.tsx
@@ -61,18 +61,16 @@ export const RemoveFromCollectionButton = ({
         tip="Remove from Collection"
         side="bottom"
       >
-        <div className="flex flex-col-reverse px-4 md:px-0 md:flex-row-reverse gap-2">
-          <Button
-            onClick={() => setOpen(true)}
-            size="small"
-            variant="outlined-primary"
-          >
-            <div className="flex items-center gap-2">
-              <FiTrash />
-              <span>Remove</span>
-            </div>
-          </Button>
-        </div>
+        <Button
+          onClick={() => setOpen(true)}
+          size="small"
+          variant="outlined-primary"
+        >
+          <div className="flex items-center gap-2">
+            <FiTrash />
+            <span>Remove</span>
+          </div>
+        </Button>
       </Tooltip>
     </>
   )


### PR DESCRIPTION
# Description
This PR introduces the ability to access event settings directly from an event collection, but only for events where the user is an organizer.

## ScreenGrabs
![Screenshot 2024-10-03 at 17 07 50](https://github.com/user-attachments/assets/84bdc0b0-b93c-4a2c-bdb6-9227db03ceca)

<br />

![Screenshot 2024-10-03 at 17 08 19](https://github.com/user-attachments/assets/bdb70754-bb6f-4bfa-96e1-bc425b8a05bd)



# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread