### PR TITLE
fix(unlock-app): Fix favorites lock persistence in dashboard

### DIFF
--- a/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
+++ b/unlock-app/src/components/interface/locks/List/elements/LockList.tsx
@@ -123,17 +123,13 @@ export const LockList = ({ owner }: LockListProps) => {
   const result = results[0]
 
   const [favoriteLocks, setFavoriteLocks] = useState<FavoriteLocks>(() => {
-    try {
-      return JSON.parse(getStorage('favoriteLocks') || '{}')
-    } catch {
-      return {}
-    }
+    return getStorage('favoriteLocks') || {}
   })
 
   const saveFavoriteLocks = useCallback(
     (newFavoriteLocks: FavoriteLocks) => {
       setFavoriteLocks(newFavoriteLocks)
-      setStorage('favoriteLocks', JSON.stringify(newFavoriteLocks))
+      setStorage('favoriteLocks', newFavoriteLocks)
     },
     [setStorage]
   )


### PR DESCRIPTION
# Description
This PR introduces a fix for an issue where favorite locks in the dashboard were lost after a page reload.

# Issues
Fixes #15515
Refs #15515

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread