### PR TITLE
fix(unlock-app): Fix email pre-fill logic for multiple recipients in checkout

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -119,11 +119,13 @@ export const MetadataInputs = ({
   const recipient = recipientFromConfig(paywallConfig, lock) || account
   const hideRecipient = shouldSkip({ paywallConfig, lock }).skipRecipient
 
-  const [hideEmailInput, setHideEmailInput] = useState<boolean>(!!email)
+  const [hideEmailInput, setHideEmailInput] = useState<boolean>(
+    !!email && id === 0
+  )
 
-  // register email value from user's
+  // register email value from user's account - to only apply to first recipient
   useEffect(() => {
-    if (email && hideEmailInput) {
+    if (email && hideEmailInput && id === 0) {
       metadataInputs?.forEach((input) => {
         const isEmailInput = [
           'email',
@@ -250,7 +252,7 @@ export const MetadataInputs = ({
             'emailaddress',
           ].includes(name.toLowerCase())
 
-          if (isEmailInput && hideEmailInput && email) {
+          if (isEmailInput && hideEmailInput && email && id === 0) {
             return (
               <div key={name} className="space-y-1">
                 <div className="ml-1 text-sm">{inputLabel}</div>
@@ -273,7 +275,7 @@ export const MetadataInputs = ({
               key={name}
               label={`${inputLabel}:`}
               autoComplete={inputLabel}
-              defaultValue={isEmailInput ? email : defaultValue}
+              defaultValue={isEmailInput && id === 0 ? email : defaultValue} // only prefill email for first recipient
               size="small"
               disabled={disabled}
               placeholder={placeholder}
@@ -281,7 +283,7 @@ export const MetadataInputs = ({
               error={errors?.metadata?.[id]?.[name]?.message}
               {...register(`metadata.${id}.${name}`, {
                 required: required && `${inputLabel} is required`,
-                value: isEmailInput ? email : value,
+                value: isEmailInput && id === 0 ? email : value, // only prefill email for first recipient
               })}
             />
           )


### PR DESCRIPTION
# Description
This PR introduces a fix to the checkout, resolving an issue where email addresses were incorrectly pre-filled across all recipient input fields. Now, only the first email input is pre-filled with the user's email address, while subsequent inputs remain empty for manual entry.


## ScreenGrabs

Before
![Screenshot 2024-11-27 at 14 41 54](https://github.com/user-attachments/assets/435349cf-ce26-497a-af33-37f37ff39a16)


<br />

After
![Screenshot 2024-11-27 at 14 47 21](https://github.com/user-attachments/assets/fd7c2328-4bbe-4a3f-bbef-2e7c2c19cc9d)



# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread