### PR TITLE
feature(unlock-app): Prompt user to sign out before account migration

### DIFF
--- a/packages/ui/lib/components/Modal/Modal.tsx
+++ b/packages/ui/lib/components/Modal/Modal.tsx
@@ -15,6 +15,7 @@ export interface Props {
   size?: 'small' | 'medium' | 'large'
   spacing?: 'small' | 'medium' | 'large' | 'none'
   closeIconStyle?: string
+  hideCloseIcon?: boolean
 }
 
 const sizeClasses = {
@@ -38,6 +39,7 @@ export function Modal({
   size = 'medium',
   spacing = 'small',
   closeIconStyle = 'fill-inherit',
+  hideCloseIcon = false,
 }: Props) {
   const sizeClass = sizeClasses[size]
   const spacingClass = spacingClasses[spacing]
@@ -54,17 +56,19 @@ export function Modal({
       <div
         className={`relative w-full ${sizeClass} mx-auto overflow-hidden transition-all transform bg-white border-none rounded-xl shadow-xl`}
       >
-        <div className="absolute top-4 right-4">
-          <button
-            aria-label="close"
-            onClick={(event) => {
-              event.preventDefault()
-              setIsOpen(false)
-            }}
-          >
-            <CloseIcon className={closeIconStyle} size={24} />
-          </button>
-        </div>
+        {!hideCloseIcon && (
+          <div className="absolute top-4 right-4">
+            <button
+              aria-label="close"
+              onClick={(event) => {
+                event.preventDefault()
+                setIsOpen(false)
+              }}
+            >
+              <CloseIcon className={closeIconStyle} size={24} />
+            </button>
+          </div>
+        )}
         <div className={spacingClass}>{children}</div>
       </div>
     )

--- a/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
@@ -11,8 +11,11 @@ import { UserAccountType } from '~/utils/userAccountType'
 import { SignInWithPassword } from './SignInWithPassword'
 import { SignInWithCode } from './SignInWithCode'
 import { SignInWithGoogle } from './SignInWithGoogle'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { PromptSignOut } from './PromptSignOut'
 
 export const MigrateUserContent = () => {
+  const { account } = useAuthenticate()
   const [userEmail, setUserEmail] = useState<string>('')
   const [walletPk, setWalletPk] = useState<string | null>(null)
   const [userAccountType, setUserAccountType] = useState<UserAccountType[]>([])
@@ -54,105 +57,111 @@ export const MigrateUserContent = () => {
   })
 
   return (
-    <div className="px-28 mt-10">
-      <div className="space-y-2 mb-20">
-        <h2 className="text-2xl font-bold">Migrate your account</h2>
-        <p>
-          We are migrating Unlock Accounts to use our new Authentication
-          provider, Privy. Please enter your email below to migrate your
-          account.
-        </p>
+    <>
+      <div className="px-28 mt-10">
+        <div className="space-y-2 mb-20">
+          <h2 className="text-2xl font-bold">Migrate your account</h2>
+          <p>
+            We are migrating Unlock Accounts to use our new Authentication
+            provider, Privy. Please enter your email below to migrate your
+            account.
+          </p>
+        </div>
+        <Tabs
+          tabs={[
+            {
+              title: 'Enter your email',
+              description: 'First, verify your email address',
+              disabled: false,
+              button: {
+                // Disable button during mutation
+                disabled:
+                  checkPrivyUserMutation.isPending ||
+                  checkUserAccountType.isPending,
+              },
+              children: ({ onNext }) => {
+                // Goal of this cimponent is to get user email address + type of account
+                // It should also check if there is a privy account already.
+                // If not, it "yields" the email account + type to the next step
+                return (
+                  <ConnectViaEmail
+                    onNext={({ email, accountType }) => {
+                      setUserEmail(email)
+                      setUserAccountType(accountType)
+                      onNext()
+                    }}
+                  />
+                )
+              },
+              showButton: false,
+            },
+            {
+              title: 'Sign in to your account',
+              description: 'Sign in to your existing Unlock account',
+              disabled: !userEmail || checkPrivyUserMutation.isPending,
+              children: ({ onNext }) => {
+                // This component is in charge of getting a private key for
+                // any account used
+                if (userAccountType?.includes(UserAccountType.UnlockAccount)) {
+                  return (
+                    <SignInWithPassword
+                      userEmail={userEmail}
+                      onNext={(walletPk) => {
+                        setWalletPk(walletPk)
+                        onNext()
+                      }}
+                    />
+                  )
+                }
+                if (
+                  userAccountType?.includes(UserAccountType.EmailCodeAccount)
+                ) {
+                  return (
+                    <SignInWithCode
+                      email={userEmail}
+                      onNext={(walletPk) => {
+                        setWalletPk(walletPk)
+                        onNext()
+                      }}
+                    />
+                  )
+                }
+                if (userAccountType?.includes(UserAccountType.GoogleAccount)) {
+                  return (
+                    <SignInWithGoogle
+                      onNext={(walletPk) => {
+                        setWalletPk(walletPk)
+                        onNext()
+                      }}
+                    />
+                  )
+                }
+                return null
+              },
+            },
+            {
+              title: 'Create a Privy Account',
+              disabled: !walletPk,
+              description: 'Create a Privy Account',
+              children: ({ onNext }) => (
+                <ConnectToPrivy userEmail={userEmail} onNext={() => onNext()} />
+              ),
+              showButton: false,
+            },
+            {
+              title: 'Migration',
+              disabled: !walletPk,
+              description:
+                'This is the last step! We will migrate your Unlock account to Privy!',
+              children: <MigrationFeedback walletPk={walletPk!} />,
+              showButton: false,
+            },
+          ]}
+        />
       </div>
-      <Tabs
-        tabs={[
-          {
-            title: 'Enter your email',
-            description: 'First, verify your email address',
-            disabled: false,
-            button: {
-              // Disable button during mutation
-              disabled:
-                checkPrivyUserMutation.isPending ||
-                checkUserAccountType.isPending,
-            },
-            children: ({ onNext }) => {
-              // Goal of this cimponent is to get user email address + type of account
-              // It should also check if there is a privy account already.
-              // If not, it "yields" the email account + type to the next step
-              return (
-                <ConnectViaEmail
-                  onNext={({ email, accountType }) => {
-                    setUserEmail(email)
-                    setUserAccountType(accountType)
-                    onNext()
-                  }}
-                />
-              )
-            },
-            showButton: false,
-          },
-          {
-            title: 'Sign in to your account',
-            description: 'Sign in to your existing Unlock account',
-            disabled: !userEmail || checkPrivyUserMutation.isPending,
-            children: ({ onNext }) => {
-              // This component is in charge of getting a private key for
-              // any account used
-              if (userAccountType?.includes(UserAccountType.UnlockAccount)) {
-                return (
-                  <SignInWithPassword
-                    userEmail={userEmail}
-                    onNext={(walletPk) => {
-                      setWalletPk(walletPk)
-                      onNext()
-                    }}
-                  />
-                )
-              }
-              if (userAccountType?.includes(UserAccountType.EmailCodeAccount)) {
-                return (
-                  <SignInWithCode
-                    email={userEmail}
-                    onNext={(walletPk) => {
-                      setWalletPk(walletPk)
-                      onNext()
-                    }}
-                  />
-                )
-              }
-              if (userAccountType?.includes(UserAccountType.GoogleAccount)) {
-                return (
-                  <SignInWithGoogle
-                    onNext={(walletPk) => {
-                      setWalletPk(walletPk)
-                      onNext()
-                    }}
-                  />
-                )
-              }
-              return null
-            },
-          },
-          {
-            title: 'Create a Privy Account',
-            disabled: !walletPk,
-            description: 'Create a Privy Account',
-            children: ({ onNext }) => (
-              <ConnectToPrivy userEmail={userEmail} onNext={() => onNext()} />
-            ),
-            showButton: false,
-          },
-          {
-            title: 'Migration',
-            disabled: !walletPk,
-            description:
-              'This is the last step! We will migrate your Unlock account to Privy!',
-            children: <MigrationFeedback walletPk={walletPk!} />,
-            showButton: false,
-          },
-        ]}
-      />
-    </div>
+
+      {account && <PromptSignOut />}
+    </>
   )
 }
 

--- a/unlock-app/src/components/legacy-auth/PromptSignOut.tsx
+++ b/unlock-app/src/components/legacy-auth/PromptSignOut.tsx
@@ -1,0 +1,23 @@
+import { Button, Modal } from '@unlock-protocol/ui'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
+
+export const PromptSignOut = () => {
+  const { signOut } = useAuthenticate()
+
+  return (
+    <Modal isOpen={true} setIsOpen={() => null} hideCloseIcon>
+      <div className="w-full bg-white rounded-2xl">
+        <h2 className="text-xl font-bold mb-4">Sign Out Required</h2>
+        <p className="mb-6">
+          You need to sign out of your current account before proceeding with
+          the migration process.
+        </p>
+        <div className="flex justify-end">
+          <Button onClick={signOut} className="w-full">
+            Sign Out
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}


### PR DESCRIPTION
# Description
This PR introduces a prompt requesting users to sign out before initiating the account migration process. The prompt appears only for users who are currently signed in on the dashboard, ensuring a smooth transition and reducing potential session-related issues during migration.


## ScreenGrab
<img width="1035" alt="Screenshot 2024-11-08 at 12 53 10" src="https://github.com/user-attachments/assets/80c96633-2b62-4e5c-ad1b-fc8d36212bf1">



# Issues
Fixes #
Refs #14858

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread