### PR TITLE
feat(network) : adding UDT/UP for tokens

### DIFF
--- a/docs/docs/governance/unlock-dao-tokens.mdx
+++ b/docs/docs/governance/unlock-dao-tokens.mdx
@@ -49,11 +49,10 @@ import { networks } from '@unlock-protocol/networks'
     return <TokenNetwork network={network} />
   })}
 </table>
- 
 
 ## Earning UP Token Rewards
 
-Unlock Protocol is governed by its implementers and users. As such, the protocol automatically distributes UP (or UDT, depending on network) tokens as a reward on every _purchase_ of a paid membership, on applicable networks. 
+Unlock Protocol is governed by its implementers and users. As such, the protocol automatically distributes UP (or UDT, depending on network) tokens as a reward on every _purchase_ of a paid membership, on applicable networks.
 
 When facilitating a purchase, the application sending the transaction can optionally add a `referrer` address to its transaction. This referrer address will receive the reward tokens, if applicable.
 
@@ -105,8 +104,7 @@ The swapping of UDT for UP is handled by a swapping smart contract. [The swappin
 
 This swapping contract was created by Unlock Labs, and **has been audited by [Code4rena](https://code4rena.com/)**.
 
-> *The Unlock Labs team has created a website at https://up-swap.unlock-protocol.com/ where anyone holding UDT can bridge their UDT from mainnet to Base and swap that UDT for UP governance tokens.*
-> 
+> _The Unlock Labs team has created a website at https://up-swap.unlock-protocol.com/ where anyone holding UDT can bridge their UDT from mainnet to Base and swap that UDT for UP governance tokens._
 
 The Unlock Labs team has created a website at [https://up-swap.unlock-protocol.com/](https://up-swap.unlock-protocol.com/) where anyone holding UDT can bridge their UDT from mainnet to Base and swap that UDT for UP governance tokens.
 
@@ -195,18 +193,19 @@ There is a Uniswap V3 liquidity pool for Base ETH/UP pairs at [https://app.unisw
 - UP has 1,000,000,000 supply while UDT had a 1,000,000 supply and UDT/UP has a fixed "exchange" rate of 1 for 1000
 
 ### Are UP tokens required?
+
 UP (and UDT, its predecessor) are perfectly _optional_. Creators can deploy smart contracts without knowledge of UP and their members can similarly purchase memberships without knowing about these tokens.
 
 ### Graphic assets for the Unlock Protocol UP token
 
 #### Square image (Right-click image to open or download)
+
 ![UP Token square icon](/img/icons/UP-token-square.png)
 
 #### Round image (Right-click image to open or download)
+
 ![UP Token round icon](/img/icons/UP-token-round.png)
 
 ### What is the Unlock Protocol Foundation?
 
 The role of the Unlock Protocol Foundation is to promote and encourage adoption of the Unlock Protocol.
-
-

--- a/docs/src/components/Network.js
+++ b/docs/src/components/Network.js
@@ -177,13 +177,12 @@ export const SupportedNetwork = ({ network }) => {
 export const TokenNetwork = ({ network }) => {
   const provider = new JsonRpcProvider(network.publicProvider)
   const { data: udt } = useQuery({
-    queryKey: ['getUdt', network.unlockAddress],
+    queryKey: ['getUdt', network.unlockAddress, network.id],
     queryFn: async () => {
       return getUdt(provider, network.unlockAddress)
     },
     enabled: !!network.unlockAddress,
   })
-  console.log(udt)
 
   const { data: symbol } = useQuery({
     queryKey: ['getSymbol', network.unlockAddress, udt],

--- a/packages/networks/src/networks/arbitrum.ts
+++ b/packages/networks/src/networks/arbitrum.ts
@@ -147,6 +147,12 @@ export const arbitrum: NetworkConfig = {
       name: 'Arbitrum',
       symbol: 'ARB',
     },
+    {
+      address: '0xd5d3aA404D7562d09a848F96a8a8d5D65977bF90',
+      decimals: 18,
+      name: 'Unlock Discount Token',
+      symbol: 'UDT',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/packages/networks/src/networks/base.ts
+++ b/packages/networks/src/networks/base.ts
@@ -138,6 +138,18 @@ export const base: NetworkConfig = {
       name: 'Degen',
       symbol: 'DEGEN',
     },
+    {
+      address: '0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187',
+      decimals: 18,
+      name: 'UnlockProtocolToken',
+      symbol: 'UP',
+    },
+    {
+      address: '0xD7eA82D19f1f59FF1aE95F1945Ee6E6d86A25B96',
+      decimals: 18,
+      name: 'Unlock Discount Token',
+      symbol: 'UDT',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',

--- a/packages/networks/src/networks/gnosis.ts
+++ b/packages/networks/src/networks/gnosis.ts
@@ -114,6 +114,12 @@ export const gnosis: NetworkConfig = {
       name: 'Tether USD on xDai',
       symbol: 'USDT',
     },
+    {
+      address: '0x8C84142c4a716a16a89d0e61707164d6107A9811',
+      decimals: 18,
+      name: 'UDT from Ethereum',
+      symbol: 'UDT',
+    },
   ],
   unlockAddress: '0x1bc53f4303c711cc693F6Ec3477B83703DcB317f',
   unlockDaoToken: {

--- a/packages/networks/src/networks/mainnet.ts
+++ b/packages/networks/src/networks/mainnet.ts
@@ -161,6 +161,12 @@ export const mainnet: NetworkConfig = {
       name: 'BNB',
       symbol: 'BNB',
     },
+    {
+      address: '0x90DE74265a416e1393A450752175AED98fe11517',
+      decimals: 18,
+      name: 'Unlock Discount Token',
+      symbol: 'UDT',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/packages/networks/src/networks/optimism.ts
+++ b/packages/networks/src/networks/optimism.ts
@@ -155,6 +155,12 @@ export const optimism: NetworkConfig = {
       name: 'Wrapped BTC',
       symbol: 'WBTC',
     },
+    {
+      address: '0xc709c9116dBf29Da9c25041b13a07A0e68aC5d2D',
+      decimals: 18,
+      name: 'Unlock Discount Token',
+      symbol: 'UDT',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/packages/networks/src/networks/polygon.ts
+++ b/packages/networks/src/networks/polygon.ts
@@ -71,8 +71,8 @@ export const polygon: NetworkConfig = {
   nativeCurrency: {
     coingecko: 'matic-network',
     decimals: 18,
-    name: 'Matic',
-    symbol: 'MATIC',
+    name: 'Wrapped Polygon Ecosystem Token',
+    symbol: 'WPOL',
     wrapped: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
   },
   opensea: {
@@ -142,14 +142,20 @@ export const polygon: NetworkConfig = {
     {
       address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
       decimals: 18,
-      name: 'Wrapped Matic',
-      symbol: 'WMATIC',
+      name: 'Wrapped Polygon Ecosystem Token',
+      symbol: 'WPOL',
     },
     {
       address: '0xE06Bd4F5aAc8D0aA337D13eC88dB6defC6eAEefE',
       decimals: 18,
       name: 'PlanetIX',
       symbol: 'IXT',
+    },
+    {
+      address: '0xf7E78d9C4c74df889A83C8C8d6D05BF70fF75876',
+      decimals: 18,
+      name: 'Unlock Discount Token (PoS)',
+      symbol: 'UDT',
     },
   ],
   uniswapV3: {

--- a/packages/networks/src/networks/sepolia.ts
+++ b/packages/networks/src/networks/sepolia.ts
@@ -139,6 +139,12 @@ export const sepolia: NetworkConfig = {
       name: 'Uniswap',
       symbol: 'UNI',
     },
+    {
+      address: '0x447B1492C5038203f1927eB2a374F5Fcdc25999d',
+      decimals: 18,
+      name: 'Unlock Discount Token',
+      symbol: 'UDT',
+    },
   ],
   uniswapV3: {
     factoryAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',


### PR DESCRIPTION
# Description

As I am about to deploy the UP Prime membership, I realize we are not showing UDT and UP as options.
This fixes it!

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
