### PR TITLE
fix(governance,unlockjs): update evm version to shanghai

### DIFF
--- a/governance/hardhat.config.js
+++ b/governance/hardhat.config.js
@@ -74,7 +74,7 @@ const config = {
     compilers: [
       // required to compile oracle as Uniswap v3-periphery supports only solc < 0.8
       { version: '0.7.6', settings: { ...settings, evmVersion: 'istanbul' } },
-      { version: '0.8.21', settings },
+      { version: '0.8.21', settings: { ...settings, evmVersion: 'shanghai' } },
     ],
   },
   sourcify: {

--- a/packages/unlock-js/hardhat.config.js
+++ b/packages/unlock-js/hardhat.config.js
@@ -5,12 +5,13 @@ require('@nomicfoundation/hardhat-ethers')
 
 module.exports = {
   solidity: {
-    version: '0.8.13',
+    version: '0.8.21',
     settings: {
       optimizer: {
         enabled: true,
         runs: 10,
       },
+      evmVersion: 'shanghai',
     },
   },
 }


### PR DESCRIPTION
# Description

This updates the evm version to a more recent once (shanghai) instead of old one (paris) that was preventing the contract deployment from succeding (because of contract size limit)

<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
