### PR TITLE
fix(unlock-app): automatically completes privy auth

### DIFF
--- a/unlock-app/app/providers.tsx
+++ b/unlock-app/app/providers.tsx
@@ -50,19 +50,19 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       <GlobalWrapper>
         <Privy>
           <SessionProvider>
-            <ConnectModalProvider>
-              <ErrorBoundary
-                fallback={(props: any) => <ErrorFallback {...props} />}
-              >
+            <Suspense fallback={<LoadingIcon />}>
+              <ConnectModalProvider>
                 <AirstackProvider apiKey={'162b7c4dda5c44afdb0857b6b04454f99'}>
-                  <Suspense fallback={<LoadingIcon />}>
+                  <ErrorBoundary
+                    fallback={(props: any) => <ErrorFallback {...props} />}
+                  >
                     <ShouldOpenConnectModal />
                     {children}
-                  </Suspense>
+                  </ErrorBoundary>
                 </AirstackProvider>
-              </ErrorBoundary>
-            </ConnectModalProvider>
-            <Toaster />
+              </ConnectModalProvider>
+              <Toaster />
+            </Suspense>
           </SessionProvider>
         </Privy>
       </GlobalWrapper>

--- a/unlock-app/src/hooks/useConnectModal.tsx
+++ b/unlock-app/src/hooks/useConnectModal.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 import { useAuthenticate } from './useAuthenticate'
+import { useSearchParams } from 'next/navigation'
 
 const ConnectModalContext = createContext({
   openConnectModal: () => {},
@@ -25,6 +26,19 @@ export const connection = new EventTarget()
 export const ConnectModalProvider = (props: Props) => {
   const [open, setOpen] = useState(false)
   const { signInWithPrivy } = useAuthenticate()
+  const searchParams = useSearchParams()
+
+  const privy_oauth_state = searchParams.get('privy_oauth_state')
+
+  useEffect(() => {
+    if (privy_oauth_state) {
+      signInWithPrivy({
+        onshowUI: () => {
+          setOpen(true)
+        },
+      })
+    }
+  }, [privy_oauth_state])
 
   const openConnectModal = async () => {
     signInWithPrivy({


### PR DESCRIPTION
# Description

I realized there was a glitch when connecting with google where the user needed to click the button again!

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
