### PR TITLE
feature(unlock-app): Add default `opengraph` metadata

### DIFF
--- a/unlock-app/app/layout.tsx
+++ b/unlock-app/app/layout.tsx
@@ -1,18 +1,13 @@
-'use client'
 import { Inter } from 'next/font/google'
-import { usePathname } from 'next/navigation'
-
 import './globals.css'
 import '~/utils/bigint'
 import Providers from './providers'
-
 import TagManagerScript from '../src/components/TagManagerScript'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import TermsOfServiceModal from '~/components/interface/layouts/index/TermsOfServiceModal'
-import DashboardHeader from '~/components/interface/layouts/index/DashboardHeader'
-import { ConnectModal } from '~/components/interface/connect/ConnectModal'
-import { Container } from '~/components/interface/Container'
-import DashboardFooter from '~/components/interface/layouts/index/DashboardFooter'
+
+import { SHARED_METADATA } from '~/config/seo'
+import { Metadata } from 'next'
+import DashboardLayout from '~/components/interface/layouts/DashboardLayout'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -21,41 +16,18 @@ const inter = Inter({
   weight: ['400', '500', '600', '700'],
 })
 
-// paths that shouldn't be wrapped in the default layout
-const UNWRAPPED_PATHS = ['/checkout', '/demo']
+export const metadata: Metadata = SHARED_METADATA
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const pathname = usePathname()
-  const shouldUnwrap = UNWRAPPED_PATHS.some((path) =>
-    pathname?.startsWith(path)
-  )
-
   return (
     <html lang="en" className={inter.className}>
       <body>
         <Providers>
-          {shouldUnwrap ? (
-            children
-          ) : (
-            <div className="overflow-hidden bg-ui-secondary-200">
-              <TermsOfServiceModal />
-              <Container>
-                <ConnectModal />
-
-                <DashboardHeader />
-
-                <div className="flex flex-col gap-10 min-h-screen">
-                  {children}
-                </div>
-
-                <DashboardFooter />
-              </Container>
-            </div>
-          )}
+          <DashboardLayout>{children}</DashboardLayout>
         </Providers>
         <TagManagerScript />
         <SpeedInsights />

--- a/unlock-app/app/prime/page.tsx
+++ b/unlock-app/app/prime/page.tsx
@@ -4,10 +4,10 @@ import PrimeContent from '~/components/interface/prime/PrimeContent'
 import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
+  ...SHARED_METADATA,
   title: 'Unlock Prime',
   description:
     'Unlock Prime offers enhanced features, monthly ETH rewards, unlimited events, and exclusive partner discounts for members. Bring your onchain experiences to the next level with a premium membership that works across all the apps from Unlock Labs.',
-  ...SHARED_METADATA,
   openGraph: {
     ...SHARED_METADATA.openGraph,
     images: [

--- a/unlock-app/app/prime/page.tsx
+++ b/unlock-app/app/prime/page.tsx
@@ -1,11 +1,22 @@
 import React from 'react'
 import { Metadata } from 'next'
 import PrimeContent from '~/components/interface/prime/PrimeContent'
+import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
   title: 'Unlock Prime',
   description:
     'Unlock Prime offers enhanced features, monthly ETH rewards, unlimited events, and exclusive partner discounts for members. Bring your onchain experiences to the next level with a premium membership that works across all the apps from Unlock Labs.',
+  ...SHARED_METADATA,
+  openGraph: {
+    ...SHARED_METADATA.openGraph,
+    images: [
+      {
+        url: 'https://storage.googleapis.com/papyrus_images/f75b33885013fd16274fb54251ef6a2f.jpg',
+        alt: 'Unlock Prime',
+      },
+    ],
+  },
 }
 
 const PrimeLandingPage: React.FC = () => {

--- a/unlock-app/src/components/interface/layouts/DashboardLayout.tsx
+++ b/unlock-app/src/components/interface/layouts/DashboardLayout.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import TermsOfServiceModal from '~/components/interface/layouts/index/TermsOfServiceModal'
+import DashboardHeader from '~/components/interface/layouts/index/DashboardHeader'
+import { ConnectModal } from '~/components/interface/connect/ConnectModal'
+import { Container } from '~/components/interface/Container'
+import DashboardFooter from '~/components/interface/layouts/index/DashboardFooter'
+import { usePathname } from 'next/navigation'
+
+// Paths that shouldn't be wrapped in the default layout
+const UNWRAPPED_PATHS = ['/checkout', '/demo']
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+
+  // Determine if the current path should bypass the default layout
+  const shouldUnwrap = UNWRAPPED_PATHS.some((path) =>
+    pathname?.startsWith(path)
+  )
+
+  return (
+    <>
+      {shouldUnwrap ? (
+        // Render children without the default layout
+        children
+      ) : (
+        // Render children within the default layout
+        <div className="overflow-hidden bg-ui-secondary-200">
+          <TermsOfServiceModal />
+          <Container>
+            <ConnectModal />
+
+            <DashboardHeader />
+
+            <div className="flex flex-col gap-10 min-h-screen">{children}</div>
+
+            <DashboardFooter />
+          </Container>
+        </div>
+      )}
+    </>
+  )
+}

--- a/unlock-app/src/config/seo.ts
+++ b/unlock-app/src/config/seo.ts
@@ -1,6 +1,35 @@
 import type { DefaultSeoProps, NextSeoProps } from 'next-seo'
 import { config } from './app'
+import { Metadata } from 'next'
 
+// seo config for app router
+export const SHARED_METADATA: Metadata = {
+  title: {
+    default: 'Unlock App',
+    template: '%s | Unlock App',
+  },
+  description:
+    'Unlock is a protocol which enables creators to monetize their content with a few lines of code in a fully decentralized way.',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: config.unlockApp,
+    siteName: 'Unlock App',
+    images: [
+      {
+        url: `${config.unlockStaticUrl}/images/unlock.png`,
+        alt: 'Unlock Protocol',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: '@UnlockProtocol',
+    creator: '@UnlockProtocol',
+  },
+}
+
+// seo config for pages directory
 export const DEFAULT_SEO: DefaultSeoProps = {
   title: 'Unlock Protocol',
   description: 'Unlock',


### PR DESCRIPTION
# Description
This PR introduces default SEO metadata for the Unlock App to ensure OpenGraph and Twitter cards are consistently populated across all pages.

### Key updates include:
- Setting default OpenGraph values to align with branding.
- Adding a custom image specifically for the Prime page.
- Ensuring all updates integrate seamlessly with existing tags currently managed by `NextSeo` without disrupting them.


# Issues
Fixes #14905
Refs #14905

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread