### PR TITLE
feature(unlock-app): Enable wallet funding in checkout

### DIFF
--- a/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
+++ b/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
@@ -1,0 +1,24 @@
+interface InsufficientFundsWarningProps {
+  enableCreditCard: boolean
+  onFundWallet: () => void
+}
+
+const InsufficientFundsWarning = ({
+  enableCreditCard,
+  onFundWallet,
+}: InsufficientFundsWarningProps) => {
+  return (
+    <div
+      onClick={!enableCreditCard ? onFundWallet : undefined}
+      className="mt-4 text-sm py-5 px-4 bg-red-200 rounded-lg border border-gray-200 cursor-pointer"
+    >
+      You don&apos;t have enough funds in your wallet to pay for this
+      membership.{' '}
+      {enableCreditCard
+        ? 'You can proceed to pay with a credit card.'
+        : 'Please add funds to your wallet to continue.'}
+    </div>
+  )
+}
+
+export default InsufficientFundsWarning

--- a/unlock-app/src/components/interface/user-account/Funding.tsx
+++ b/unlock-app/src/components/interface/user-account/Funding.tsx
@@ -39,6 +39,9 @@ export const Funding = () => {
     })
   }
 
+  const ethPriceNumber =
+    typeof ethPrice === 'string' ? parseFloat(ethPrice) : ethPrice
+
   return (
     <SettingCard
       label="Fund Wallet"
@@ -60,11 +63,11 @@ export const Funding = () => {
               >
                 {userBalance?.toFixed(4)} ETH
               </Badge>
-              {userBalance && ethPrice && ethPrice > 0 && (
+              {userBalance && ethPriceNumber && ethPriceNumber > 0 && (
                 <div className="text-gray-600">
                   (≈{' '}
                   <span className="font-semibold">
-                    ${new Intl.NumberFormat().format(ethPrice)}
+                    ${new Intl.NumberFormat().format(ethPriceNumber)}
                   </span>
                   )
                 </div>

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -181,6 +181,12 @@ export const Privy = ({ children }: { children: ReactNode }) => {
         appearance: {
           landingHeader: '',
         },
+        fundingMethodConfig: {
+          moonpay: {
+            uiConfig: { accentColor: '#603DEB', theme: 'light' },
+            useSandbox: config.env !== 'prod',
+          },
+        },
         // @ts-expect-error internal api
         _render: {
           standalone: true,

--- a/unlock-app/src/hooks/useEthPrice.ts
+++ b/unlock-app/src/hooks/useEthPrice.ts
@@ -1,20 +1,53 @@
 import { useQuery } from '@tanstack/react-query'
 import { locksmith } from '~/config/locksmith'
 
+/**
+ * Custom hook to fetch the current price of Ethereum (ETH) based on the specified amount and network.
+ * 1. If converting USD to ETH (currency='USD'):
+ *    - First gets the price of 1 ETH in USD
+ *    - Adds $0.01 to the input USD amount for gas fees
+ *    - Calculates the ETH equivalent of the adjusted USD amount
+ *
+ * 2. If converting ETH to USD (currency='ETH'):
+ *    - Directly fetches the USD price for the specified ETH amount
+ *
+ * @param {Object} params - Parameters for the hook.
+ * @param {string | undefined} params.amount - The amount to convert
+ * @param {number} params.network - The network identifier for fetching the price
+ * @param {'ETH' | 'USD'} [params.currency='ETH'] - The source currency to convert from
+ *
+ * @returns {Object} Query result containing the converted amount or null if:
+ *  - amount is not provided
+ *  - an error occurs
+ *  - price data is unavailable
+ */
+
 export const useEthPrice = ({
   amount,
   network,
+  currency = 'ETH',
 }: {
   amount: string | undefined
   network: number
+  currency?: 'ETH' | 'USD'
 }) => {
   return useQuery({
-    queryKey: ['getEthPrice', amount, network],
+    queryKey: ['getEthPrice', amount, network, currency],
     queryFn: async () => {
       if (!amount) return null
       try {
-        const response = await locksmith.price(network, parseFloat(amount))
-        return response.data.result?.priceInAmount
+        if (currency === 'ETH') {
+          const response = await locksmith.price(network, parseFloat(amount))
+          return response.data.result?.priceInAmount
+        } else {
+          const response = await locksmith.price(network, 1)
+          const oneEthInUsd = response.data.result?.priceInAmount
+          if (!oneEthInUsd) return null
+
+          // Add 10 cents ($0.10) for gas fees when converting USD to ETH
+          const amountWithPenny = parseFloat(amount) + 0.1
+          return (amountWithPenny / oneEthInUsd).toFixed(6).toString()
+        }
       } catch (error) {
         return null
       }

--- a/unlock-app/src/hooks/useEthPrice.ts
+++ b/unlock-app/src/hooks/useEthPrice.ts
@@ -44,8 +44,8 @@ export const useEthPrice = ({
           const oneEthInUsd = response.data.result?.priceInAmount
           if (!oneEthInUsd) return null
 
-          // Add 10 cents ($0.10) for gas fees when converting USD to ETH
-          const amountWithPenny = parseFloat(amount) + 0.1
+          // Add 50 cents ($0.50) for gas fees when converting USD to ETH
+          const amountWithPenny = parseFloat(amount) + 0.5
           return (amountWithPenny / oneEthInUsd).toFixed(6).toString()
         }
       } catch (error) {


### PR DESCRIPTION
# Description
This PR introduces the ability for users to fund their wallet directly during checkout if their balance is insufficient to complete the purchase.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread