### PR TITLE
Typo Update using-subgraphs.md

### DIFF
--- a/docs/docs/tutorials/misc/using-subgraphs.md
+++ b/docs/docs/tutorials/misc/using-subgraphs.md
@@ -46,7 +46,7 @@ We retrieve the locks sorted by the creation block in a descending order (first 
 
 ## Sending the request
 
-There are exists multiple GraphQL libraries in many languages. Here we will focus on the most basic approach: using JavaScript's fetch function that is available in any web browser environment, but also in node.js using [`node-fetch`](https://www.npmjs.com/package/node-fetch).
+There are multiple GraphQL libraries in many languages. Here we will focus on the most basic approach: using JavaScript's fetch function that is available in any web browser environment, but also in node.js using [`node-fetch`](https://www.npmjs.com/package/node-fetch).
 
 ```javascript
 // We build the query, with a variable $owner


### PR DESCRIPTION
This pull request fixes a grammatical error in the "Using Subgraphs" tutorial. The original sentence:

**"There are exists multiple GraphQL libraries..."**

was incorrect. The correct form is:

**"There are multiple GraphQL libraries..."**

The error occurred because in English, it's incorrect to use both **"are"** and **"exists"** together. The correct structure would be **"There are"** to indicate the existence of something in plural form, and **"exists"** should only be used in singular contexts (e.g., **"There exists a library"**).

This fix is important for maintaining clarity and correctness in the documentation, ensuring that readers understand the content without confusion.

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread
