### PR TITLE
feature(locksmith): Add `submitterAddress` to `EventCollectionAssociation`

### DIFF
--- a/locksmith/__tests__/operations/eventCollectionOperations.test.ts
+++ b/locksmith/__tests__/operations/eventCollectionOperations.test.ts
@@ -438,6 +438,7 @@ describe('eventCollectionOperations', () => {
           eventSlug: 'test-event',
           collectionSlug: 'test-collection',
           isApproved: true,
+          submitterAddress: '0x123',
         },
       })
       expect(result).toEqual({

--- a/locksmith/migrations/20241030130105-add-submitter-to-event-associations.js
+++ b/locksmith/migrations/20241030130105-add-submitter-to-event-associations.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      'EventCollectionAssociations',
+      'submitterAddress',
+      {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }
+    )
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(
+      'EventCollectionAssociations',
+      'submitterAddress'
+    )
+  },
+}

--- a/locksmith/src/models/EventCollectionAssociation.ts
+++ b/locksmith/src/models/EventCollectionAssociation.ts
@@ -15,6 +15,7 @@ export class EventCollectionAssociation extends Model<
   declare eventSlug: string
   declare collectionSlug: string
   declare isApproved: boolean
+  declare submitterAddress: string
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
 }
@@ -46,6 +47,10 @@ EventCollectionAssociation.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    submitterAddress: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     createdAt: DataTypes.DATE,
     updatedAt: DataTypes.DATE,

--- a/locksmith/src/operations/eventCollectionOperations.ts
+++ b/locksmith/src/operations/eventCollectionOperations.ts
@@ -288,6 +288,7 @@ export const addEventToCollectionOperation = async (
       eventSlug: event.slug,
       collectionSlug: collection.slug,
       isApproved: isManager,
+      submitterAddress: userAddress,
     },
   })
 


### PR DESCRIPTION
# Description
This PR introduces a `submitterAddress` field to the `EventCollectionAssociation`, enabling accurate tracking of the user who submitted each event to a collection.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread