### PR TITLE
Fix grammatical and typo corrections for multiple files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Unlock has multiple projects ongoing whose release cycles are decoupled because 
 
 We use the traditional web-dev approach to release early and often. This allows for quick iterations and fast progress. Once reviewed and approved, any change is merged into our master branch and immediately \(minutes\) deployed to our staging environment. Each commit in the `master` branch should be expected to be deployed in production and should hence be "production-grade".
 
-We also maintain a production branch which is used to deployed to ... production! This branch is also protected and the only way to add commits to it is to go thru a regular pull request process. This pull request has to be approved and manually merged by one of our team members. Once approved and merge the various production web applications are immediately updated.
+We also maintain a production branch which is used to deploy to ... production! This branch is also protected and the only way to add commits to it is to go thru a regular pull request process. This pull request has to be approved and manually merged by one of our team members. Once approved and merge the various production web applications are immediately updated.
 
 If needed, we can also deploy specific versions to production. For this is recommended approach is to open a new pull request against the production branch containing **only** the commits to be deployed since the latest production deploy. One way to do this is to rebase a local production-fix branch against the remote production branch and cherry pick the commits to be deployed from master. After this is a pull request is made and has to be approved by some of our team members. Once approved the updated production branch is immediately deployed.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd docker
 docker compose exec eth-node yarn provision
 ```
 
-### Run one of the app
+### Run one of the apps
 
 The main dashboard lives in the `unlock-app` folder of this repo.
 


### PR DESCRIPTION
### Description

Added typo corrections to documentation for the following files:

**README.md**

"Run one of the app" corrected to "Run one of the apps".

The word "apps" should be plural here, as it implies running one out of multiple applications.

**CODE_OF_CONDUCT.md**

"pledge to making participation" corrected to "pledge to make participation".

The correct form after "pledge to" is the infinitive "make," not "making."

**CONTRIBUTING.md**

"to deployed to ... production!" corrected to "to deploy to ... production!"

The verb form should be "deploy" rather than "deployed" in this context.

### Goal

Correct grammatical errors and improve readability of the documentation.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread
