### PR TITLE
fix(unlock-app): Prevent redundant user account type checks  

### DIFF
--- a/unlock-app/src/components/legacy-auth/ConnectViaEmail.tsx
+++ b/unlock-app/src/components/legacy-auth/ConnectViaEmail.tsx
@@ -19,7 +19,7 @@ export const ConnectViaEmail = ({ onNext, email }: ConnectViaEmailProps) => {
   })
 
   useEffect(() => {
-    if (email) {
+    if (email && !methods.getValues('email')) {
       methods.setValue('email', email)
       onSubmit({ email })
     }


### PR DESCRIPTION
# Description
This PR introduces a safeguard to avoid re-triggering checks for the user account type when a preexisting value is already set.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread