### PR TITLE
feature(subgraphs): Add `creationTransactionHash` to lock entity in subgraph

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -45,6 +45,8 @@ type Lock @entity {
   The primary reason for this role is to support additional purchase mechanisms beyond direct key purchases like credit-card purchases.
   """
   keyGranters: [Bytes!]!
+  "transaction hash of the lock's creation"
+  transactionHash: String!
 }
 
 type Key @entity {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -46,7 +46,7 @@ type Lock @entity {
   """
   keyGranters: [Bytes!]!
   "transaction hash of the lock's creation"
-  transactionHash: String!
+  creationTransactionHash: String!
 }
 
 type Key @entity {

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -105,7 +105,7 @@ export function handleNewLock(event: NewLock): void {
   lock.createdAtBlock = event.block.number
   lock.lastKeyMintedAt = null
   lock.lastKeyRenewedAt = null
-  lock.transactionHash = event.transaction.hash.toHexString()
+  lock.creationTransactionHash = event.transaction.hash.toHexString()
 
   if (version.le(BigInt.fromI32(8))) {
     // prior to v8, add default lock manager

--- a/subgraph/src/unlock.ts
+++ b/subgraph/src/unlock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable prefer-const */
-import { log, BigInt, ethereum } from '@graphprotocol/graph-ts'
+import { log, BigInt } from '@graphprotocol/graph-ts'
 import { NewLock, LockUpgraded, GNPChanged } from '../generated/Unlock/Unlock'
 import { PublicLock as PublicLockMerged } from '../generated/templates/PublicLock/PublicLock'
 import { PublicLock } from '../generated/templates'
@@ -105,6 +105,7 @@ export function handleNewLock(event: NewLock): void {
   lock.createdAtBlock = event.block.number
   lock.lastKeyMintedAt = null
   lock.lastKeyRenewedAt = null
+  lock.transactionHash = event.transaction.hash.toHexString()
 
   if (version.le(BigInt.fromI32(8))) {
     // prior to v8, add default lock manager

--- a/subgraph/tests/locks-utils.ts
+++ b/subgraph/tests/locks-utils.ts
@@ -35,6 +35,11 @@ export function createNewLockEvent(
 ): NewLock {
   const newLockEvent = changetype<NewLock>(newMockEvent())
 
+  // Set a deterministic transaction hash for testing
+  newLockEvent.transaction.hash = Bytes.fromHexString(
+    '0x0000000000000000000000000000000000000000000000000000000000000001'
+  )
+
   newLockEvent.parameters = []
 
   newLockEvent.parameters.push(

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -85,6 +85,12 @@ describe('Describe Locks events', () => {
     assert.entityCount('Lock', 1)
     assert.fieldEquals('Lock', lockAddress, 'address', lockAddress)
     assert.fieldEquals('Lock', lockAddress, 'createdAtBlock', '1')
+    assert.fieldEquals(
+      'Lock',
+      lockAddress,
+      'transactionHash',
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    )
     assert.fieldEquals('Lock', lockAddress, 'version', '11')
     assert.fieldEquals('Lock', lockAddress, 'price', '1000')
     assert.fieldEquals('Lock', lockAddress, 'name', 'My lock graph')

--- a/subgraph/tests/locks.test.ts
+++ b/subgraph/tests/locks.test.ts
@@ -88,7 +88,7 @@ describe('Describe Locks events', () => {
     assert.fieldEquals(
       'Lock',
       lockAddress,
-      'transactionHash',
+      'creationTransactionHash',
       '0x0000000000000000000000000000000000000000000000000000000000000001'
     )
     assert.fieldEquals('Lock', lockAddress, 'version', '11')

--- a/subgraph/tests/receipts.test.ts
+++ b/subgraph/tests/receipts.test.ts
@@ -65,6 +65,9 @@ describe('Receipts for base currency locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     // transfer event
@@ -99,6 +102,9 @@ describe('Receipts for base currency locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     // create a key
@@ -149,6 +155,9 @@ describe('Receipts for base currency locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     // transfer event
@@ -182,6 +191,9 @@ describe('Receipts for base currency locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     // renew event
@@ -226,6 +238,9 @@ describe('Receipts for base currency locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     const key = new Key(`${lockAddress}-${tokenId}`)
@@ -290,6 +305,9 @@ describe('Receipts for an ERC20 locks', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     // transfer event
@@ -331,6 +349,9 @@ describe('Receipts for Cancel and refund', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     const key = new Key(`${lockAddress}-${tokenId}`)
@@ -407,6 +428,9 @@ describe('Receipts for Cancel and refund', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     const key = new Key(`${lockAddress}-${tokenId}`)
@@ -445,6 +469,9 @@ describe('Receipts for Cancel and refund', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     const key = new Key(`${lockAddress}-${tokenId}`)
@@ -521,6 +548,9 @@ describe('Receipts for Cancel and refund', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
 
     const key = new Key(`${lockAddress}-${tokenId}`)

--- a/subgraph/tests/referrer.test.ts
+++ b/subgraph/tests/referrer.test.ts
@@ -26,6 +26,9 @@ describe('Referrer', () => {
     lock.deployer = Bytes.fromHexString(lockManagers[0])
     lock.numberOfReceipts = BigInt.fromU32(0)
     lock.numberOfCancelReceipts = BigInt.fromU32(0)
+    lock.creationTransactionHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    lock.createdAtBlock = BigInt.fromI32(1)
     lock.save()
   })
 


### PR DESCRIPTION
# Description
This PR introduces an update to our subgraph by adding the `creationTransactionHash` field to the `lock` entity.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread