### PR TITLE
fix(unlock-app): Fix UI conflict with sign-out prompt during account migration

### DIFF
--- a/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
@@ -19,6 +19,8 @@ export const MigrateUserContent = () => {
   const [userEmail, setUserEmail] = useState<string>('')
   const [walletPk, setWalletPk] = useState<string | null>(null)
   const [userAccountType, setUserAccountType] = useState<UserAccountType[]>([])
+  //  track migration status
+  const [isMigrating, setIsMigrating] = useState(false)
 
   // Mutation to handle the user account type
   const checkUserAccountType = useMutation({
@@ -153,14 +155,19 @@ export const MigrateUserContent = () => {
               disabled: !walletPk,
               description:
                 'This is the last step! We will migrate your Unlock account to Privy!',
-              children: <MigrationFeedback walletPk={walletPk!} />,
+              children: (
+                <MigrationFeedback
+                  walletPk={walletPk!}
+                  onMigrationStart={() => setIsMigrating(true)}
+                />
+              ),
               showButton: false,
             },
           ]}
         />
       </div>
 
-      {account && <PromptSignOut />}
+      {account && !isMigrating && <PromptSignOut />}
     </>
   )
 }

--- a/unlock-app/src/components/legacy-auth/MigrationFeedback.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrationFeedback.tsx
@@ -7,7 +7,13 @@ import Link from 'next/link'
 import { onSignedInWithPrivy } from '~/config/PrivyProvider'
 import { ToastHelper } from '../helpers/toast.helper'
 
-export default function MigrationFeedback({ walletPk }: { walletPk: string }) {
+export default function MigrationFeedback({
+  walletPk,
+  onMigrationStart,
+}: {
+  walletPk: string
+  onMigrationStart: () => void
+}) {
   // @ts-ignore
   const { importWallet } = usePrivy()
   const [isImporting, setIsImporting] = useState(false)
@@ -15,6 +21,7 @@ export default function MigrationFeedback({ walletPk }: { walletPk: string }) {
 
   const handleImport = async () => {
     setIsImporting(true)
+    onMigrationStart()
     try {
       // First attempt the wallet import
       const importResult = await importWallet({ privateKey: walletPk })


### PR DESCRIPTION
# Description
This PR introduces a state flag to resolve a UI conflict where the sign-out prompt modal was incorrectly displayed during account migration. With this flag, the modal is suppressed once migration begins, preventing disruption in the migration flow.

# Issues
Fixes #
Refs #14858

# Checklist:
- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread