### PR TITLE
feature(unlock-app): Customizable email template for recurring subscription expiration reminders

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/elements/EmailPreview.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/EmailPreview.tsx
@@ -96,6 +96,7 @@ export const EmailPreview = ({
               __html: email?.html || '',
             }}
             style={{ width: '200px' }}
+            className="text-left"
           />
           <div className="flex flex-col gap-2">
             <Input

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingEmail.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingEmail.tsx
@@ -106,8 +106,6 @@ export const SettingEmail = ({
   const emailTemplates =
     TemplateByLockType[template as keyof LockType] || DEFAULT_EMAIL_TEMPLATES
 
-  console.log('emailTemplates', emailTemplates)
-
   return (
     <div className="grid grid-cols-1 gap-6">
       <SettingCard

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingEmail.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingEmail.tsx
@@ -30,6 +30,12 @@ const TemplateByLockType: Record<keyof LockType, TemplateProps[]> = {
       templateId: 'eventKeyMined',
     },
     {
+      label: 'Subscription reminder template',
+      description:
+        'Customize the content of the email sent when a membership is about to expire.',
+      templateId: 'keyExpiring',
+    },
+    {
       label: 'Airdrop confirmation template',
       description:
         'Customize the content of the email sent when an event ticket has been airdropped. ',
@@ -59,6 +65,12 @@ const DEFAULT_EMAIL_TEMPLATES: TemplateProps[] = [
     description:
       'Customize the content of the email sent when a new membership has been purchased. Emails are only sent if you selected the Collect Email option on the checkout.',
     templateId: 'keyMined',
+  },
+  {
+    label: 'Subscription reminder template',
+    description:
+      'Customize the content of the email sent when a membership is about to expire.',
+    templateId: 'keyExpiring',
   },
   {
     label: 'Airdrop confirmation template',
@@ -93,6 +105,8 @@ export const SettingEmail = ({
   // template based on lockType
   const emailTemplates =
     TemplateByLockType[template as keyof LockType] || DEFAULT_EMAIL_TEMPLATES
+
+  console.log('emailTemplates', emailTemplates)
 
   return (
     <div className="grid grid-cols-1 gap-6">


### PR DESCRIPTION
# Description
This PR introduces functionality for subscription and lock managers to customize the content of emails sent to users when their subscription or membership is about to expire.

### Screenshots
1. **Dashboard Settings** – Shows the new customization options with sample content.
![Screenshot 2024-11-19 at 14 28 29](https://github.com/user-attachments/assets/1a6ed416-93b1-402f-aec8-42f761f80d39)


2. **Email Preview** – Displays a preview of the email with the custom content.
![Screenshot 2024-11-19 at 14 28 38](https://github.com/user-attachments/assets/2b6686d9-6930-44c7-8116-201e304e2499)


3. **Sent Email Confirmation** – Verifies the email was successfully sent to the user with the customized message.
![Screenshot 2024-11-19 at 14 29 28](https://github.com/user-attachments/assets/c5844e8d-97fd-4a45-8f89-a4a7a6ff6bec)



# Issues
Fixes #15027
Refs #15027

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread
