### PR TITLE
feature(unlock-app): Disable automatic wallet creation

### DIFF
--- a/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrateUserContent.tsx
@@ -11,11 +11,11 @@ import { UserAccountType } from '~/utils/userAccountType'
 import { SignInWithPassword } from './SignInWithPassword'
 import { SignInWithCode } from './SignInWithCode'
 import { SignInWithGoogle } from './SignInWithGoogle'
-import { useAuthenticate } from '~/hooks/useAuthenticate'
 import { PromptSignOut } from './PromptSignOut'
+import { usePrivy } from '@privy-io/react-auth'
 
 export const MigrateUserContent = () => {
-  const { account } = useAuthenticate()
+  const { user } = usePrivy()
   const [userEmail, setUserEmail] = useState<string>('')
   const [walletPk, setWalletPk] = useState<string | null>(null)
   const [userAccountType, setUserAccountType] = useState<UserAccountType[]>([])
@@ -173,7 +173,9 @@ export const MigrateUserContent = () => {
         />
       </div>
 
-      {account && !isMigrating && <PromptSignOut />}
+      {user?.email?.address && user?.wallet && !isMigrating && (
+        <PromptSignOut />
+      )}
     </>
   )
 }

--- a/unlock-app/src/components/legacy-auth/MigrationFeedback.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrationFeedback.tsx
@@ -35,8 +35,10 @@ export default function MigrationFeedback({
 
       // Only proceed with dashboard authentication if wallet import was successful
       try {
-        await onSignedInWithPrivy(user)
-        setIsImported(true)
+        if (user) {
+          await onSignedInWithPrivy(user)
+          setIsImported(true)
+        }
       } catch (authError) {
         console.error('Failed to fully authenticate with dashboard:', authError)
         ToastHelper.error(

--- a/unlock-app/src/components/legacy-auth/MigrationNotificationModal.tsx
+++ b/unlock-app/src/components/legacy-auth/MigrationNotificationModal.tsx
@@ -1,0 +1,28 @@
+import { Button, Modal } from '@unlock-protocol/ui'
+import Link from 'next/link'
+
+export const MigrationModal = ({
+  isOpen,
+  setIsOpen,
+}: {
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+}) => {
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} size="small">
+      <div className="flex flex-col gap-4 text-center">
+        <h2 className="text-xl font-bold">Legacy Account Detected</h2>
+        <p>
+          We&apos;ve detected that you have an existing Unlock account that
+          needs to be migrated. Please complete the migration process to
+          continue.
+        </p>
+        <div className="flex justify-center">
+          <Link href="/migrate-user">
+            <Button>Start Migration</Button>
+          </Link>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -131,7 +131,7 @@ export function useAuthenticate() {
   const signInWithPrivy = async ({ onshowUI }: { onshowUI: () => void }) => {
     if (!(await signInWithExistingSession())) {
       setAccount(undefined)
-      if (privyAuthenticated) {
+      if (privyAuthenticated && user) {
         await onSignedInWithPrivy(user)
       } else {
         privyLogin()


### PR DESCRIPTION
# Description
This PR introduces a check for existing legacy (1.0 or 2.0) Unlock accounts. If no legacy account is found, a new wallet is created and linked to the user's Privy account. If a legacy account exists, no wallet is created; instead, the UI displays a message prompting the user to migrate their account, with a link to the migration page.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread