### PR TITLE
feature(unlock-app): Remove `next-seo`

### DIFF
--- a/unlock-app/app/event/[slug]/page.tsx
+++ b/unlock-app/app/event/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { toFormData } from '~/components/interface/locks/metadata/utils'
 import { notFound } from 'next/navigation'
 import { Metadata } from 'next'
 import { fetchEventMetadata } from '~/utils/eventMetadata'
+import { fetchMetadata } from 'frames.js/next'
+import { config } from '~/config/app'
 
 export interface EventPageProps {
   params: {
@@ -51,6 +53,11 @@ export async function generateMetadata({
       title: event.name || 'Event',
       description: event.description || '',
       images: [event.image || '/default-event-image.png'],
+    },
+    other: {
+      ...(await fetchMetadata(
+        new URL(`/frames/event/${event.slug}`, config.unlockApp)
+      )),
     },
   }
 }

--- a/unlock-app/app/event/[slug]/page.tsx
+++ b/unlock-app/app/event/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { toFormData } from '~/components/interface/locks/metadata/utils'
 import { notFound } from 'next/navigation'
 import { Metadata } from 'next'
 import { fetchEventMetadata } from '~/utils/eventMetadata'
-import { fetchMetadata } from 'frames.js/next'
+import { fetchMetadata as fetchFramesMetadata } from 'frames.js/next'
 import { config } from '~/config/app'
 
 export interface EventPageProps {
@@ -55,7 +55,7 @@ export async function generateMetadata({
       images: [event.image || '/default-event-image.png'],
     },
     other: {
-      ...(await fetchMetadata(
+      ...(await fetchFramesMetadata(
         new URL(`/frames/event/${event.slug}`, config.unlockApp)
       )),
     },

--- a/unlock-app/app/event/[slug]/page.tsx
+++ b/unlock-app/app/event/[slug]/page.tsx
@@ -35,6 +35,16 @@ export async function generateMetadata({
     slug: eventMetadata.slug,
   }) as Event
 
+  // Get frames metadata
+  const framesMetadata = await fetchFramesMetadata(
+    new URL(`/frames/event/${event.slug}/page`, config.unlockApp)
+  )
+
+  // Filter out any undefined values from frames metadata
+  const filteredFramesMetadata = Object.fromEntries(
+    Object.entries(framesMetadata).filter(([_, value]) => value !== undefined)
+  )
+
   // Construct and return the metadata object for the event page, including Open Graph and Twitter card info
   return {
     title: event.name || 'Event',
@@ -55,9 +65,17 @@ export async function generateMetadata({
       images: [event.image || '/default-event-image.png'],
     },
     other: {
-      ...(await fetchFramesMetadata(
-        new URL(`/frames/event/${event.slug}`, config.unlockApp)
-      )),
+      ...filteredFramesMetadata,
+      'fc:frame': 'vNext',
+      'fc:frame:image': `${config.unlockApp}/og/event/${event.slug}`,
+      'fc:frame:post_url': `${config.unlockApp}/frames/event?p=${encodeURIComponent(
+        `${config.unlockApp}/frames/event/${event.slug}`
+      )}&s=${encodeURIComponent('{"view":"default"}')}`,
+      'fc:frame:button:1': 'Register',
+      'fc:frame:button:1:target': `${config.unlockApp}/event/${event.slug}`,
+      'fc:frame:button:1:action': 'link',
+      'fc:frame:button:2': 'See description',
+      'fc:frame:button:2:action': 'post',
     },
   }
 }

--- a/unlock-app/app/event/page.tsx
+++ b/unlock-app/app/event/page.tsx
@@ -5,7 +5,7 @@ import EventContent from '~/components/content/EventContent'
 export const metadata: Metadata = {
   title: 'Unlock Events',
   description:
-    'Create event tickets and landing pages for your conference, event, or meetup in under five minutes with Unlock Protocol.',
+    'Unlock Protocol empowers everyone to create events the true web3 way. Deploy a contract, sell tickets as NFTs, and perform check-in with a dedicated QR code. We got it covered.',
 }
 
 const EventLandingPage: React.FC = () => {

--- a/unlock-app/app/event/page.tsx
+++ b/unlock-app/app/event/page.tsx
@@ -4,6 +4,7 @@ import EventContent from '~/components/content/EventContent'
 import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
+  ...SHARED_METADATA,
   title: 'Unlock Events',
   description:
     'Unlock Protocol empowers everyone to create events the true web3 way. Deploy a contract, sell tickets as NFTs, and perform check-in with a dedicated QR code. We got it covered.',

--- a/unlock-app/app/event/page.tsx
+++ b/unlock-app/app/event/page.tsx
@@ -1,11 +1,21 @@
 import React from 'react'
 import { Metadata } from 'next'
 import EventContent from '~/components/content/EventContent'
+import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
   title: 'Unlock Events',
   description:
     'Unlock Protocol empowers everyone to create events the true web3 way. Deploy a contract, sell tickets as NFTs, and perform check-in with a dedicated QR code. We got it covered.',
+  openGraph: {
+    ...SHARED_METADATA.openGraph,
+    images: [
+      {
+        alt: 'Event',
+        url: 'https://events.unlock-protocol.com/',
+      },
+    ],
+  },
 }
 
 const EventLandingPage: React.FC = () => {

--- a/unlock-app/app/subscription/page.tsx
+++ b/unlock-app/app/subscription/page.tsx
@@ -1,11 +1,21 @@
 import React from 'react'
 import { Metadata } from 'next'
 import SubscriptionContent from '~/components/content/SubscriptionContent'
+import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
   title: 'Onchain Subscriptions',
   description:
     'SUBSCRIPTIONS by Unlock Labs is best way for fans to subscribe to writing, podcasts, music, digital art, and creativity onchain with automatically recurring payments.',
+  openGraph: {
+    ...SHARED_METADATA.openGraph,
+    images: [
+      {
+        alt: 'Onchain subscriptions',
+        url: 'https://subscriptions.unlock-protocol.com/',
+      },
+    ],
+  },
 }
 
 const SubscriptionPage: React.FC = () => {

--- a/unlock-app/app/subscription/page.tsx
+++ b/unlock-app/app/subscription/page.tsx
@@ -4,6 +4,7 @@ import SubscriptionContent from '~/components/content/SubscriptionContent'
 import { SHARED_METADATA } from '~/config/seo'
 
 export const metadata: Metadata = {
+  ...SHARED_METADATA,
   title: 'Onchain Subscriptions',
   description:
     'SUBSCRIPTIONS by Unlock Labs is best way for fans to subscribe to writing, podcasts, music, digital art, and creativity onchain with automatically recurring payments.',

--- a/unlock-app/package.json
+++ b/unlock-app/package.json
@@ -53,7 +53,6 @@
     "lottie-react": "2.4.0",
     "next": "14.2.14",
     "next-auth": "4.24.8",
-    "next-seo": "6.6.0",
     "node-forge": "1.3.1",
     "postmate": "1.5.2",
     "prettier": "3.3.3",

--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -3,7 +3,6 @@
 import { BiQrScan as ScanIcon } from 'react-icons/bi'
 import { useEffect } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
-import { NextSeo } from 'next-seo'
 import {
   Button,
   Card,
@@ -25,9 +24,6 @@ import { SettingEmail } from '~/components/interface/locks/Settings/elements/Set
 import { locksmith } from '~/config/locksmith'
 import { FaUsers } from 'react-icons/fa'
 import { TbSettings } from 'react-icons/tb'
-import { config } from '~/config/app'
-import removeMd from 'remove-markdown'
-import { truncateString } from '~/utils/truncateString'
 import { useEventVerifiers } from '~/hooks/useEventVerifiers'
 import { EventDefaultLayout } from './Layout/EventDefaultLayout'
 import { EventBannerlessLayout } from './Layout/EventBannerlessLayout'
@@ -193,63 +189,6 @@ export const EventDetails = ({
 
   return (
     <div>
-      <NextSeo
-        title={event.name}
-        description={`${truncateString(
-          removeMd(event.description, {
-            useImgAltText: false,
-          }),
-          650
-        )} 
-        Powered by Unlock Protocol`}
-        openGraph={{
-          title: event.title,
-          type: 'website',
-          url: eventUrl,
-          images: [
-            {
-              alt: event.title,
-              url: `${config.unlockApp}/og/event/${event.slug}`,
-            },
-          ],
-        }}
-        additionalMetaTags={[
-          {
-            property: 'fc:frame',
-            content: 'vNext',
-          },
-          {
-            name: 'fc:frame:image',
-            content: `${config.unlockApp}/og/event/${event.slug}`,
-          },
-          {
-            name: 'fc:frame:post_url',
-            content: `${config.unlockApp}/frames/event?p=${encodeURIComponent(
-              `${config.unlockApp}/frames/event/${event.slug}`
-            )}&s=${encodeURIComponent('{"view":"default"}')}`,
-          },
-          {
-            name: 'fc:frame:button:1',
-            content: 'Register',
-          },
-          {
-            name: 'fc:frame:button:1:target',
-            content: eventUrl,
-          },
-          {
-            name: 'fc:frame:button:1:action',
-            content: 'link',
-          },
-          {
-            name: 'fc:frame:button:2',
-            content: 'See description',
-          },
-          {
-            name: 'fc:frame:button:2:action',
-            content: 'post',
-          },
-        ]}
-      />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col-reverse px-4 md:px-0 md:flex-row-reverse gap-2 ">
           {isOrganizer && (

--- a/unlock-app/src/components/content/event/EventLandingPage.tsx
+++ b/unlock-app/src/components/content/event/EventLandingPage.tsx
@@ -3,7 +3,6 @@
 import { Button } from '@unlock-protocol/ui'
 import Link from 'next/link'
 import { LockTypeLandingPage } from '~/components/interface/LockTypeLandingPage'
-import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 
 const customers = [
@@ -149,18 +148,6 @@ interface LandingPageProps {
 export const EventLandingPage = ({ handleCreateEvent }: LandingPageProps) => {
   return (
     <>
-      <NextSeo
-        title="Unlock Events"
-        description="Unlock Protocol empowers everyone to create events the true web3 way. Deploy a contract, sell tickets as NFTs, and perform check-in with a dedicated QR code. We got it covered."
-        openGraph={{
-          images: [
-            {
-              alt: 'Event',
-              url: 'https://events.unlock-protocol.com/',
-            },
-          ],
-        }}
-      />
       <LockTypeLandingPage
         title={
           <h1

--- a/unlock-app/src/components/content/subscription/SubscriptionLandingPage.tsx
+++ b/unlock-app/src/components/content/subscription/SubscriptionLandingPage.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@unlock-protocol/ui'
 import { LockTypeLandingPage } from '~/components/interface/LockTypeLandingPage'
-import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 
 const customers = [
@@ -119,18 +118,6 @@ export const SubscriptionLandingPage = ({
 }: LandingPageProps) => {
   return (
     <>
-      <NextSeo
-        title="Onchain Subscriptions"
-        description="SUBSCRIPTIONS by Unlock Labs is best way for fans to subscribe to writing, podcasts, music, digital art, and creativity onchain with automatically recurring payments."
-        openGraph={{
-          images: [
-            {
-              alt: 'Onchain subscriptions',
-              url: 'https://subscriptions.unlock-protocol.com/',
-            },
-          ],
-        }}
-      />
       <LockTypeLandingPage
         title={
           <h1

--- a/unlock-app/src/config/seo.ts
+++ b/unlock-app/src/config/seo.ts
@@ -1,4 +1,3 @@
-import type { DefaultSeoProps, NextSeoProps } from 'next-seo'
 import { config } from './app'
 import { Metadata } from 'next'
 
@@ -27,62 +26,4 @@ export const SHARED_METADATA: Metadata = {
     site: '@UnlockProtocol',
     creator: '@UnlockProtocol',
   },
-}
-
-// seo config for pages directory
-export const DEFAULT_SEO: DefaultSeoProps = {
-  title: 'Unlock Protocol',
-  description: 'Unlock',
-  openGraph: {
-    type: 'website',
-    locale: 'en_US',
-    url: config.unlockApp,
-    site_name: 'Unlock Protocol',
-    images: [],
-  },
-  twitter: {
-    handle: 'UnlockProtocol',
-    site: 'UnlockProtocol',
-    cardType: 'summary_large_image',
-  },
-}
-
-interface SEOProps {
-  title: string
-  description?: string
-  imagePath?: string
-  twitter?: {
-    handle?: string
-    site?: string
-    cardType?: string
-  }
-  path?: string
-}
-
-export function customizeSEO(options: SEOProps): NextSeoProps {
-  const images = options.imagePath
-    ? [
-        // Twitter only fetch og:image if it is an absolute path with domain.
-        {
-          url: new URL(options.imagePath, config.unlockApp).toString(),
-          alt: options.title,
-        },
-      ]
-    : DEFAULT_SEO.openGraph?.images
-  const path = options.path ?? '/'
-  const url = new URL(path, config.unlockApp).toString()
-  return {
-    ...DEFAULT_SEO,
-    ...options,
-    twitter: {
-      ...DEFAULT_SEO,
-      handle: options.twitter?.handle || DEFAULT_SEO.twitter?.handle,
-      site: options.twitter?.site || DEFAULT_SEO.twitter?.site,
-    },
-    openGraph: {
-      ...DEFAULT_SEO.openGraph,
-      images,
-      url,
-    },
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21575,7 +21575,6 @@ __metadata:
     lottie-react: "npm:2.4.0"
     next: "npm:14.2.14"
     next-auth: "npm:4.24.8"
-    next-seo: "npm:6.6.0"
     node-forge: "npm:1.3.1"
     postcss: "npm:8.4.47"
     postmate: "npm:1.5.2"


### PR DESCRIPTION
# Description
This PR introduces the removal of `next-seo` as a dependency, migrating relevant dashboard components to leverage Next.js’s native `generateMetadata`.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread