### PR TITLE
feature(unlock-app): Prefill user email in checkout and event rsvp

### DIFF
--- a/unlock-app/src/components/content/event/Registration/WalletlessRegistration.tsx
+++ b/unlock-app/src/components/content/event/Registration/WalletlessRegistration.tsx
@@ -228,16 +228,16 @@ export const RegistrationForm = ({
   const config = useConfig()
   const { recaptchaRef, getCaptchaValue } = useCaptcha()
   const [loading, setLoading] = useState<boolean>(false)
-  const { account } = useAuthenticate()
+  const { account, email } = useAuthenticate()
 
   // If there is an email, we pre-fill the email field
-  // if (email) {
-  //   metadataInputs?.map((input) => {
-  //     if (input.name === 'email') {
-  //       input.defaultValue = email
-  //     }
-  //   })
-  // }
+  if (email) {
+    metadataInputs?.map((input) => {
+      if (input.name === 'email') {
+        input.defaultValue = email
+      }
+    })
+  }
 
   const localForm = useForm<any>({
     mode: 'onChange',

--- a/unlock-app/src/components/interface/PromptEmailLink.tsx
+++ b/unlock-app/src/components/interface/PromptEmailLink.tsx
@@ -1,24 +1,28 @@
 'use client'
 
-import { usePrivy } from '@privy-io/react-auth'
 import { Button, Modal } from '@unlock-protocol/ui'
 import { usePathname } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import Link from 'next/link'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { usePrivy } from '@privy-io/react-auth'
 
 export const PromptEmailLink = () => {
-  const { user, ready } = usePrivy()
+  const { authenticated } = usePrivy()
+  const { email, privyReady } = useAuthenticate()
   const pathname = usePathname()
   const [showModal, setShowModal] = useState(false)
 
+  const exemptPaths = useMemo(() => ['/settings', '/checkout'], [])
+
   useEffect(() => {
-    if (ready && user) {
-      const hasEmail = user.linkedAccounts.some(
-        (account) => account.type === 'email'
+    if (privyReady && authenticated) {
+      setShowModal(
+        (!email || email === undefined || email === null) &&
+          !exemptPaths.includes(pathname)
       )
-      setShowModal(!hasEmail && pathname !== '/settings')
     }
-  }, [ready, user, pathname])
+  }, [privyReady, authenticated, email, pathname, exemptPaths])
 
   return (
     <Modal isOpen={showModal} setIsOpen={() => {}} size="small">

--- a/unlock-app/src/components/interface/checkout/main/CardPayment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/CardPayment.tsx
@@ -24,6 +24,7 @@ import {
   usePaymentMethodList,
   useRemovePaymentMethods,
 } from '~/hooks/usePaymentMethods'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
 
 interface Props {
   checkoutService: CheckoutService
@@ -183,7 +184,7 @@ export function PaymentForm({
   const {
     register,
     formState: { errors, isSubmitting },
-    // setValue,
+    setValue,
     getValues,
     handleSubmit,
   } = useForm<{
@@ -194,16 +195,17 @@ export function PaymentForm({
       email: '',
     },
   })
+  const { email } = useAuthenticate()
   // state to check if the email field should be filled with the user's email address
-  const [fillUnlockEmail, setFillUnlockEmail] = useState<boolean>(false)
+  const [fillUnlockEmail, setFillUnlockEmail] = useState<boolean>(!!email)
 
-  // useEffect(() => {
-  //   // this effect ensures that the form default value updates when the authentication context changes
-  //   if (email) {
-  //     setValue('email', email)
-  //     setFillUnlockEmail(!!email)
-  //   }
-  // }, [email, setValue])
+  useEffect(() => {
+    // this effect ensures that the form default value updates when the authentication context changes
+    if (email) {
+      setValue('email', email)
+      setFillUnlockEmail(!!email)
+    }
+  }, [email, setValue])
 
   const onHandleSubmit = async ({
     name,

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -69,7 +69,7 @@ export const MetadataInputs = ({
   const [hideRecipientAddress, setHideRecipientAddress] = useState<boolean>(
     hideFirstRecipient || false
   )
-  const { account } = useAuthenticate()
+  const { account, email } = useAuthenticate()
   const config = useConfig()
   const [useEmail, setUseEmail] = useState(false)
   const web3Service = useWeb3Service()
@@ -118,6 +118,24 @@ export const MetadataInputs = ({
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account
   const hideRecipient = shouldSkip({ paywallConfig, lock }).skipRecipient
+
+  const [hideEmailInput, setHideEmailInput] = useState<boolean>(!!email)
+
+  // register email value from user's
+  useEffect(() => {
+    if (email && hideEmailInput) {
+      metadataInputs?.forEach((input) => {
+        const isEmailInput = [
+          'email',
+          'email-address',
+          'emailaddress',
+        ].includes(input.name.toLowerCase())
+        if (isEmailInput) {
+          setValue(`metadata.${id}.${input.name}`, email)
+        }
+      })
+    }
+  }, [email, hideEmailInput, id, metadataInputs, setValue])
 
   return (
     <div className="grid gap-2">
@@ -225,18 +243,37 @@ export const MetadataInputs = ({
           const { name, label, placeholder, required, value } =
             metadataInputItem ?? {}
           const { defaultValue, type } = metadataInputItem ?? {}
-          // if (name === 'email') {
-          // We pre-fill it with the user's email!
-          // defaultValue = email
-          // type = 'hidden'
-          // }
           const inputLabel = label || name
+          const isEmailInput = [
+            'email',
+            'email-address',
+            'emailaddress',
+          ].includes(name.toLowerCase())
+
+          if (isEmailInput && hideEmailInput && email) {
+            return (
+              <div key={name} className="space-y-1">
+                <div className="ml-1 text-sm">{inputLabel}</div>
+                <div className="flex items-center pl-4 pr-2 py-1.5 justify-between bg-gray-200 rounded-lg">
+                  <div className="w-32 text-sm truncate">{email}</div>
+                  <Button
+                    type="button"
+                    onClick={() => setHideEmailInput(false)}
+                    size="tiny"
+                  >
+                    Change
+                  </Button>
+                </div>
+              </div>
+            )
+          }
+
           return (
             <Input
               key={name}
               label={`${inputLabel}:`}
               autoComplete={inputLabel}
-              defaultValue={defaultValue}
+              defaultValue={isEmailInput ? email : defaultValue}
               size="small"
               disabled={disabled}
               placeholder={placeholder}
@@ -244,7 +281,7 @@ export const MetadataInputs = ({
               error={errors?.metadata?.[id]?.[name]?.message}
               {...register(`metadata.${id}.${name}`, {
                 required: required && `${inputLabel} is required`,
-                value,
+                value: isEmailInput ? email : value,
               })}
             />
           )

--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -31,6 +31,7 @@ export function useAuthenticate() {
     getAccessToken: privyGetAccessToken,
     ready: privyReady,
     authenticated: privyAuthenticated,
+    user,
   } = usePrivy()
   const queryClient = useQueryClient()
   const { siweSign } = useSIWE()
@@ -178,6 +179,7 @@ export function useAuthenticate() {
 
   return {
     account,
+    email: user?.email?.address,
     signInWithSIWE,
     signInWithPrivy,
     signOut,


### PR DESCRIPTION
# Description
This PR introduces email autofill for checkout and RSVP forms, automatically populating the email field with the user’s email address.

## ScreenGrabs
![Screenshot 2024-10-28 at 12 21 06](https://github.com/user-attachments/assets/4fd1fcf3-143f-416b-91e5-0a75e6eb5e52)
<br />
![Screenshot 2024-10-28 at 12 26 02](https://github.com/user-attachments/assets/4c10e557-b74c-4029-88bf-5ece6d9e64ba)


# Issues
Fixes #14467, #14859
Refs #14467, #14859

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread