### PR TITLE
feature(docs): Restrict colour mode

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -31,6 +31,11 @@ const config: Config = {
     ],
   ],
   themeConfig: {
+    colorMode: {
+      defaultMode: 'light',
+      disableSwitch: true,
+      respectPrefersColorScheme: false,
+    },
     start_urls: ['https://docs.unlock-protocol.com'],
     sitemap_urls: ['https://docs.unlock-protocol.com/sitemap.xml'],
     algolia: {


### PR DESCRIPTION
# Description
This PR introduces a change to the docs, restricting it to light mode and preventing users from toggling color preferences.


## ScreenGrab
![Screenshot 2025-02-10 at 14 38 37](https://github.com/user-attachments/assets/22a48fc8-5e8d-4903-83e7-a91817a53e63)


# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread