### PR TITLE
feature(unlock-app): Migrate `subscription`-related pages to `app` router

### DIFF
--- a/unlock-app/app/subscription/layout.tsx
+++ b/unlock-app/app/subscription/layout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react'
+
+import TermsOfServiceModal from '~/components/interface/layouts/index/TermsOfServiceModal'
+import { Container } from '~/components/interface/Container'
+import { ConnectModal } from '~/components/interface/connect/ConnectModal'
+import SubscriptionHeader from '~/components/interface/layouts/subscription/SubscriptionHeader'
+import DashboardFooter from '~/components/interface/layouts/index/DashboardFooter'
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-hidden bg-ui-secondary-200">
+      <TermsOfServiceModal />
+      <Container>
+        <ConnectModal />
+
+        <SubscriptionHeader />
+        <div className="flex flex-col gap-10 min-h-screen">{children}</div>
+
+        <DashboardFooter />
+      </Container>
+    </div>
+  )
+}

--- a/unlock-app/app/subscription/new/page.tsx
+++ b/unlock-app/app/subscription/new/page.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Metadata } from 'next'
+import NewSubscriptionContent from '~/components/content/subscription/NewSubscription'
+import { AuthRequired } from 'app/Components/ProtectedContent'
+
+export const metadata: Metadata = {
+  title: 'New Subscription | Unlock Protocol',
+  description: 'Create a new subscription with Unlock Protocol.',
+}
+
+const NewSubscriptionPage: React.FC = () => {
+  return (
+    <AuthRequired>
+      <NewSubscriptionContent />
+    </AuthRequired>
+  )
+}
+
+export default NewSubscriptionPage

--- a/unlock-app/app/subscription/page.tsx
+++ b/unlock-app/app/subscription/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Metadata } from 'next'
+import SubscriptionContent from '~/components/content/SubscriptionContent'
+
+export const metadata: Metadata = {
+  title: 'Onchain Subscriptions',
+  description:
+    'SUBSCRIPTIONS by Unlock Labs is best way for fans to subscribe to writing, podcasts, music, digital art, and creativity onchain with automatically recurring payments.',
+}
+
+const SubscriptionPage: React.FC = () => {
+  return <SubscriptionContent />
+}
+
+export default SubscriptionPage

--- a/unlock-app/src/components/content/SubscriptionContent.tsx
+++ b/unlock-app/src/components/content/SubscriptionContent.tsx
@@ -1,6 +1,5 @@
-import Head from 'next/head'
-import { pageTitle } from '../../constants'
-import { AppLayout, FOOTER } from '../interface/layouts/AppLayout'
+'use client'
+
 import { SubscriptionLandingPage } from './subscription/SubscriptionLandingPage'
 import { useRouter } from 'next/navigation'
 
@@ -8,25 +7,13 @@ export const SubscriptionContent = () => {
   const router = useRouter()
 
   return (
-    <AppLayout
-      showFooter={{ ...FOOTER, subscriptionForm: undefined }}
-      showLinks={false}
-      authRequired={false}
-      logoRedirectUrl="/subscription"
-      logoImageUrl="/images/svg/logo-unlock-subscriptions.svg"
-    >
-      <Head>
-        <title>{pageTitle('Onchain subscriptions')}</title>
-      </Head>
-
-      <SubscriptionLandingPage
-        handleCreateSubscription={() => {
-          router.push(
-            'https://unlock-protocol-19942922.hs-sites.com/unlock-subscription-signup'
-          )
-        }}
-      />
-    </AppLayout>
+    <SubscriptionLandingPage
+      handleCreateSubscription={() => {
+        router.push(
+          'https://unlock-protocol-19942922.hs-sites.com/unlock-subscription-signup'
+        )
+      }}
+    />
   )
 }
 

--- a/unlock-app/src/components/content/subscription/NewSubscription.tsx
+++ b/unlock-app/src/components/content/subscription/NewSubscription.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useCallback, useState } from 'react'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { ONE_DAY_IN_SECONDS, UNLIMITED_KEYS_COUNT } from '~/constants'
@@ -5,11 +7,9 @@ import networks from '@unlock-protocol/networks'
 import { ToastHelper } from '~/components/helpers/toast.helper'
 import { useMutation } from '@tanstack/react-query'
 import { CreateLockForm } from '~/components/interface/locks/Create/elements/CreateLockForm'
-import BrowserOnly from '~/components/helpers/BrowserOnly'
-import { AppLayout } from '~/components/interface/layouts/AppLayout'
 import { CreateLockFormSummary } from '~/components/interface/locks/Create/elements/CreateLockFormSummary'
 import { BsArrowLeft as ArrowBack } from 'react-icons/bs'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export const Deploy: React.FC = () => {
   const { getWalletService } = useAuth()
@@ -75,89 +75,87 @@ export const Deploy: React.FC = () => {
   }
 
   return (
-    <BrowserOnly>
-      <AppLayout>
-        <div>
-          {!transactionHash && (
-            <div className="grid items-center grid-cols-6 md:grid-cols-3">
-              <div className="col-auto">
-                <ArrowBack
-                  size={20}
-                  className="cursor-pointer"
-                  onClick={onBack}
-                />
-              </div>
-              <h1 className="col-span-4 text-lg font-semibold text-center md:col-auto md:text-xl">
-                Deploy Subscription
-              </h1>
+    <>
+      <div>
+        {!transactionHash && (
+          <div className="grid items-center grid-cols-6 md:grid-cols-3">
+            <div className="col-auto">
+              <ArrowBack
+                size={20}
+                className="cursor-pointer"
+                onClick={onBack}
+              />
             </div>
-          )}
-        </div>
-        <div>
-          {!transactionHash && (
-            <div className="grid gap-4 md:grid-cols-2 md:gap-28 pt-8 md:pt-14">
-              <div className="flex-col hidden mx-auto md:flex md:max-w-lg">
-                <h4 className="mb-4 text-5xl font-bold">
-                  Deploy your onchain subscription
-                </h4>
-                <span className="text-xl font-normal">
-                  For creators who want to monetize their work onchain, with
-                  recurring payments!
-                </span>
-                <img
-                  className="mt-9"
-                  src="/images/svg/create-lock/members.svg"
-                  alt="Create lock members"
-                />
-              </div>
-              <div className="md:max-w-lg">
-                <CreateLockForm
-                  onSubmit={onSubmitMutation.mutate}
-                  hideFields={['quantity']}
-                  defaultOptions={{
-                    expirationDuration: {
-                      label: 'Renew every',
-                      values: [
-                        {
-                          label: 'Week',
-                          value: 7,
-                        },
-                        {
-                          label: 'Month',
-                          value: 30,
-                        },
-                        {
-                          label: 'Quarter',
-                          value: 90,
-                        },
-                      ],
-                    },
-                    notFree: true,
-                    notUnlimited: true,
-                    noNative: true,
-                  }}
-                  defaultValues={{
-                    name: 'My subscription',
-                    unlimitedQuantity: true,
-                    keyPrice: 5.0,
-                    expirationDuration: 30,
-                  }}
-                  isLoading={onSubmitMutation.isPending}
-                />
-              </div>
+            <h1 className="col-span-4 text-lg font-semibold text-center md:col-auto md:text-xl">
+              Deploy Subscription
+            </h1>
+          </div>
+        )}
+      </div>
+      <div>
+        {!transactionHash && (
+          <div className="grid gap-4 md:grid-cols-2 md:gap-28 pt-8 md:pt-14">
+            <div className="flex-col hidden mx-auto md:flex md:max-w-lg">
+              <h4 className="mb-4 text-5xl font-bold">
+                Deploy your onchain subscription
+              </h4>
+              <span className="text-xl font-normal">
+                For creators who want to monetize their work onchain, with
+                recurring payments!
+              </span>
+              <img
+                className="mt-9"
+                src="/images/svg/create-lock/members.svg"
+                alt="Create lock members"
+              />
             </div>
-          )}
-          {transactionHash && (
-            <CreateLockFormSummary
-              formData={formData}
-              lockAddress={lockAddress}
-              transactionHash={transactionHash}
-              showStatus
-            />
-          )}
-        </div>
-      </AppLayout>
-    </BrowserOnly>
+            <div className="md:max-w-lg">
+              <CreateLockForm
+                onSubmit={onSubmitMutation.mutate}
+                hideFields={['quantity']}
+                defaultOptions={{
+                  expirationDuration: {
+                    label: 'Renew every',
+                    values: [
+                      {
+                        label: 'Week',
+                        value: 7,
+                      },
+                      {
+                        label: 'Month',
+                        value: 30,
+                      },
+                      {
+                        label: 'Quarter',
+                        value: 90,
+                      },
+                    ],
+                  },
+                  notFree: true,
+                  notUnlimited: true,
+                  noNative: true,
+                }}
+                defaultValues={{
+                  name: 'My subscription',
+                  unlimitedQuantity: true,
+                  keyPrice: 5.0,
+                  expirationDuration: 30,
+                }}
+                isLoading={onSubmitMutation.isPending}
+              />
+            </div>
+          </div>
+        )}
+        {transactionHash && (
+          <CreateLockFormSummary
+            formData={formData}
+            lockAddress={lockAddress}
+            transactionHash={transactionHash}
+            showStatus
+          />
+        )}
+      </div>
+    </>
   )
 }
 

--- a/unlock-app/src/components/content/subscription/SubscriptionLandingPage.tsx
+++ b/unlock-app/src/components/content/subscription/SubscriptionLandingPage.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Button } from '@unlock-protocol/ui'
 import { LockTypeLandingPage } from '~/components/interface/LockTypeLandingPage'
 import { NextSeo } from 'next-seo'

--- a/unlock-app/src/components/interface/layouts/subscription/SubscriptionHeader.tsx
+++ b/unlock-app/src/components/interface/layouts/subscription/SubscriptionHeader.tsx
@@ -1,0 +1,65 @@
+'use client'
+import { Button, HeaderNav } from '@unlock-protocol/ui'
+import { useConnectModal } from '~/hooks/useConnectModal'
+import useEns from '~/hooks/useEns'
+import { addressMinify } from '~/utils/strings'
+import { MdExitToApp as DisconnectIcon } from 'react-icons/md'
+import { useAuth } from '~/contexts/AuthenticationContext'
+
+const MENU = {
+  extraClass: {
+    mobile: 'bg-ui-secondary-200 px-6',
+  },
+  showSocialIcons: false,
+  logo: {
+    url: '/subscription',
+    src: '/images/svg/logo-unlock-subscriptions.svg',
+  },
+  menuSections: [],
+}
+
+export default function SubscriptionHeader() {
+  const { account, email } = useAuth()
+  const { openConnectModal } = useConnectModal()
+  const userEns = useEns(account || '')
+
+  return (
+    <HeaderNav
+      {...MENU}
+      actions={[
+        {
+          content: account ? (
+            <div className="flex gap-2">
+              <button
+                onClick={(event) => {
+                  event.preventDefault()
+                  openConnectModal()
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-brand-ui-primary text-right">
+                    {userEns === account
+                      ? email
+                        ? email
+                        : addressMinify(userEns)
+                      : userEns}
+                  </span>
+                  <DisconnectIcon className="text-brand-ui-primary" size={20} />
+                </div>
+              </button>
+            </div>
+          ) : (
+            <Button
+              onClick={(event) => {
+                event.preventDefault()
+                openConnectModal()
+              }}
+            >
+              Connect
+            </Button>
+          ),
+        },
+      ]}
+    />
+  )
+}

--- a/unlock-app/src/pages/subscription.tsx
+++ b/unlock-app/src/pages/subscription.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import SubscriptionContent from '../components/content/SubscriptionContent'
-
-const Subscription = () => <SubscriptionContent />
-
-export default Subscription

--- a/unlock-app/src/pages/subscription/new.tsx
+++ b/unlock-app/src/pages/subscription/new.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import NewSubscriptionContent from '~/components/content/subscription/NewSubscription'
-
-const NewSubscription = () => <NewSubscriptionContent />
-
-export default NewSubscription


### PR DESCRIPTION
# Description
This PR introduces changes that migrate `subscription`-related pages in the `unlock-app` to use the Next.js `app` router.


# Issues
Fixes #
Refs #13673


# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet