### PR TITLE
feature(unlock-app): `useAuthenticate` loading state

### DIFF
--- a/unlock-app/app/Components/ProtectedContent.tsx
+++ b/unlock-app/app/Components/ProtectedContent.tsx
@@ -3,13 +3,18 @@
 import { ReactNode } from 'react'
 import { WalletNotConnected } from '~/components/interface/layouts/index/WalletNotConnected'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { LoadingIcon } from '~/components/interface/Loading'
 
 interface AuthRequiredProps {
   children: ReactNode
 }
 
 export function AuthRequired({ children }: AuthRequiredProps) {
-  const { account } = useAuthenticate()
+  const { account, isLoading } = useAuthenticate()
+
+  if (isLoading) {
+    return <LoadingIcon size={40} />
+  }
 
   if (!account) {
     return <WalletNotConnected />

--- a/unlock-app/src/components/content/KeychainContent.tsx
+++ b/unlock-app/src/components/content/KeychainContent.tsx
@@ -10,9 +10,10 @@ import { TbWorld as WorldIcon } from 'react-icons/tb'
 import { OpenSeaIcon } from '../icons'
 import { WalletNotConnected } from '../interface/layouts/index/WalletNotConnected'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { LoadingIcon } from '../interface/Loading'
 
 export const KeychainContent = () => {
-  const { account } = useAuthenticate()
+  const { account, isLoading } = useAuthenticate()
   const searchParams = useSearchParams()
   const [owner, setOwner] = useState<string | null>(null)
 
@@ -26,6 +27,10 @@ export const KeychainContent = () => {
   }, [account, searchParams])
 
   const networkConfig = networks[1]
+
+  if (isLoading) {
+    return <LoadingIcon size={40} />
+  }
 
   if (!owner) {
     return <WalletNotConnected />

--- a/unlock-app/src/hooks/useAuthenticate.ts
+++ b/unlock-app/src/hooks/useAuthenticate.ts
@@ -159,5 +159,6 @@ export function useAuthenticate() {
     signInWithPrivy,
     signOut,
     privyReady,
+    isLoading: !privyReady || (privyAuthenticated && !wallets[0]?.address),
   }
 }


### PR DESCRIPTION
# Description
This PR introduces a loading state in the `useAuthenticate` hook. The loading state is true when Privy is not ready or when the user is authenticated but lacks a wallet address. It is false once Privy is ready and either the user is unauthenticated or has a wallet address. This improves state handling for authentication-dependent logic.


# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread