### PR TITLE
fix(unlock-app): not showing locks on list of events

### DIFF
--- a/unlock-app/src/components/interface/locks/List/elements/EventCard.tsx
+++ b/unlock-app/src/components/interface/locks/List/elements/EventCard.tsx
@@ -7,7 +7,6 @@ import { Card, Detail, Icon } from '@unlock-protocol/ui'
 import dayjs from 'dayjs'
 import { useEventAttendees } from '~/hooks/useEventAttendees'
 import { useEventRSVP } from '~/hooks/useRsvp'
-import { WrappedAddress } from '~/components/interface/WrappedAddress'
 
 interface EventCardProps {
   event: {
@@ -36,8 +35,6 @@ const EventImage = ({ imageUrl }: EventImageProps) => {
 
 export const EventCard = ({ event }: EventCardProps) => {
   const { name, checkoutConfig, slug, ticket, image: imageUrl } = event
-  const lockAddress = Object.keys(checkoutConfig.config.locks)[0]
-  const network = checkoutConfig.config.locks[lockAddress].network
   const eventDate = dayjs(ticket.event_start_date).format('D MMM YYYY')
   const eventEndDate = dayjs(ticket.event_end_date).format('D MMM YYYY')
 
@@ -62,12 +59,6 @@ export const EventCard = ({ event }: EventCardProps) => {
                 {name}
               </span>
             </div>
-            <WrappedAddress
-              className="text-brand-dark text-sm md:text-base overflow-hidden overflow-ellipsis line-clamp-3"
-              address={lockAddress}
-              network={network}
-              addressType="lock"
-            />
           </div>
         </div>
 


### PR DESCRIPTION
# Description

Showing the locks is not really useful/necessary and breaks until the locks have actually been deployed


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
