### PR TITLE
feature(smart-contracts): adding the ability to execute more tx as part of a deployment.

### DIFF
--- a/smart-contracts/contracts/interfaces/IUnlock.sol
+++ b/smart-contracts/contracts/interfaces/IUnlock.sol
@@ -67,11 +67,25 @@ interface IUnlock {
    * Create an upgradeable lock using a specific PublicLock version
    * @param data bytes containing the call to initialize the lock template
    * (refer to createUpgradeableLock for more details)
-   * @param _lockVersion the version of the lock to use
+   * @param lockVersion the version of the lock to use
    */
   function createUpgradeableLockAtVersion(
     bytes memory data,
-    uint16 _lockVersion
+    uint16 lockVersion
+  ) external returns (address);
+
+  /**
+   * Create an upgradeable lock using a specific PublicLock version, and execute
+   * transaction on the created lock.
+   * @param data bytes containing the call to initialize the lock template
+   * (refer to createUpgradeableLock for more details)
+   * @param lockVersion the version of the lock to use
+   * @param transactions an array of transactions to be executed on the newly created lock.
+   */
+  function createUpgradeableLockAtVersion(
+    bytes memory data,
+    uint16 lockVersion,
+    bytes[] calldata transactions
   ) external returns (address);
 
   /**


### PR DESCRIPTION
# Description

One pattern we have seen multiple times is the need to deploy a lock but customize its behavior immediately (add lock managers, change fees... etc). 
Until now, this requires sending multiple transaction: one to deploy the lock and then all the ones to change the values that need to be changed.

I propose a minor addition to let someone pass a list of transactions to be executed from _Unlock.sol_ on the newly deployed lock. This will let someone deploy and customize a lock in a single transaction.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

