### PR TITLE
feature(unlock-app): `useCentralizedLockData` hook

### DIFF
--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { MdOutlineTipsAndUpdates } from 'react-icons/md'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { Button, Icon } from '@unlock-protocol/ui'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Fragment, useEffect, useState } from 'react'
@@ -397,17 +397,6 @@ export const ManageLockContent = () => {
     approval: ApprovalStatus.MINTED,
   })
   const [page, setPage] = useState(1)
-
-  const { data: eventData } = useQuery({
-    queryKey: ['getEventForLock', lockAddress, network],
-    queryFn: async () => {
-      const { data: eventDetails } = await locksmith.getEventDetails(
-        Number(network),
-        lockAddress
-      )
-      return eventDetails
-    },
-  })
 
   if (!owner) {
     return <ConnectWalletModal isOpen={true} setIsOpen={() => void 0} />

--- a/unlock-app/src/config/queryClient.ts
+++ b/unlock-app/src/config/queryClient.ts
@@ -35,13 +35,17 @@ export const queryClient = new QueryClient({
   }),
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000, // 1 minute!
+      staleTime: 60 * 1000, // 1 minute
+      gcTime: 5 * 60 * 1000, // 5 minutes
       refetchInterval: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       refetchIntervalInBackground: false,
+      // Add retryDelay to space out retries and prevent flooding
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
       retry: (failureCount, error) => {
-        if (failureCount > 3) {
+        // Limit retries more aggressively
+        if (failureCount > 2) {
           return false
         }
         if (error instanceof AxiosError) {

--- a/unlock-app/src/hooks/useCentralizedLockData.ts
+++ b/unlock-app/src/hooks/useCentralizedLockData.ts
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query'
+import { locksmith } from '~/config/locksmith'
+import { graphService } from '~/config/subgraph'
+
+/**
+ * Hook for fetching centralized lock data used across multiple components
+ * to eliminate redundant subgraph requests
+ */
+export const useCentralizedLockData = (
+  lockAddress?: string,
+  network?: number,
+  owner?: string,
+  options = {
+    staleTime: 1 * 60 * 1000, // 1 minute default stale time
+  }
+) => {
+  return useQuery({
+    queryKey: ['centralizedLockData', lockAddress, network],
+    // Only run this query when we have valid lock parameters
+    enabled: !!lockAddress && !!network && !!owner,
+    queryFn: async () => {
+      if (!network || !lockAddress) return null
+
+      // Fetch all relevant lock data in a single query
+      const [
+        subgraphLock,
+        lockSettingsResponse,
+        eventDetailsResponse,
+        metadataResponse,
+      ] = await Promise.all([
+        // Lock data from subgraph
+        graphService.lock(
+          {
+            where: {
+              address: lockAddress,
+            },
+          },
+          { network }
+        ),
+        // Lock settings from locksmith
+        locksmith.getLockSettings(network, lockAddress),
+        // Event details if available
+        locksmith
+          .getEventDetails(network, lockAddress)
+          .catch(() => ({ data: null })),
+        // Metadata
+        locksmith
+          .lockMetadata(network, lockAddress)
+          .catch(() => ({ data: {} })),
+      ])
+
+      // Check if the current user is a lock manager
+      const isUserLockManager = subgraphLock?.lockManagers?.includes(
+        owner?.toLowerCase()
+      )
+
+      return {
+        lock: subgraphLock,
+        lockSettings: lockSettingsResponse?.data || {},
+        isManager: isUserLockManager,
+        eventDetails: eventDetailsResponse?.data || null,
+        metadata: metadataResponse?.data || {},
+      }
+    },
+    staleTime: options.staleTime, // Configurable stale time with reasonable default
+    refetchOnWindowFocus: false,
+  })
+}
+
+export default useCentralizedLockData


### PR DESCRIPTION
# Description
This PR introduces a custom hook to fetch all necessary lock data, reducing redundant checks on the lock’s settings page. It also includes a configurable cache time.


# Issues
Fixes #
Refs #15534

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread