### PR TITLE
Typo and Grammar Corrections in Unlock Protocol Documentation

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -76,6 +76,7 @@
     "Myestery",
     "Supeeerpower",
     "blurpesec"
+    "cypherpepe"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "
 }

--- a/docs/docs/core-protocol/public-lock/README.md
+++ b/docs/docs/core-protocol/public-lock/README.md
@@ -6,7 +6,7 @@ description: >-
 
 # Public Lock
 
-A "Lock" (`PublicLock.sol`) is a customized smart contract for minting (creating) ERC-721 NFT's. They are the Unlock Protocol version of a "minting contract". They are created with the [Unlock](../../core-protocol/unlock/) smart contract, which is a "factory" contract. That factory contract uses the [Public Lock](../../core-protocol/public-lock/) template contact along with
+A "Lock" (`PublicLock.sol`) is a customized smart contract for minting (creating) ERC-721 NFT's. They are the Unlock Protocol version of a "minting contract". They are created with the [Unlock](../../core-protocol/unlock/) smart contract, which is a "factory" contract. That factory contract uses the [Public Lock](../../core-protocol/public-lock/) template contract along with
 with the configuration options you choose to record a new customized
 smart contract to the blockchain [network](../../core-protocol/unlock/networks) of your choice.
 
@@ -84,7 +84,7 @@ Easily check if a key is ready for renewal
 
 **Released**: October 2022
 
-The following are the signifigant changes and a full list of commits including bug fixes can be found [here](https://github.com/unlock-protocol/unlock/issues?q=+label%3A%22publicLock+v12%22+).
+The following are the significant changes and a full list of commits including bug fixes can be found [here](https://github.com/unlock-protocol/unlock/issues?q=+label%3A%22publicLock+v12%22+).
 
 #### `onGrantKeyHook` and `onKeyExtendHook`
 

--- a/docs/docs/core-protocol/public-lock/deploying-locks.md
+++ b/docs/docs/core-protocol/public-lock/deploying-locks.md
@@ -41,14 +41,14 @@ await unlock.createUpgradeableLockAtVersion(calldata, version)
 
 This is the method the Unlock labs team uses in the Unlock [Dashboard](../../tools/dashboard/) so that we have time after a new version is released to update the UI to support it. Locks deployed using this method can later be upgraded to newer versions. Your application should verify the version of a lock to avoid unexpected behaviors.
 
-You can also create Locks from another contract that would call the Unlock factory contract. This can be useful if your applicatiion requires a specific lock setup (special referrer fees, metadata... etc), but also if you want to deploy locks on behalf of users and provide a gasless experience for lock managers.
+You can also create Locks from another contract that would call the Unlock factory contract. This can be useful if your application requires a specific lock setup (special referrer fees, metadata... etc), but also if you want to deploy locks on behalf of users and provide a gasless experience for lock managers.
 
 ### `createLock`
 
 This method provides the simplest interface as it takes arguments for the duration of each NFT membership (key), the currency contract address, the price, the maximum number of keys, the name... etc. It creates locks that are using the current version of the protocol.
 
 :::note
-If a new version of the protocol is released using "createLock" might break your implementation of a deployment script as the signature for that function migth change, and the locks deployed after the upgrade might be of a newer version.
+If a new version of the protocol is released using "createLock" might break your implementation of a deployment script as the signature for that function might change, and the locks deployed after the upgrade might be of a newer version.
 :::
 
 ## Upgrading Locks

--- a/docs/docs/core-protocol/public-lock/hooks.md
+++ b/docs/docs/core-protocol/public-lock/hooks.md
@@ -145,7 +145,7 @@ interface ILockValidKeyHook
 
 ## onKeyTransferHook Hook
 
-Called when a key is transfered, it can be useful to use with `onKeyPurchaseHook` to track key ownership on a 3rd party contract.
+Called when a key is transferred, it can be useful to use with `onKeyPurchaseHook` to track key ownership on a 3rd party contract.
 
 The `ILockKeyTransferHook` interface is quite straightforward:
 

--- a/docs/docs/core-protocol/smart-contracts-api/README.md
+++ b/docs/docs/core-protocol/smart-contracts-api/README.md
@@ -18,7 +18,7 @@ interface references.
 ## Using Smart Contract Interfaces
 
 A Solidity contract interface is a list of function definitions without
-implementation. This allows for a seperation between the interface and the
+implementation. This allows for a separation between the interface and the
 implementation much like Abstract Base Classes in Python or C++.
 
 You can use these interfaces in your own smart contracts to interact with


### PR DESCRIPTION
This PR addresses multiple typographical and grammatical errors in the Unlock Protocol documentation. The following files were updated to improve readability and accuracy:

- `README.md`
- `deploying-locks.md`
- `hooks.md`
- Other related `.md` files

Key corrections include:
- Fixing spelling errors (e.g., "seperation" → "separation").
- Refining grammar to enhance clarity.


# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have updated the documentation to reflect my changes, if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective, or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code includes visual changes, I am adding applicable screenshots to this thread