### PR TITLE
fix(unlock-app): Fix back navigation loop on settings page

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -313,11 +313,9 @@ export const TopActionBar = ({ lockAddress, network }: TopActionBarProps) => {
     <>
       <div className="flex items-center justify-between">
         <Button variant="borderless" aria-label="arrow back">
-          <ArrowBackIcon
-            size={20}
-            className="cursor-pointer"
-            onClick={() => router.back()}
-          />
+          <Link href="/locks">
+            <ArrowBackIcon size={20} className="cursor-pointer" />
+          </Link>
         </Button>
         <div className="flex gap-3">
           {isManager && (


### PR DESCRIPTION
# Description
This PR fixes an issue where clicking the back arrow on the settings page would incorrectly toggle between two views in an infinite loop. Now, the back navigation behaves as expected.

# Issues
Fixes #15527
Refs #15527

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread