### PR TITLE
feature(locksmith): Enhance merkle tree for recipient-amount pairs

### DIFF
--- a/locksmith/__tests__/controllers/v2/merkleTreeController.test.ts
+++ b/locksmith/__tests__/controllers/v2/merkleTreeController.test.ts
@@ -1,0 +1,127 @@
+import request from 'supertest'
+import app from '../../app'
+import { vi, expect, describe, it, beforeEach } from 'vitest'
+import { uploadJsonToS3 } from '../../../src/utils/s3'
+
+// Mock S3 upload function
+vi.mock('../../../src/utils/s3', () => ({
+  uploadJsonToS3: vi.fn(() => Promise.resolve()),
+}))
+
+describe('Merkle Tree Controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createMerkleTree endpoint', () => {
+    it('should create a merkle tree from an array of addresses with default amount of 1', async () => {
+      const addresses = [
+        '0x1234567890123456789012345678901234567890',
+        '0x2234567890123456789012345678901234567890',
+      ]
+
+      const response = await request(app)
+        .post('/v2/merkle-tree')
+        .send(addresses)
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('root')
+      expect(typeof response.body.root).toBe('string')
+
+      // Verify S3 upload was called with correct parameters
+      expect(uploadJsonToS3).toHaveBeenCalledTimes(1)
+      expect(uploadJsonToS3).toHaveBeenCalledWith(
+        expect.any(String), // bucket name
+        `${response.body.root}.json`,
+        expect.any(Object) // tree data
+      )
+    })
+
+    it('should create a merkle tree from an array of [address, amount] tuples', async () => {
+      const entries = [
+        ['0x1234567890123456789012345678901234567890', '100'],
+        ['0x2234567890123456789012345678901234567890', '200'],
+      ]
+
+      const response = await request(app).post('/v2/merkle-tree').send(entries)
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('root')
+      expect(typeof response.body.root).toBe('string')
+    })
+
+    it('should handle numeric amounts by converting them to strings', async () => {
+      const entries = [
+        ['0x1234567890123456789012345678901234567890', 100],
+        ['0x2234567890123456789012345678901234567890', 200],
+      ]
+
+      const response = await request(app).post('/v2/merkle-tree').send(entries)
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('root')
+    })
+
+    it('should reject mixed entry types', async () => {
+      const entries = [
+        '0x1234567890123456789012345678901234567890',
+        ['0x2234567890123456789012345678901234567890', '200'],
+      ]
+
+      const response = await request(app).post('/v2/merkle-tree').send(entries)
+
+      expect(response.status).toBe(400)
+      expect(response.headers['content-type']).toMatch(/json/)
+      expect(response.body).toEqual({
+        error: {
+          issues: [
+            {
+              code: 'custom',
+              message:
+                'All entries must be of the same type: either simple recipient strings or [recipient, amount] tuples. Empty arrays are not allowed.',
+              path: [],
+            },
+          ],
+        },
+      })
+    })
+
+    it('should reject empty arrays', async () => {
+      const response = await request(app).post('/v2/merkle-tree').send([])
+
+      expect(response.status).toBe(400)
+      expect(response.headers['content-type']).toMatch(/json/)
+      expect(response.body).toEqual({
+        error: {
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.stringContaining('Empty arrays are not allowed'),
+            }),
+          ]),
+        },
+      })
+    })
+
+    it('should reject invalid addresses', async () => {
+      const entries = [
+        ['invalid-address', '100'],
+        ['0x2234567890123456789012345678901234567890', '200'],
+      ]
+
+      const response = await request(app).post('/v2/merkle-tree').send(entries)
+
+      expect(response.status).toBe(400)
+    })
+
+    it('should reject invalid amounts', async () => {
+      const entries = [
+        ['0x1234567890123456789012345678901234567890', 'invalid-amount'],
+        ['0x2234567890123456789012345678901234567890', '200'],
+      ]
+
+      const response = await request(app).post('/v2/merkle-tree').send(entries)
+
+      expect(response.status).toBe(400)
+    })
+  })
+})

--- a/locksmith/src/controllers/v2/merkleTreeController.ts
+++ b/locksmith/src/controllers/v2/merkleTreeController.ts
@@ -4,18 +4,65 @@ import { StandardMerkleTree } from '@openzeppelin/merkle-tree'
 import { uploadJsonToS3 } from '../../utils/s3'
 import config from '../../config/config'
 
-const CreateMerkleTreeBody = z.array(z.string())
+/**
+ * A tree entry can either be:
+ * - a string (recipient) which will assign a fixed amount of "1", or
+ * - a tuple of [recipient, amount] where amount can be a number or a string, ideal for airdrops with varying amounts.
+ */
+const RawMerkleTreeEntry = z.union([
+  z.string(),
+  z.tuple([z.string(), z.union([z.string(), z.number()])]),
+])
 
+/**
+ * CreateMerkleTreeEntries first validates that the array does not contain mixed types.
+ * Then it transforms the array into a normalized array of [recipient, amount] with amount as a string.
+ */
+const CreateMerkleTreeEntries = z
+  .array(RawMerkleTreeEntry)
+  .refine(
+    (entries) => {
+      if (entries.length === 0) return true
+      // If first element is a string, all entries must be strings
+      const isSimpleList = typeof entries[0] === 'string'
+      return entries.every((entry) =>
+        isSimpleList ? typeof entry === 'string' : Array.isArray(entry)
+      )
+    },
+    {
+      message:
+        'All entries must be of the same type: either simple recipient strings or [recipient, amount] tuples.',
+    }
+  )
+  .transform((entries) => {
+    if (entries.length === 0 || typeof entries[0] === 'string') {
+      return (entries as string[]).map(
+        (recipient) => [recipient, '1'] as [string, string]
+      )
+    } else {
+      return (entries as [string, number | string][]).map(
+        ([recipient, amount]) => [recipient, amount.toString()]
+      )
+    }
+  })
+
+/**
+ * createMerkleTree function that handles both types of payloads.
+ *
+ * If the payload is an array of strings, it assigns a fixed amount "1" to each address.
+ * If the payload is an array of [recipient, amount] tuples, it uses the provided amount (normalized to a string).
+ * The second format is particularly useful for airdrops where different recipients receive different amounts.
+ */
 export const createMerkleTree = async (
   request: Request,
   response: Response
 ) => {
-  const addresses = await CreateMerkleTreeBody.parseAsync(request.body)
-
-  const tree = StandardMerkleTree.of(
-    addresses.map((recipient) => [recipient, '1']),
-    ['address', 'uint256']
+  const normalizedEntries = await CreateMerkleTreeEntries.parseAsync(
+    request.body
   )
+
+  const tree = StandardMerkleTree.of(normalizedEntries, ['address', 'uint256'])
+
   // dump the tree
   const fullTree = tree.dump()
 
@@ -27,5 +74,4 @@ export const createMerkleTree = async (
   )
 
   response.status(200).send({ root: tree.root })
-  return
 }

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -5353,22 +5353,34 @@ paths:
           application/json:
             schema:
               type: array
-              items:
-                oneOf:
-                  - type: string
-                    description: Recipient address (will be assigned amount "1")
-                  - type: array
-                    minItems: 2
-                    maxItems: 2
-                    items:
-                      - type: string
-                        description: Recipient address
-                      - oneOf:
-                          - type: string
-                            description: Amount as string
-                          - type: number
-                            description: Amount as number
               description: Array must contain either all strings or all tuples, no mixing allowed
+              items:
+                type: object
+                oneOf:
+                  - type: object
+                    properties:
+                      value:
+                        type: string
+                        description: Recipient address (will be assigned amount "1")
+                  - type: object
+                    properties:
+                      value:
+                        type: array
+                        minItems: 2
+                        maxItems: 2
+                        items:
+                          oneOf:
+                            - type: object
+                              properties:
+                                recipient:
+                                  type: string
+                                  description: Recipient address
+                                amount:
+                                  oneOf:
+                                    - type: string
+                                      description: Amount as string
+                                    - type: number
+                                      description: Amount as number
       responses:
         200:
           description: Successfully saved the Merkle Tree

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -5353,34 +5353,29 @@ paths:
           application/json:
             schema:
               type: array
-              description: Array must contain either all strings or all tuples, no mixing allowed
+              minItems: 1
+              description: Array must contain either all strings (addresses) or all [address, amount] tuples, no mixing allowed
               items:
                 type: object
                 oneOf:
-                  - type: object
-                    properties:
-                      value:
-                        type: string
-                        description: Recipient address (will be assigned amount "1")
-                  - type: object
-                    properties:
-                      value:
-                        type: array
-                        minItems: 2
-                        maxItems: 2
-                        items:
-                          oneOf:
-                            - type: object
-                              properties:
-                                recipient:
-                                  type: string
-                                  description: Recipient address
-                                amount:
-                                  oneOf:
-                                    - type: string
-                                      description: Amount as string
-                                    - type: number
-                                      description: Amount as number
+                  - type: string
+                    description: Recipient address (will be assigned amount "1")
+                  - type: array
+                    description: Address and amount tuple
+                    minItems: 2
+                    maxItems: 2
+                    items:
+                      oneOf:
+                        - type: string
+                          description: Recipient address
+                        - type: object
+                          properties:
+                            amount:
+                              oneOf:
+                                - type: string
+                                  description: Amount as string
+                                - type: number
+                                  description: Amount as number
       responses:
         200:
           description: Successfully saved the Merkle Tree
@@ -5388,18 +5383,14 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - root
                 properties:
-                  success:
-                    type: boolean
-                    default: true
                   root:
                     type: string
                     description: The merkle tree root hash
-                  url:
-                    type: string
-                    description: URL where the merkle tree is stored
         400:
-          description: Missing required fields
+          description: Invalid request (empty array, mixed types, or invalid addresses)
           content:
             application/json:
               schema:
@@ -5408,15 +5399,22 @@ paths:
                   - error
                 properties:
                   error:
-                    type: string
+                    type: object
+                    required:
+                      - issues
+                    properties:
+                      issues:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            code:
+                              type: string
+                            message:
+                              type: string
+                            path:
+                              type: array
+                              items:
+                                type: string
         500:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - error
-                properties:
-                  error:
-                    type: string
+          $ref: '#/components/responses/500.InternalError'

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -5346,7 +5346,7 @@ paths:
   /v2/merkle-tree:
     post:
       operationId: saveMerkleTree
-      description: Saves a merkle tree from a list of addresses.
+      description: Saves a merkle tree from either a list of addresses or a list of [address, amount] tuples.
       requestBody:
         required: true
         content:
@@ -5354,7 +5354,21 @@ paths:
             schema:
               type: array
               items:
-                type: string
+                oneOf:
+                  - type: string
+                    description: Recipient address (will be assigned amount "1")
+                  - type: array
+                    minItems: 2
+                    maxItems: 2
+                    items:
+                      - type: string
+                        description: Recipient address
+                      - oneOf:
+                          - type: string
+                            description: Amount as string
+                          - type: number
+                            description: Amount as number
+              description: Array must contain either all strings or all tuples, no mixing allowed
       responses:
         200:
           description: Successfully saved the Merkle Tree
@@ -5365,10 +5379,13 @@ paths:
                 properties:
                   success:
                     type: boolean
+                    default: true
                   root:
                     type: string
+                    description: The merkle tree root hash
                   url:
                     type: string
+                    description: URL where the merkle tree is stored
         400:
           description: Missing required fields
           content:


### PR DESCRIPTION
# Description
This PR introduces support for recipient-amount pairs in merkle tree generation, allowing variable token amounts per address.

# Issues
Fixes #
Refs #15541

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread