### PR TITLE
feature(unlock-app): Migrate `certifications` to `app` router

### DIFF
--- a/unlock-app/app/certification/layout.tsx
+++ b/unlock-app/app/certification/layout.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+
+import DashboardFooter from '~/components/interface/layouts/index/DashboardFooter'
+import TermsOfServiceModal from '~/components/interface/layouts/index/TermsOfServiceModal'
+import { Container } from '~/components/interface/Container'
+import { ConnectModal } from '~/components/interface/connect/ConnectModal'
+import CertificationHeader from '~/components/interface/layouts/certification/CertificationHeader'
+
+export default function CertificationLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div className="overflow-hidden bg-ui-secondary-200">
+      <TermsOfServiceModal />
+      <Container>
+        <ConnectModal />
+
+        <CertificationHeader />
+
+        <div className="flex flex-col gap-10 min-h-screen">{children}</div>
+
+        <DashboardFooter />
+      </Container>
+    </div>
+  )
+}

--- a/unlock-app/app/certification/new/page.tsx
+++ b/unlock-app/app/certification/new/page.tsx
@@ -1,0 +1,20 @@
+import { AuthRequired } from 'app/Components/ProtectedContent'
+import { Metadata } from 'next'
+import React from 'react'
+import NewCertificationContent from '~/components/content/certification/NewCertification'
+
+export const metadata: Metadata = {
+  title: 'Create a New Certification',
+  description:
+    'Create a new certification in under five minutes with Unlock Protocol',
+}
+
+const NewCertificationPage: React.FC = () => {
+  return (
+    <AuthRequired>
+      <NewCertificationContent />
+    </AuthRequired>
+  )
+}
+
+export default NewCertificationPage

--- a/unlock-app/app/certification/page.tsx
+++ b/unlock-app/app/certification/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next'
+import CertificationContent from '~/components/content/certification/CertificationContent'
+
+export const metadata: Metadata = {
+  title: 'Unlock Certification',
+  description:
+    'Bring your certification or credentialing program onchain with Unlock.',
+}
+
+export default function CertificationPage() {
+  return <CertificationContent />
+}

--- a/unlock-app/src/components/content/certification/CertificationContent.tsx
+++ b/unlock-app/src/components/content/certification/CertificationContent.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import Head from 'next/head'
-import { CertificationDetails } from './CertificationDetails'
-import { CertificationLanding } from './CertificationLanding'
-import { useRouter } from 'next/router'
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import LoadingIcon from '~/components/interface/Loading'
-import { AppLayout } from '~/components/interface/layouts/AppLayout'
 import { pageTitle } from '~/constants'
 import { useMetadata } from '~/hooks/metadata'
 import { useRouterQueryForLockAddressAndNetworks } from '~/hooks/useRouterQueryForLockAddressAndNetworks'
+import { CertificationDetails } from './CertificationDetails'
+import { CertificationLanding } from './CertificationLanding'
 
 export const CertificationContent = () => {
   const router = useRouter()
@@ -22,6 +22,12 @@ export const CertificationContent = () => {
 
   const showDetails = lockAddress && network
 
+  useEffect(() => {
+    document.title = metadata
+      ? pageTitle(`${metadata?.name} | Certification`)
+      : pageTitle('Certification')
+  }, [metadata])
+
   if (isLoading) {
     return <LoadingIcon />
   }
@@ -31,25 +37,13 @@ export const CertificationContent = () => {
   }
 
   return (
-    <AppLayout
-      showLinks={false}
-      authRequired={false}
-      logoRedirectUrl="/certification"
-      logoImageUrl="/images/svg/logo-unlock-certificate.svg"
-    >
-      <Head>
-        <title>
-          {metadata
-            ? pageTitle(`${metadata?.name} | 'Certification`)
-            : 'Certification'}
-        </title>
-        {metadata && (
-          <>
-            <meta property="og:title" content={metadata?.name} />
-            <meta property="og:image" content={metadata.image} />
-          </>
-        )}
-      </Head>
+    <>
+      {metadata && (
+        <>
+          <meta property="og:title" content={metadata?.name} />
+          <meta property="og:image" content={metadata.image} />
+        </>
+      )}
       {!showDetails && (
         <CertificationLanding
           handleCreateCertification={handleCreateCertification}
@@ -64,7 +58,7 @@ export const CertificationContent = () => {
           />
         </div>
       )}
-    </AppLayout>
+    </>
   )
 }
 

--- a/unlock-app/src/components/content/certification/CertificationDetails.tsx
+++ b/unlock-app/src/components/content/certification/CertificationDetails.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import { useMetadata } from '~/hooks/metadata'
 import { toFormData } from '~/components/interface/locks/metadata/utils'
@@ -11,7 +13,7 @@ import {
   minifyAddress,
   Card,
 } from '@unlock-protocol/ui'
-import router from 'next/router'
+import { useRouter } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import { useLockManager } from '~/hooks/useLockManager'
 import { RiExternalLinkLine as ExternalLinkIcon } from 'react-icons/ri'
@@ -128,6 +130,7 @@ export const CertificationDetails = ({
 }: CertificationDetailsProps) => {
   const { account } = useAuth()
   const [isCheckoutOpen, setCheckoutOpen] = useState(false)
+  const router = useRouter()
 
   const { lock, isLockLoading: isLockDataLoading } = useLockData({
     lockAddress,
@@ -141,9 +144,7 @@ export const CertificationDetails = ({
   })
 
   const onEdit = () => {
-    return router.push(
-      `/locks/metadata?lockAddress=${lockAddress}&network=${network}`
-    )
+    router.push(`/locks/metadata?lockAddress=${lockAddress}&network=${network}`)
   }
 
   const { data: key } = useCertification({

--- a/unlock-app/src/components/content/certification/CertificationForm.tsx
+++ b/unlock-app/src/components/content/certification/CertificationForm.tsx
@@ -22,7 +22,7 @@ import { NetworkWarning } from '~/components/interface/locks/Create/elements/Net
 import { getAccountTokenBalance } from '~/hooks/useAccount'
 import { Web3Service } from '@unlock-protocol/unlock-js'
 import { useQuery } from '@tanstack/react-query'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 import { useAvailableNetworks } from '~/utils/networks'
 import Link from 'next/link'
 import { BalanceWarning } from '~/components/interface/locks/Create/elements/BalanceWarning'

--- a/unlock-app/src/components/content/certification/NewCertification.tsx
+++ b/unlock-app/src/components/content/certification/NewCertification.tsx
@@ -1,6 +1,7 @@
+'use client'
+
 import { networks } from '@unlock-protocol/networks'
 import { useState } from 'react'
-import { AppLayout } from '~/components/interface/layouts/AppLayout'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 
 import { formDataToMetadata } from '~/components/interface/locks/metadata/utils'
@@ -91,18 +92,16 @@ export const NewCertification = () => {
   }
 
   return (
-    <AppLayout showLinks={false} authRequired={true}>
-      <div className="grid max-w-3xl gap-6 pb-24 mx-auto">
-        {transactionDetails && (
-          <CertificationDeploying
-            transactionDetails={transactionDetails}
-            lockAddress={lockAddress}
-            slug={slug}
-          />
-        )}
-        {!transactionDetails && <CertificationForm onSubmit={onSubmit} />}
-      </div>
-    </AppLayout>
+    <div className="grid max-w-3xl gap-6 pb-24 mx-auto">
+      {transactionDetails && (
+        <CertificationDeploying
+          transactionDetails={transactionDetails}
+          lockAddress={lockAddress}
+          slug={slug}
+        />
+      )}
+      {!transactionDetails && <CertificationForm onSubmit={onSubmit} />}
+    </div>
   )
 }
 

--- a/unlock-app/src/components/interface/layouts/certification/CertificationHeader.tsx
+++ b/unlock-app/src/components/interface/layouts/certification/CertificationHeader.tsx
@@ -1,0 +1,65 @@
+'use client'
+import { Button, HeaderNav } from '@unlock-protocol/ui'
+import { useConnectModal } from '~/hooks/useConnectModal'
+import useEns from '~/hooks/useEns'
+import { addressMinify } from '~/utils/strings'
+import { MdExitToApp as DisconnectIcon } from 'react-icons/md'
+import { useAuth } from '~/contexts/AuthenticationContext'
+
+const MENU = {
+  extraClass: {
+    mobile: 'bg-ui-secondary-200 px-6',
+  },
+  showSocialIcons: false,
+  logo: {
+    url: '/certification',
+    src: '/images/svg/logo-unlock-certificate.svg',
+  },
+  menuSections: [],
+}
+
+export default function CertificationHeader() {
+  const { account, email } = useAuth()
+  const { openConnectModal } = useConnectModal()
+  const userEns = useEns(account || '')
+
+  return (
+    <HeaderNav
+      {...MENU}
+      actions={[
+        {
+          content: account ? (
+            <div className="flex gap-2">
+              <button
+                onClick={(event) => {
+                  event.preventDefault()
+                  openConnectModal()
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-brand-ui-primary text-right">
+                    {userEns === account
+                      ? email
+                        ? email
+                        : addressMinify(userEns)
+                      : userEns}
+                  </span>
+                  <DisconnectIcon className="text-brand-ui-primary" size={20} />
+                </div>
+              </button>
+            </div>
+          ) : (
+            <Button
+              onClick={(event) => {
+                event.preventDefault()
+                openConnectModal()
+              }}
+            >
+              Connect
+            </Button>
+          ),
+        },
+      ]}
+    />
+  )
+}

--- a/unlock-app/src/pages/certification/index.tsx
+++ b/unlock-app/src/pages/certification/index.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import CertificationContent from '~/components/content/certification/CertificationContent'
-
-const Certification = () => <CertificationContent />
-
-export default Certification

--- a/unlock-app/src/pages/certification/new.tsx
+++ b/unlock-app/src/pages/certification/new.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import NewCertificationContent from '~/components/content/certification/NewCertification'
-
-const NewCertification = () => <NewCertificationContent />
-
-export default NewCertification


### PR DESCRIPTION
# Description
This PR introduces the migration of all certification-related pages and features from the legacy `pages` directory to the new `app` router structure.


# Issues
Fixes #
Refs #13673

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread