### PR TITLE
fix(locksmith): unique composite index

### DIFF
--- a/locksmith/migrations/20250122205156-add-processedhookitem-unique-index.js
+++ b/locksmith/migrations/20250122205156-add-processedhookitem-unique-index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const table = 'ProcessedHookItems'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex(table, {
+      fields: ['network', 'type', 'objectId'],
+      unique: true,
+      name: 'processed_hook_items_unique_network_type_object',
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex(
+      table,
+      'processed_hook_items_unique_network_type_object'
+    )
+  },
+}


### PR DESCRIPTION
# Description
This PR introduces a migration that creates a unique composite index for the `ProcessedHookItems` table.

# Issues
Fixes #
Refs #

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread