### PR TITLE
feat(locksmith): executing multiple transactions in deployment

### DIFF
--- a/locksmith/__tests__/controllers/v2/eventCasterController.test.ts
+++ b/locksmith/__tests__/controllers/v2/eventCasterController.test.ts
@@ -1,6 +1,9 @@
 import request from 'supertest'
 import { vi, describe, expect } from 'vitest'
 import app from '../../app'
+import { ethers } from 'ethers'
+import { Unlock } from '@unlock-protocol/contracts'
+import networks from '../../../../packages/networks/dist'
 
 const lockAddress = '0xce332211f030567bd301507443AD9240e0b13644'
 const tokenId = 1337
@@ -8,18 +11,20 @@ const owner = '0xCEEd9585854F12F81A0103861b83b995A64AD915'
 
 const mockWalletService = {
   connect: vi.fn(),
-  createLock: async () => {
-    return lockAddress
-  },
   grantKey: async () => {
     return { id: tokenId, owner }
   },
 }
 
 vi.mock('@unlock-protocol/unlock-js', () => ({
-  // Web3Service: function Web3Service() {},
   WalletService: function WalletService() {
     return mockWalletService
+  },
+}))
+
+vi.mock('../../../src/operations/eventCasterOperations', () => ({
+  deployLockForEventCaster: async () => {
+    return { address: lockAddress, network: 84532 }
   },
 }))
 

--- a/locksmith/src/controllers/v2/eventCasterController.ts
+++ b/locksmith/src/controllers/v2/eventCasterController.ts
@@ -6,14 +6,19 @@ import {
   getProviderForNetwork,
   getPurchaser,
 } from '../../fulfillment/dispatcher'
-import { isProduction } from '../../config/config'
-
-const DEFAULT_NETWORK = isProduction ? 8453 : 84532 // Base or Base Sepolia
+import { deployLockForEventCaster } from '../../operations/eventCasterOperations'
 
 // This is the API endpoint used by EventCaster to create events
 const CreateEventBody = z.object({
   id: z.string(),
   title: z.string(),
+  hosts: z.array(
+    z.object({
+      verified_addresses: z.object({
+        eth_addresses: z.array(z.string()),
+      }),
+    })
+  ),
 })
 
 // This is the API endpoint used by EventCaster to create events
@@ -26,29 +31,18 @@ const RsvpBody = z.object({
 })
 
 export const createEvent: RequestHandler = async (request, response) => {
-  const { title } = await CreateEventBody.parseAsync(request.body)
-  const lockParams = {
-    name: title,
-    expirationDuration: -1, // Never expire
-    maxNumberOfKeys: 0, // none for sale (only granted!)
-    keyPrice: 0, // free
-  }
-  const [provider, wallet] = await Promise.all([
-    getProviderForNetwork(DEFAULT_NETWORK),
-    getPurchaser({ network: DEFAULT_NETWORK }),
-  ])
+  const {
+    title,
+    id: eventId,
+    hosts,
+  } = await CreateEventBody.parseAsync(request.body)
 
-  const walletService = new WalletService(networks)
-  await walletService.connect(provider, wallet)
-  const lockAddress = await walletService.createLock(lockParams)
-
-  // TODO: add managers
-  // TODO: set transfers?
-  // TODO: set metadata for event
-
-  return response
-    .status(201)
-    .json({ address: lockAddress, network: DEFAULT_NETWORK })
+  const { address, network } = await deployLockForEventCaster({
+    title,
+    hosts,
+    eventId,
+  })
+  return response.status(201).json({ address, network })
 }
 
 // This is the API endpoint used by EventCaster to mint RSVP tokens
@@ -66,16 +60,11 @@ export const rsvpForEvent: RequestHandler = async (request, response) => {
     return response.status(422).json({ message: 'Could not retrieve event' })
   }
 
-  if (!event.contract) {
+  if (!(event.contract?.address && event.contract?.network)) {
     return response
       .status(422)
       .json({ message: 'This event does not have a contract attached.' })
   }
-
-  const [provider, wallet] = await Promise.all([
-    getProviderForNetwork(event.contract.network),
-    getPurchaser({ network: event.contract.network }),
-  ])
 
   // Get the recipient
   if (!user.verified_addresses.eth_addresses[0]) {
@@ -83,6 +72,11 @@ export const rsvpForEvent: RequestHandler = async (request, response) => {
       .status(422)
       .json({ message: 'User does not have a verified address.' })
   }
+
+  const [provider, wallet] = await Promise.all([
+    getProviderForNetwork(event.contract.network),
+    getPurchaser({ network: event.contract.network }),
+  ])
 
   const walletService = new WalletService(networks)
   await walletService.connect(provider, wallet)

--- a/locksmith/src/operations/eventCasterOperations.ts
+++ b/locksmith/src/operations/eventCasterOperations.ts
@@ -1,0 +1,134 @@
+import { PublicLock } from '@unlock-protocol/contracts'
+import { ethers } from 'ethers'
+import { isProduction } from '../config/config'
+import { getProviderForNetwork, getPurchaser } from '../fulfillment/dispatcher'
+import networks from '@unlock-protocol/networks'
+import { WalletService } from '@unlock-protocol/unlock-js'
+
+const DEFAULT_NETWORK = isProduction ? 8453 : 84532 // Base or Base Sepolia
+
+const LOCK_DEPLOYER_ADDRESS = isProduction
+  ? '0x9685F90FBd7F3b2120838762A673E0424d2d60fd'
+  : '0xFd6Cf113fcDa14820531a7eF1Af992E64929EE19'
+
+const LOCK_DEPLOYER_ABI = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'unlock', type: 'address' },
+      { internalType: 'uint16', name: 'version', type: 'uint16' },
+      { internalType: 'bytes', name: 'params', type: 'bytes' },
+      { internalType: 'bytes[]', name: 'transactions', type: 'bytes[]' },
+    ],
+    name: 'deployLockAndExecute',
+    outputs: [
+      { internalType: 'address', name: 'lockAddress', type: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]
+
+// TODO: use unlockjs API when it's ready
+export const deployLockForEventCaster = async ({
+  title,
+  hosts,
+  eventId,
+}: {
+  title: string
+  hosts: any[]
+  eventId: string
+}) => {
+  const [provider, wallet] = await Promise.all([
+    getProviderForNetwork(DEFAULT_NETWORK),
+    getPurchaser({ network: DEFAULT_NETWORK }),
+  ])
+
+  const walletService = new WalletService(networks)
+  await walletService.connect(provider, wallet)
+
+  const lockProxyDeployer = new ethers.Contract(
+    LOCK_DEPLOYER_ADDRESS,
+    LOCK_DEPLOYER_ABI,
+    wallet
+  )
+
+  // Deploy a new lock
+  const lockInterface = new ethers.Interface(PublicLock.abi)
+
+  const calldata = lockInterface.encodeFunctionData(
+    'initialize(address,uint256,address,uint256,uint256,string)',
+    [
+      LOCK_DEPLOYER_ADDRESS, // first manager
+      ethers.MaxUint256, // expirationDuration
+      ethers.ZeroAddress, //currencyContractAddress
+      0, // decimalKeyPrice
+      0, // maxNumberOfKeys
+      title, // lockName
+    ]
+  )
+
+  const transactions = []
+  const setLockMetadata = lockInterface.encodeFunctionData(
+    'setLockMetadata(string,string,string)',
+    [
+      title,
+      'TKT',
+      `https://events.xyz/api/v1/nft/unlock/${DEFAULT_NETWORK}/${eventId}`,
+    ]
+  )
+  transactions.push(setLockMetadata)
+
+  const disableTransfers = lockInterface.encodeFunctionData(
+    'updateTransferFee(uint256)',
+    [10000]
+  )
+  transactions.push(disableTransfers)
+
+  const addEventsXyzLockManager = lockInterface.encodeFunctionData(
+    'addLockManager(address)',
+    ['0x2Eaf2c5E20E028a0A305801748294ba0015A6bea']
+  )
+  transactions.push(addEventsXyzLockManager)
+
+  hosts.forEach((host) => {
+    if (host.verified_addresses) {
+      host.verified_addresses.eth_addresses.forEach((address: string) => {
+        const addEventsOrganizerLockManager = lockInterface.encodeFunctionData(
+          'addLockManager(address)',
+          [address]
+        )
+        transactions.push(addEventsOrganizerLockManager)
+      })
+    }
+  })
+
+  const receipt = await (
+    await lockProxyDeployer.deployLockAndExecute(
+      networks[DEFAULT_NETWORK].unlockAddress,
+      14,
+      calldata,
+      transactions
+    )
+  ).wait()
+
+  if (!receipt) {
+    throw new Error('No receipt')
+  }
+
+  const unlock = await walletService.getUnlockContract()
+  const parsedLogs = receipt.logs
+    .map((log: any) => unlock.interface.parseLog(log))
+    .map((log: any) => log || {})
+
+  const newLockEvent = parsedLogs.find(
+    (log: any) => log.fragment && log.fragment.name === 'NewLock'
+  )
+  if (!newLockEvent) {
+    throw new Error('No NewLock event')
+  }
+
+  return {
+    address: newLockEvent.args.newLockAddress,
+    network: DEFAULT_NETWORK,
+  }
+}

--- a/locksmith/src/operations/eventCasterOperations.ts
+++ b/locksmith/src/operations/eventCasterOperations.ts
@@ -73,7 +73,7 @@ export const deployLockForEventCaster = async ({
     [
       title,
       'TKT',
-      `https://events.xyz/api/v1/nft/unlock/${DEFAULT_NETWORK}/${eventId}`,
+      `https://events.xyz/api/v1/nft/unlock/${DEFAULT_NETWORK}/${eventId}/`,
     ]
   )
   transactions.push(setLockMetadata)


### PR DESCRIPTION
# Description

The API endpoint that deploys locks for eventcaster now also sets lock managers as expected, disable transfers and sets the right metadata base URI.

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
