### PR TITLE
chore(contracts): replace dodoc by solidity-docgen

### DIFF
--- a/packages/contracts/bin/build_docs.sh
+++ b/packages/contracts/bin/build_docs.sh
@@ -2,12 +2,19 @@
 SRC_DOCS_FOLDER="$(pwd)/docs"
 DEST_DOCS_FOLDER="$(pwd)/docs-reorg"
 
+#cleanup 
+rm -rf $SRC_DOCS_FOLDER
+
 # build docs
-yarn hardhat dodoc
+yarn hardhat docgen
 
 # delete existing folder
 rm -rf $DEST_DOCS_FOLDER
 mkdir -p $DEST_DOCS_FOLDER
+
+# delete all contracts than are NOT interfaces
+find  ./docs -type f -name 'PublicLock*' -exec rm {} \;
+find  ./docs -type f -name 'Unlock*' -exec rm {} \;
 
 # first archive all 
 cp -R $SRC_DOCS_FOLDER $DEST_DOCS_FOLDER
@@ -152,4 +159,7 @@ echo '{
 # replace docs
 rm -rf $SRC_DOCS_FOLDER
 mv $DEST_DOCS_FOLDER $SRC_DOCS_FOLDER
+
+# cleanup tmp files
+find  ./docs -type f -name '*.md-e' -exec rm {} \;
 

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -51,7 +51,6 @@ module.exports = {
       'UP',
       'utils',
       'Governor',
-      'Hooks',
       'UnlockDiscountToken',
     ],
   },

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -3,25 +3,13 @@
  */
 
 // to build contract docs
-require('@primitivefi/hardhat-dodoc')
+// require('@primitivefi/hardhat-dodoc')
+require('solidity-docgen')
 
 const fs = require('fs-extra')
 require('./task/exportAbis')
 
 const contractsPath = './src/contracts'
-
-// list all interfaces to document
-const contractsToDocument = fs
-  .readdirSync(contractsPath)
-  .map((contractName) =>
-    fs.readdirSync(`${contractsPath}/${contractName}`).filter(
-      (n) =>
-        n.startsWith('I') && // only interfaces
-        !n.includes('Sol') && // exclude various solc versions
-        !n.startsWith('IUnlockDiscountToken') // exclude UDT
-    )
-  )
-  .flat()
 
 const settings = {
   optimizer: {
@@ -53,11 +41,19 @@ module.exports = {
       },
     ],
   },
-  dodoc: {
-    // debugMode: true,
-    keepFileStructure: true,
-    include: contractsToDocument,
-    exclude: ['IERC165', 'IERC721', 'IERC721Enumerable', 'Initializable'],
+  docgen: {
+    pages: 'files',
+    exclude: [
+      'IERC165',
+      'IERC721',
+      'IERC721Enumerable',
+      'Initializable',
+      'UP',
+      'utils',
+      'Governor',
+      'Hooks',
+      'UnlockDiscountToken',
+    ],
   },
   paths: {
     sources: contractsPath,

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -17,6 +17,7 @@
     "copyutils": "cp dist/src/utils/* dist",
     "copyindex": "cp dist/src/index.js dist && cp -r dist/src/abis dist",
     "docs": "sh ./bin/build_docs.sh",
+    "docs:docgen": "yarn hardhat docgen",
     "docs:copy": "copyfiles --verbose docs/**/*.json docs/**/*.md  dist",
     "prepublish": "yarn clean && yarn build && yarn build:docs",
     "publish:npm": "yarn prepublish && npm publish"
@@ -27,7 +28,6 @@
     "directory": "packages/contracts"
   },
   "devDependencies": {
-    "@primitivefi/hardhat-dodoc": "0.2.3",
     "@unlock-protocol/networks": "workspace:^",
     "@unlock-protocol/tsconfig": "workspace:./packages/tsconfig",
     "@unlock-protocol/types": "workspace:^",
@@ -39,5 +39,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "solidity-docgen": "0.6.0-beta.36"
+  }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -35,12 +35,10 @@
     "eslint": "9.11.1",
     "fs-extra": "11.2.0",
     "hardhat": "2.22.9",
+    "solidity-docgen": "0.6.0-beta.36",
     "typescript": "5.6.2"
   },
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "solidity-docgen": "0.6.0-beta.36"
-  }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14368,18 +14368,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@primitivefi/hardhat-dodoc@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@primitivefi/hardhat-dodoc@npm:0.2.3"
-  dependencies:
-    squirrelly: "npm:^8.0.8"
-  peerDependencies:
-    hardhat: ^2.6.4
-    squirrelly: ^8.0.8
-  checksum: 10/0db4f31bf0fbcf3dbce5a58e5570e5bb915247d9fafecc0239bfeb50fda20d6fd76c16bae704b092714d81a42ee378f63b50a51c06423638d536325e5be2f1a9
-  languageName: node
-  linkType: hard
-
 "@prisma/instrumentation@npm:5.19.1":
   version: 5.19.1
   resolution: "@prisma/instrumentation@npm:5.19.1"
@@ -20527,7 +20515,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@unlock-protocol/contracts@workspace:packages/contracts"
   dependencies:
-    "@primitivefi/hardhat-dodoc": "npm:0.2.3"
     "@unlock-protocol/networks": "workspace:^"
     "@unlock-protocol/tsconfig": "workspace:./packages/tsconfig"
     "@unlock-protocol/types": "workspace:^"
@@ -20535,6 +20522,7 @@ __metadata:
     eslint: "npm:9.11.1"
     fs-extra: "npm:11.2.0"
     hardhat: "npm:2.22.9"
+    solidity-docgen: "npm:0.6.0-beta.36"
     typescript: "npm:5.6.2"
   languageName: unknown
   linkType: soft
@@ -33982,7 +33970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.8":
+"handlebars@npm:4.7.8, handlebars@npm:^4.7.7":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
   dependencies:
@@ -49019,6 +49007,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"solidity-ast@npm:^0.4.38":
+  version: 0.4.59
+  resolution: "solidity-ast@npm:0.4.59"
+  checksum: 10/95172fcc3b4ea183c328c36b72b1b861c2e1a2c0f8334f5375f05c1f7a11e13b10f126818dd1a65bb672b4bca87278faaa2bae5c25d2433e162bc86a47d43daa
+  languageName: node
+  linkType: hard
+
 "solidity-ast@npm:^0.4.51, solidity-ast@npm:^0.4.56":
   version: 0.4.56
   resolution: "solidity-ast@npm:0.4.56"
@@ -49088,6 +49083,18 @@ __metadata:
   bin:
     solidity-coverage: plugins/bin.js
   checksum: 10/8fab639ccbc57fe0e9d6403c8d33ab68cb5e14a36f393b87dce4131d6bf16cb4a0935f75d1268173c4f8d3eb2438435de6d1d35f6b20d64025883ab98d7629cf
+  languageName: node
+  linkType: hard
+
+"solidity-docgen@npm:0.6.0-beta.36":
+  version: 0.6.0-beta.36
+  resolution: "solidity-docgen@npm:0.6.0-beta.36"
+  dependencies:
+    handlebars: "npm:^4.7.7"
+    solidity-ast: "npm:^0.4.38"
+  peerDependencies:
+    hardhat: ^2.8.0
+  checksum: 10/7c055101f5801d9eb812c0275551de59f0bdd0ec886ab23af1cd25dc33322947205f298a78b9389ba155aee9338718b5d93933fb303c00144b556178808d6656
   languageName: node
   linkType: hard
 
@@ -49406,13 +49413,6 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10/c34828732ab8509c2741e5fd1af6b767c3daf2c642f267788f933a65b1614943c282e74c4284f4fa749c264b18ee016a0d37a3e5b73aee446da46277d3a85daa
-  languageName: node
-  linkType: hard
-
-"squirrelly@npm:^8.0.8":
-  version: 8.0.8
-  resolution: "squirrelly@npm:8.0.8"
-  checksum: 10/b07f7456b9f7709cdfd5b04d9756304838384fd7f932fb76fab0d1489a85158fd3e78cc22cb2c93e8b92156003a2f5f12fd614c202b72d538f293a5dc25f505b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR replaces doc engine to build NatSpec solidity docstring into markdown files. We now use the OZ solution which seems standard in many other projects

Also this will allow  to dedupe documentation in main contracts and inherits all doc from interfaces - as mentioned in  #10253

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
