### PR TITLE
feat(locksmith): returning an existing key rather than trying to mint another one

### DIFF
--- a/locksmith/src/controllers/v2/eventCasterController.ts
+++ b/locksmith/src/controllers/v2/eventCasterController.ts
@@ -1,5 +1,5 @@
 import networks from '@unlock-protocol/networks'
-import { WalletService } from '@unlock-protocol/unlock-js'
+import { WalletService, Web3Service } from '@unlock-protocol/unlock-js'
 import { RequestHandler } from 'express'
 import { z } from 'zod'
 import {
@@ -77,12 +77,30 @@ export const rsvpForEvent: RequestHandler = async (request, response) => {
     getPurchaser({ network: event.contract.network }),
   ])
 
+  const ownerAddress = user.verified_addresses.eth_addresses[0]
+  // Check first if the user has a key
+  const web3Service = new Web3Service(networks)
+  const existingKey = await web3Service.getKeyByLockForOwner(
+    event.contract.address,
+    ownerAddress,
+    event.contract.network
+  )
+
+  if (existingKey.tokenId > 0) {
+    return response.status(200).json({
+      network: event.contract.network,
+      address: event.contract.address,
+      id: existingKey.tokenId,
+      owner: ownerAddress,
+    })
+  }
+
   const walletService = new WalletService(networks)
   await walletService.connect(provider, wallet)
 
   const token = await walletService.grantKey({
     lockAddress: event.contract.address,
-    recipient: user.verified_addresses.eth_addresses[0],
+    recipient: ownerAddress,
   })
 
   return response.status(201).json({


### PR DESCRIPTION
# Description

When RSVP'ing thru eventcaster, making sure we return an existing key rather than mint a new one!

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
