### PR TITLE
feature(unlock-app): Migrate `home` page to `app` router

### DIFF
--- a/unlock-app/app/page.tsx
+++ b/unlock-app/app/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Metadata } from 'next'
+import { HomeContent } from '~/components/content/HomeContent'
+
+export const metadata: Metadata = {
+  title: 'Creator Dashboard | Unlock Protocol',
+  description:
+    'Deploy, manage, and update locks, view key owners, and withdraw funds from your memberships and subscriptions.',
+}
+
+const HomePage: React.FC = () => {
+  return <HomeContent />
+}
+
+export default HomePage

--- a/unlock-app/src/__tests__/pages/pages.test.tsx
+++ b/unlock-app/src/__tests__/pages/pages.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import * as rtl from '@testing-library/react'
 
-import Home from '../../pages/index'
+import Home from '../../../app/page'
 
 import { pageTitle } from '../../constants'
 import { ConfigContext } from '../../utils/withConfig'

--- a/unlock-app/src/components/content/HomeContent.tsx
+++ b/unlock-app/src/components/content/HomeContent.tsx
@@ -1,14 +1,14 @@
+'use client'
+
 import { useEffect } from 'react'
-import Head from 'next/head'
-import { pageTitle } from '../../constants'
-import { TwitterTags } from '../page/TwitterTags'
-import { OpenGraphTags } from '../page/OpenGraphTags'
-import { AppLayout } from '../interface/layouts/AppLayout'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import Loading from '../interface/Loading'
 import { Launcher } from '../interface/Launcher'
 import { useSession } from '~/hooks/useSession'
+import { Container } from '../interface/Container'
+import DashboardHeader from '../interface/layouts/index/DashboardHeader'
+import { ConnectModal } from '../interface/connect/ConnectModal'
 
 export const HomeContent = () => {
   const { isLoading } = useSession()
@@ -22,14 +22,11 @@ export const HomeContent = () => {
   }, [account, router])
 
   return (
-    <AppLayout authRequired={false} showLinks={false}>
-      <Head>
-        <title>{pageTitle()}</title>
-        <TwitterTags />
-        <OpenGraphTags />
-      </Head>
+    <Container>
+      <ConnectModal />
+      <DashboardHeader />
       {account && <Loading />}
       {!account && !isLoading && <Launcher />}
-    </AppLayout>
+    </Container>
   )
 }

--- a/unlock-app/src/components/interface/layouts/index/DashboardHeader.tsx
+++ b/unlock-app/src/components/interface/layouts/index/DashboardHeader.tsx
@@ -3,6 +3,7 @@ import { Button, HeaderNav } from '@unlock-protocol/ui'
 import { useConnectModal } from '~/hooks/useConnectModal'
 import { useAuth } from '~/contexts/AuthenticationContext'
 import { UserMenu } from '../../connect/UserMenu'
+import { usePathname } from 'next/navigation'
 
 const MENU = {
   extraClass: {
@@ -35,8 +36,10 @@ export default function DashboardHeader({
 }: DashboardHeaderProps) {
   const { account } = useAuth()
   const { openConnectModal } = useConnectModal()
+  const pathname = usePathname()
 
-  const menuProps = showMenu ? MENU : { ...MENU, menuSections: [] }
+  const menuProps =
+    showMenu && pathname !== '/' ? MENU : { ...MENU, menuSections: [] }
 
   return (
     <HeaderNav

--- a/unlock-app/src/pages/index.tsx
+++ b/unlock-app/src/pages/index.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import { HomeContent } from '../components/content/HomeContent'
-
-const Home = () => <HomeContent />
-
-export default Home


### PR DESCRIPTION
# Description
This PR introduces the migration of the `home` page from the `pages` directory to the `app` router.

# Issues
Fixes #
Refs #13673

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread