### PR TITLE
feature(provider): ENS/Basenames caching

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -8,6 +8,33 @@ For each network, the RPC endpoint URL is `https://rpc.unlock-protocol.com/<chai
 
 The Ethereum JSON RPC API specification [can be found there](https://github.com/ethereum/execution-apis).
 
+## Caching
+
+The provider implements caching for ENS and BaseName resolution requests. These requests are cached to reduce load on the underlying RPC providers and improve performance.
+
+The following types of requests are cached:
+
+- ENS resolver lookups (`eth_call` to ENS resolver functions)
+- Base name resolution (`eth_call` to L2 resolver functions)
+
+Cache keys are based on the network ID, method, and parameters of the request.
+
+### Cache Duration
+
+By default, the cache duration is set to 1 hour (3600 seconds). This is configured in the `wrangler.toml` file:
+
+```toml
+[vars]
+CACHE_DURATION_SECONDS = "3600"
+```
+
+To modify the cache duration, simply update this value in the wrangler.toml file:
+
+- For a 30-minute cache: `CACHE_DURATION_SECONDS = "1800"`
+- For a 2-hour cache: `CACHE_DURATION_SECONDS = "7200"`
+
+If the environment variable contains an invalid value, the default 1-hour duration will be used.
+
 # Development
 
 You can use the `yarn dev` to run locally.

--- a/provider/src/handler.ts
+++ b/provider/src/handler.ts
@@ -8,6 +8,48 @@ interface RpcRequest {
   params: string[]
 }
 
+// Cache TTL in seconds (1 hour)
+const CACHE_TTL = 60 * 60
+
+// Methods that should be cached
+const CACHEABLE_METHODS = [
+  'eth_call', // utilised by ENS resolver and other name resolution services
+]
+
+// Check if the request is for name resolution (ENS or Base name)
+const isNameResolutionRequest = (body: RpcRequest): boolean => {
+  if (body.method !== 'eth_call') return false
+
+  // ENS and BaseName resolution typically use eth_call with specific contract data
+  // This checks for common ENS and BaseName resolution patterns in the call data
+  const callParams = body.params[0] as { data?: string } | undefined
+  const callData = callParams?.data?.toLowerCase() || ''
+
+  // ENS resolver methods
+  const ensPatterns = [
+    '0x3b3b57de', // addr(bytes32)
+    '0xf1cb7e06', // addr(bytes32,uint256)
+    '0x691f3431', // name(bytes32)
+    '0x2203ab56', // text(bytes32,string)
+  ]
+
+  // Base Name resolver patterns (L2 resolver methods)
+  const baseNamePatterns = [
+    '0x691f3431', // name(bytes32)
+  ]
+
+  return (
+    ensPatterns.some((pattern) => callData.startsWith(pattern)) ||
+    baseNamePatterns.some((pattern) => callData.startsWith(pattern))
+  )
+}
+
+// Create a cache key from a request
+const createCacheKey = (networkId: string, body: RpcRequest): string => {
+  // For name resolution, we want to cache based on the method and params
+  return `${networkId}:${body.method}:${JSON.stringify(body.params)}`
+}
+
 const handler = async (request: Request, env: Env): Promise<Response> => {
   // Handling CORS
   if (request.method === 'OPTIONS') {
@@ -124,6 +166,7 @@ const handler = async (request: Request, env: Env): Promise<Response> => {
   const body: RpcRequest = await request.json()
   const bodyAsString = JSON.stringify(body)
   console.log(bodyAsString)
+
   // Handling chainId locally
   if (
     body?.method?.toLocaleLowerCase().trim() ===
@@ -141,6 +184,25 @@ const handler = async (request: Request, env: Env): Promise<Response> => {
     )
   }
 
+  // Check if this is a cacheable request
+  const isCacheable =
+    CACHEABLE_METHODS.includes(body.method) && isNameResolutionRequest(body)
+
+  // If cacheable, try to get the result from the cache
+  if (isCacheable) {
+    const cacheKey = createCacheKey(networkId, body)
+
+    // Try to get the cached response
+    const cache = caches.default
+    const cachedResponse = await cache.match(new Request(cacheKey))
+
+    if (cachedResponse) {
+      console.log(`Cache hit for ${cacheKey}`)
+      return cachedResponse
+    }
+    console.log(`Cache miss for ${cacheKey}`)
+  }
+
   // Make JSON RPC request
   const response = await fetch(supportedNetwork, {
     method: 'POST',
@@ -153,9 +215,30 @@ const handler = async (request: Request, env: Env): Promise<Response> => {
 
   const json = await response.json()
 
-  return Response.json(json, {
+  // Create the response object
+  const jsonResponse = Response.json(json, {
     headers,
   })
+
+  // If this is a cacheable request, store the response in the cache
+  if (isCacheable) {
+    const cacheKey = createCacheKey(networkId, body)
+    const cache = caches.default
+
+    // Clone the response before modifying it for cache storage
+    const responseToCache = new Response(JSON.stringify(json), {
+      headers: {
+        ...headers,
+        'Cache-Control': `public, max-age=${CACHE_TTL}`,
+      },
+    })
+
+    // Store the response in the cache with the specified TTL
+    await cache.put(new Request(cacheKey), responseToCache)
+    console.log(`Cached response for ${cacheKey}`)
+  }
+
+  return jsonResponse
 }
 
 export default handler

--- a/provider/src/handler.ts
+++ b/provider/src/handler.ts
@@ -183,7 +183,6 @@ const handler = async (request: Request, env: Env): Promise<Response> => {
 
   const body: RpcRequest = await request.json()
   const bodyAsString = JSON.stringify(body)
-  console.log(bodyAsString)
 
   // Handling chainId locally
   if (

--- a/provider/src/types.ts
+++ b/provider/src/types.ts
@@ -14,4 +14,7 @@ export interface Env {
   LINEA_PROVIDER: string
   ZKEVM_PROVIDER: string
   SCROLL_PROVIDER: string
+
+  // Optional environment variable for configuring cache duration in seconds
+  CACHE_DURATION_SECONDS?: string
 }

--- a/provider/wrangler.toml
+++ b/provider/wrangler.toml
@@ -2,3 +2,8 @@ name = "rpc-provider"
 main = "src/index.ts"
 compatibility_date = "2022-08-17"
 tail_consumers = [{service = "rpc-provider-tail"}]
+
+# Optional environment variables
+[vars]
+# Cache duration in seconds for ENS/Basename resolution (default: 3600 seconds / 1 hour)
+CACHE_DURATION_SECONDS = "3600"


### PR DESCRIPTION
# Description
This PR introduces intelligent caching for ENS/BaseName resolution in our `provider` worker. It detects name resolution requests by matching common method signatures (`0x3b3b57de`, `0x691f3431`, etc.) and caches responses for 1 hour by default. Cache duration is configurable via `CACHE_DURATION_SECONDS` in `wrangler.toml`.

Works for both forward and reverse lookups, reducing provider load and improving response times.



# Issues
Fixes #15542
Refs #15542

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread