### PR TITLE
fix(smart-contracts): pass folder name in release task

### DIFF
--- a/smart-contracts/tasks/release.js
+++ b/smart-contracts/tasks/release.js
@@ -7,7 +7,8 @@ const exec = util.promisify(require('child_process').exec)
 task('release', 'Release a new version of the contract')
   .addParam('contract', 'The contract path')
   .addOptionalParam('contractVersion', 'The contract version to use')
-  .setAction(async ({ contract, contractVersion }, hre) => {
+  .addOptionalParam('destFolder', 'The destination folder in contracts package')
+  .setAction(async ({ contract, contractVersion, destFolder }, hre) => {
     let versioned, abiPath, solPath
     const libPath = path.resolve('../packages/contracts/src')
     const contractName = path.basename(contract).replace('.sol', '')
@@ -49,6 +50,19 @@ task('release', 'Release a new version of the contract')
         'contracts',
         contractName,
         `${versioned}.sol`
+      )
+    } else if (destFolder) {
+      abiPath = path.resolve(
+        libPath,
+        'abis',
+        destFolder,
+        `${contractName}.json`
+      )
+      solPath = path.resolve(
+        libPath,
+        'contracts',
+        destFolder,
+        `${contractName}.sol`
       )
     } else {
       abiPath = path.resolve(


### PR DESCRIPTION
# Description

add ability to pass a folder name when releasing to contracts package.

```
yarn hardhat release --contract contracts/tokens/UP/Airdrops.sol --dest-folder UP
```

will copy contracts to `/UP/Airdrops.sol`


<!--
Please include a summary of the change and which issue is fixed -include its number-. It's important that PRs connect to an existing issue, and we'll review this PR in part based on the content of that issue. Please also include relevant motivation and context.
-->

# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #
Refs #

# Checklist:

- [ ] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
