### PR TITLE
fix(smart-contracts): wrong token id after a key was burnt

### DIFF
--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -84,6 +84,9 @@ contract MixinKeys is MixinErrors, MixinLockCore {
   // Mapping owner address to token count
   mapping(address => uint256) private _balances;
 
+  // keep track of how many keys have been burnt to prevent token id conflicts
+  uint internal _burntTokens;
+
   /**
    * Ensure that the caller is the keyManager of the key
    * or that the caller has been approved
@@ -182,7 +185,7 @@ contract MixinKeys is MixinErrors, MixinLockCore {
     unchecked {
       _totalSupply++;
     }
-    tokenId = _totalSupply;
+    tokenId = _totalSupply + _burntTokens;
 
     // create the key
     _keys[tokenId] = Key(tokenId, expirationTimestamp);

--- a/smart-contracts/contracts/mixins/MixinKeys.sol
+++ b/smart-contracts/contracts/mixins/MixinKeys.sol
@@ -619,6 +619,7 @@ contract MixinKeys is MixinErrors, MixinLockCore {
     return _maxKeysPerAddress;
   }
 
+  // decrease 996 to 995 when adding _burntTokens mappings in v15
   // decrease 1000 to 996 when adding new tokens/owners mappings in v10
-  uint256[996] private __safe_upgrade_gap;
+  uint256[995] private __safe_upgrade_gap;
 }

--- a/smart-contracts/contracts/mixins/MixinTransfer.sol
+++ b/smart-contracts/contracts/mixins/MixinTransfer.sol
@@ -179,6 +179,9 @@ contract MixinTransfer is
 
     // decrease totalSupply
     _totalSupply--;
+
+    // increase burnt token counter
+    _burntTokens++;
   }
 
   /**

--- a/smart-contracts/test/Lock/burn.js
+++ b/smart-contracts/test/Lock/burn.js
@@ -67,6 +67,18 @@ describe('Lock / burn', () => {
     compareBigNumbers(await lock.totalSupply(), totalSupply - 1n)
   })
 
+  it('tokenId is not used twice', async () => {
+    const totalSupply = await lock.totalSupply()
+    // assert.equal(tokenId + 1n, totalSupply)
+    await lock.connect(keyOwner).burn(tokenId)
+    compareBigNumbers(await lock.totalSupply(), totalSupply - 1n)
+    const { tokenId: tokenIdAfterBurn } = await purchaseKey(
+      lock,
+      await keyOwner.getAddress()
+    )
+    assert.notEqual(tokenId, tokenIdAfterBurn)
+  })
+
   it('should work only on existing keys', async () => {
     await reverts(lock.burn(123), 'NO_SUCH_KEY')
   })

--- a/smart-contracts/test/Lock/burn.js
+++ b/smart-contracts/test/Lock/burn.js
@@ -69,7 +69,6 @@ describe('Lock / burn', () => {
 
   it('tokenId is not used twice', async () => {
     const totalSupply = await lock.totalSupply()
-    // assert.equal(tokenId + 1n, totalSupply)
     await lock.connect(keyOwner).burn(tokenId)
     compareBigNumbers(await lock.totalSupply(), totalSupply - 1n)
     const { tokenId: tokenIdAfterBurn } = await purchaseKey(

--- a/smart-contracts/test/Lock/burn.js
+++ b/smart-contracts/test/Lock/burn.js
@@ -68,14 +68,20 @@ describe('Lock / burn', () => {
   })
 
   it('tokenId is not used twice', async () => {
+    const { tokenId: tokenIdBeforeBurn } = await purchaseKey(
+      lock,
+      await keyOwner.getAddress()
+    )
     const totalSupply = await lock.totalSupply()
-    await lock.connect(keyOwner).burn(tokenId)
+    await lock.connect(keyOwner).burn(tokenIdBeforeBurn)
     compareBigNumbers(await lock.totalSupply(), totalSupply - 1n)
     const { tokenId: tokenIdAfterBurn } = await purchaseKey(
       lock,
       await keyOwner.getAddress()
     )
     assert.notEqual(tokenId, tokenIdAfterBurn)
+    assert.notEqual(tokenIdAfterBurn, tokenId + 1n)
+    compareBigNumbers(await lock.totalSupply(), totalSupply)
   })
 
   it('should work only on existing keys', async () => {


### PR DESCRIPTION
# Description

This PR fixes a bug in token id assignation after burning a key. As the token id is based on the existing supply of keys and the `burn` function decrease that supply, the token id calculations should take into account the number of keys that have been burnt.

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
