### PR TITLE
fix(unlock-app): Fix Overlap Issue Between Dashboard User Menu and Components

### DIFF
--- a/unlock-app/src/components/interface/connect/UserMenu.tsx
+++ b/unlock-app/src/components/interface/connect/UserMenu.tsx
@@ -28,7 +28,7 @@ export const UserMenu = () => {
   }, [signOut])
 
   return (
-    <Menu as="div" className="relative inline-block text-left">
+    <Menu as="div" className="relative inline-block z-10 text-left">
       <MenuButton className="flex items-center gap-2">
         <span className="text-brand-ui-primary text-right">
           {userEns === account ? addressMinify(userEns) : userEns}

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -4,7 +4,7 @@ import { MdOutlineTipsAndUpdates } from 'react-icons/md'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { Button, Icon } from '@unlock-protocol/ui'
 import { useRouter, useSearchParams } from 'next/navigation'
-import React, { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { ConnectWalletModal } from '../../ConnectWalletModal'
 import { LockDetailCard } from './elements/LockDetailCard'
 import { Members } from './elements/Members'
@@ -257,7 +257,7 @@ const ToolsMenu = ({ lockAddress, network }: TopActionBarProps) => {
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-1"
             >
-              <Popover.Panel className="absolute right-0 z-10 max-w-sm px-4 mt-3 transform w-80">
+              <Popover.Panel className="absolute right-0 z-[5] max-w-sm px-4 mt-3 transform w-80">
                 <div className="overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
                   <div className="relative grid gap-8 bg-white p-7">
                     <a href={DEMO_URL} target="_blank" rel="noreferrer">


### PR DESCRIPTION
# Description
This PR introduces a fix for an overlap issue where the dashboard's user menu was rendered beneath other components. 

## ScreenGrabs
<img width="742" alt="Screenshot 2024-10-23 at 21 31 54" src="https://github.com/user-attachments/assets/3ef2aa98-fa61-496b-b99a-d2ce7718a498">

<br />

<img width="692" alt="Screenshot 2024-10-23 at 21 32 29" src="https://github.com/user-attachments/assets/2fabb406-f7db-4ef9-a36f-14faf3b8798c">


# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread