### PR TITLE
fix(unlock-app): ensuring the frame content is formatted correctly

### DIFF
--- a/unlock-app/app/frames/checkout/components/DefaultImage.tsx
+++ b/unlock-app/app/frames/checkout/components/DefaultImage.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { Lock } from '../frames'
+import { truncateString } from '~/utils/truncateString'
+import removeMd from 'remove-markdown'
 
 interface DefaultImageProps {
   lock: Lock
@@ -7,27 +9,35 @@ interface DefaultImageProps {
 }
 
 export function DefaultImage({ lock, rightSideContent }: DefaultImageProps) {
-  const { image, defaultImage, name, description, price } = lock
+  const { image, defaultImage, price, name, description } = lock
 
   const defaultRightSideContent = (
-    <div tw="flex-1 flex flex-col ml-4 justify-center">
-      <p tw="text-6xl">{name}</p>
-      <p>{description}</p>
-      <p>{price}</p>
+    <div tw="flex flex-col">
+      <div tw="flex flex-col">
+        <p tw="m-0 p-0 text-6xl overflow-hidden mb-4 max-h-40">
+          {truncateString(name, 34)}
+        </p>
+        <p tw="m-0 p-0 text-2xl mb-4 overflow-hidden">
+          {truncateString(removeMd(description, { useImgAltText: false }), 450)}
+        </p>
+      </div>
+      <p tw="m-0 p-0 text-3xl">🏷️ {price}</p>
     </div>
   )
-
   const leftImage = (
     <img
+      alt="Membership"
       src={defaultImage ? defaultImage : image}
-      tw="flex-1 min-h-full border-4 border-white rounded-lg"
+      tw="min-h-full border-4 border-white rounded-lg"
     />
   )
 
   return (
     <div tw="flex w-full h-full bg-gray-200 p-2">
-      {leftImage}
-      {rightSideContent || defaultRightSideContent}
+      <div tw="flex w-1/2">{leftImage}</div>
+      <div tw="flex flex-col w-1/2 pl-2">
+        {rightSideContent || defaultRightSideContent}
+      </div>
     </div>
   )
 }

--- a/unlock-app/app/frames/checkout/components/TransactionSuccess.tsx
+++ b/unlock-app/app/frames/checkout/components/TransactionSuccess.tsx
@@ -3,7 +3,7 @@ import { DefaultImage } from './DefaultImage'
 
 export function TransactionSuccess({ lock }: any) {
   const rightSideContent = (
-    <div tw="flex-1 flex flex-col justify-center items-center ml-4">
+    <div tw="flex flex-col">
       <p tw="text-6xl">Success! Purchased {lock.name} membership!</p>
     </div>
   )


### PR DESCRIPTION
# Description

Fixing the format for the frames. https://github.com/unlock-protocol/unlock/issues/14885
Here are 2 current examples:

<img width="1226" alt="Screenshot 2024-10-28 at 4 30 36 PM" src="https://github.com/user-attachments/assets/abdbc090-b8ea-4b87-a15b-ef85840a31d5">

<img width="1232" alt="Screenshot 2024-10-28 at 4 30 47 PM" src="https://github.com/user-attachments/assets/d2f00cfa-5504-4809-860f-c4c8f35cd074">

# Checklist:

- [X] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the docs to reflect my changes if applicable
- [X] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [X] I have performed a self-review of my own code
- [X] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
