### PR TITLE
feature(unlock-app): Migrate `verification` page to `app` router

### DIFF
--- a/unlock-app/app/verification/layout.tsx
+++ b/unlock-app/app/verification/layout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react'
+
+import TermsOfServiceModal from '~/components/interface/layouts/index/TermsOfServiceModal'
+import { Container } from '~/components/interface/Container'
+import { ConnectModal } from '~/components/interface/connect/ConnectModal'
+import DashboardFooter from '~/components/interface/layouts/index/DashboardFooter'
+import DashboardHeader from '~/components/interface/layouts/index/DashboardHeader'
+
+export default function VerificationLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div className="overflow-hidden bg-ui-secondary-200">
+      <TermsOfServiceModal />
+      <Container>
+        <ConnectModal />
+
+        <DashboardHeader showMenu={false} />
+        <div className="flex flex-col gap-10 min-h-screen">{children}</div>
+
+        <DashboardFooter />
+      </Container>
+    </div>
+  )
+}

--- a/unlock-app/app/verification/page.tsx
+++ b/unlock-app/app/verification/page.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Metadata } from 'next'
+import VerificationContent from '~/components/content/VerificationContent'
+
+export const metadata: Metadata = {
+  title: 'Verification | Unlock Events',
+  description: 'Verify your membership to an event on Unlock Protocol.',
+}
+
+const VerificationPage: React.FC = () => {
+  return <VerificationContent />
+}
+
+export default VerificationPage

--- a/unlock-app/src/components/content/VerificationContent.tsx
+++ b/unlock-app/src/components/content/VerificationContent.tsx
@@ -1,10 +1,9 @@
-import Head from 'next/head'
+'use client'
+
 import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useState } from 'react'
 import { getMembershipVerificationConfig } from '~/utils/verification'
-import { pageTitle } from '../../constants'
 import LocksContext from '../../contexts/LocksContext'
-import { AppLayout } from '../interface/layouts/AppLayout'
 import { Scanner } from '../interface/verification/Scanner'
 import VerificationStatus from '../interface/VerificationStatus'
 
@@ -20,14 +19,9 @@ export const VerificationContent: React.FC<unknown> = () => {
 
   if (!membershipVerificationConfig) {
     return (
-      <AppLayout title="Verification" showLinks={false} authRequired={false}>
-        <Head>
-          <title>{pageTitle('Verification')}</title>
-        </Head>
-        <main>
-          <Scanner />
-        </main>
-      </AppLayout>
+      <main>
+        <Scanner />
+      </main>
     )
   }
 
@@ -39,24 +33,19 @@ export const VerificationContent: React.FC<unknown> = () => {
   }
 
   return (
-    <AppLayout title="Verification" showLinks={false} authRequired={false}>
-      <Head>
-        <title>{pageTitle('Verification')}</title>
-      </Head>
-      <LocksContext.Provider
-        value={{
-          locks,
-          addLock,
+    <LocksContext.Provider
+      value={{
+        locks,
+        addLock,
+      }}
+    >
+      <VerificationStatus
+        config={membershipVerificationConfig}
+        onVerified={() => {
+          router.push('/verification')
         }}
-      >
-        <VerificationStatus
-          config={membershipVerificationConfig}
-          onVerified={() => {
-            router.push('/verification')
-          }}
-        />
-      </LocksContext.Provider>
-    </AppLayout>
+      />
+    </LocksContext.Provider>
   )
 }
 

--- a/unlock-app/src/components/interface/layouts/index/DashboardHeader.tsx
+++ b/unlock-app/src/components/interface/layouts/index/DashboardHeader.tsx
@@ -26,13 +26,21 @@ const MENU = {
   ],
 }
 
-export default function DashboardHeader() {
+interface DashboardHeaderProps {
+  showMenu?: boolean
+}
+
+export default function DashboardHeader({
+  showMenu = true,
+}: DashboardHeaderProps) {
   const { account } = useAuth()
   const { openConnectModal } = useConnectModal()
 
+  const menuProps = showMenu ? MENU : { ...MENU, menuSections: [] }
+
   return (
     <HeaderNav
-      {...MENU}
+      {...menuProps}
       actions={[
         {
           content: account ? (

--- a/unlock-app/src/pages/verification.tsx
+++ b/unlock-app/src/pages/verification.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import VerificationContent from '../components/content/VerificationContent'
-
-const Verification = () => <VerificationContent />
-
-export default Verification


### PR DESCRIPTION
# Description
This PR introduces the migration of the `verification` page from the `pages` directory to the `app` router.

# Issues
Fixes #
Refs #13673

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread