### PR TITLE
fix(airdrops): add `opengraph` image to campaign detail page

### DIFF
--- a/airdrops/app/campaigns/[campaign]/page.tsx
+++ b/airdrops/app/campaigns/[campaign]/page.tsx
@@ -27,10 +27,22 @@ export async function generateMetadata({
     openGraph: {
       title: `${campaign.name} | ${config.appName.default}`,
       description: campaign.description,
+      images: [
+        {
+          url: config.images.default,
+          alt: config.appName.brand,
+        },
+      ],
     },
     twitter: {
       title: `${campaign.name} | ${config.appName.default}`,
       description: campaign.description,
+      images: [
+        {
+          url: config.images.default,
+          alt: config.appName.brand,
+        },
+      ],
     },
   }
 }


### PR DESCRIPTION
# Description
This PR introduces a fix for the `opengraph` metadata on the campaign detail page. Previously, only the campaign’s name and description were shown.

# Issues
Fixes #
Refs #15541

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread