### PR TITLE
fix(unlock-app): Omit funding notification for free locks in checkout  

### DIFF
--- a/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
+++ b/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
@@ -48,7 +48,7 @@ const InsufficientFundsWarning = ({
     return null
   }
 
-  if (!enableClaim) {
+  if (enableClaim) {
     return null
   }
 

--- a/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
+++ b/unlock-app/src/components/interface/checkout/InsufficientFundsWarning.tsx
@@ -7,6 +7,7 @@ import { useBaseRoute } from '~/hooks/useCrosschainBaseRoute'
 
 interface InsufficientFundsWarningProps {
   enableCreditCard: boolean
+  enableClaim: boolean
   isCrossChainRoutesLoading?: boolean
   hasCrossChainRoutes?: boolean
   checkoutService: CheckoutService
@@ -14,6 +15,7 @@ interface InsufficientFundsWarningProps {
 
 const InsufficientFundsWarning = ({
   enableCreditCard,
+  enableClaim,
   isCrossChainRoutesLoading,
   hasCrossChainRoutes,
   checkoutService,
@@ -43,6 +45,10 @@ const InsufficientFundsWarning = ({
   }
 
   if (enableCreditCard) {
+    return null
+  }
+
+  if (!enableClaim) {
     return null
   }
 

--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -436,6 +436,7 @@ export function Payment({ checkoutService }: Props) {
 
         <InsufficientFundsWarning
           enableCreditCard={!!enableCreditCard}
+          enableClaim={!!enableClaim}
           isCrossChainRoutesLoading={isCrossChaingRoutesLoading}
           hasCrossChainRoutes={Boolean(
             crosschainRoutes && crosschainRoutes.length > 0


### PR DESCRIPTION
# Description
This PR introduces a change to omit the funding notification for free locks during the checkout process.

## ScreenGrab

![Screenshot 2024-11-27 at 16 31 48](https://github.com/user-attachments/assets/73b166b8-355d-47e3-98af-56191ace7a28)



# Issues
Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
