### PR TITLE
feature(unlock-app): Link Email Address

### DIFF
--- a/unlock-app/app/layout.tsx
+++ b/unlock-app/app/layout.tsx
@@ -7,6 +7,7 @@ import Providers from './providers'
 
 import TagManagerScript from '../src/components/TagManagerScript'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { PromptEmailLink } from '~/components/interface/PromptEmailLink'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -23,7 +24,10 @@ export default function RootLayout({
   return (
     <html lang="en" className={inter.className}>
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <PromptEmailLink />
+        </Providers>
         <TagManagerScript />
         <SpeedInsights />
       </body>

--- a/unlock-app/src/components/interface/PromptEmailLink.tsx
+++ b/unlock-app/src/components/interface/PromptEmailLink.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { usePrivy } from '@privy-io/react-auth'
+import { Button, Modal } from '@unlock-protocol/ui'
+import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export const PromptEmailLink = () => {
+  const { user, ready } = usePrivy()
+  const pathname = usePathname()
+  const [showModal, setShowModal] = useState(false)
+
+  useEffect(() => {
+    if (ready && user) {
+      const hasEmail = user.linkedAccounts.some(
+        (account) => account.type === 'email'
+      )
+      setShowModal(!hasEmail && pathname !== '/settings')
+    }
+  }, [ready, user, pathname])
+
+  return (
+    <Modal isOpen={showModal} setIsOpen={() => {}} size="small">
+      <div className="z-10 w-full max-w-sm bg-white rounded-2xl p-6">
+        <h2 className="text-xl font-bold mb-4">Email Required</h2>
+        <p className="mb-6">
+          To continue using the dashboard, please add your email address.
+        </p>
+        <Link href="/settings">
+          <Button className="w-full">Add Email</Button>
+        </Link>
+      </div>
+    </Modal>
+  )
+}

--- a/unlock-app/src/components/interface/user-account/AccountInfo.tsx
+++ b/unlock-app/src/components/interface/user-account/AccountInfo.tsx
@@ -1,26 +1,91 @@
+import {
+  LoginModal,
+  usePrivy,
+  useLinkAccount,
+  useUpdateAccount,
+} from '@privy-io/react-auth'
+import { useState } from 'react'
 import { Item } from './styles'
 import useEns from '../../../hooks/useEns'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { Button, Modal } from '@unlock-protocol/ui'
+import { ToastHelper } from '~/components/helpers/toast.helper'
 
 export const AccountInfo = () => {
-  const { account } = useAuthenticate()
-
+  const { account, ready } = useAuthenticate()
+  const { user } = usePrivy()
+  const [showEmailModal, setShowEmailModal] = useState(false)
   const name = useEns(account || '')
 
+  const { linkEmail } = useLinkAccount({
+    onSuccess: () => {
+      setShowEmailModal(false)
+      ToastHelper.success('Email added successfully')
+    },
+    onError: (error) => {
+      ToastHelper.error('Error linking email')
+      console.error('Error linking email:', error)
+    },
+  })
+
+  const { updateEmail } = useUpdateAccount({
+    onSuccess: () => {
+      setShowEmailModal(false)
+      ToastHelper.success('Email updated successfully')
+    },
+    onError: (error) => {
+      ToastHelper.error('Error updating email')
+      console.error('Error updating email:', error)
+    },
+  })
+
+  const handleUpdateEmail = () => {
+    setShowEmailModal(true)
+    updateEmail()
+  }
+
+  const handleLinkEmail = () => {
+    setShowEmailModal(true)
+    linkEmail()
+  }
+
   return (
-    <div className="grid max-w-4xl gap-4 grid-cols-[repeat(12,[col-start]_1fr)">
-      <div className="col-span-12 text-base font-bold leading-5">Account</div>
-      {/* {email && (
-        <Item title="Email" count="half">
-          <span className="flex h-5 mx-1 my-3 text-black">{email}</span>
+    <div className="max-w-4xl mt-10">
+      <h2 className="text-base font-bold leading-5 mb-4">Account</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Item title="Wallet Address" count="half">
+          <span className="flex h-5 mx-1 my-3 text-black text-sm md:text-base">
+            {account} {name !== account ? `(${name})` : ''}
+          </span>
         </Item>
-      )} */}
-      <Item title="Wallet Address" count="half">
-        <span className="flex h-5 mx-1 my-3 text-black">
-          {account} {name !== account ? `(${name})` : ''}
-        </span>
-      </Item>
+        <Item title="Email" count="half">
+          <div className="flex justify-between items-center">
+            <span className="flex h-5 mx-1 my-3 text-black text-sm md:text-base">
+              {user?.email?.address || 'No email added yet'}
+            </span>
+            {user?.email?.address ? (
+              <Button
+                size="small"
+                onClick={handleUpdateEmail}
+                disabled={!ready}
+              >
+                Update Email
+              </Button>
+            ) : (
+              <Button size="small" onClick={handleLinkEmail} disabled={!ready}>
+                Link Email
+              </Button>
+            )}
+          </div>
+        </Item>
+      </div>
+
+      <Modal isOpen={showEmailModal} setIsOpen={setShowEmailModal} size="small">
+        <LoginModal open={showEmailModal} />
+      </Modal>
     </div>
   )
 }
+
 export default AccountInfo


### PR DESCRIPTION
# Description
This PR introduces a feature to collect user email addresses using Privy. When a user logs into the dashboard and they're yet to link their email, they will be prompted to provide one. The collected email will be displayed on the settings page, where users can update it if necessary.

## ScreenGrabs
![Screenshot 2024-10-23 at 13 46 06](https://github.com/user-attachments/assets/1511c838-50e3-4e14-a289-58ef75009080)
![Screenshot 2024-10-23 at 13 46 17](https://github.com/user-attachments/assets/e96d3717-8f9e-45b4-bb48-f5b4b1e88fa8)
![Screenshot 2024-10-23 at 13 46 49](https://github.com/user-attachments/assets/de06ee32-2e7b-4938-8f7a-7606e0316634)


## Flow
[Loom](https://www.loom.com/share/1758efdd92f0493ba0c9732e7ea4ed91)

# Issues
Fixes #14859
Refs #14859

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread