### PR TITLE
fix(unlock-app): Fix email preview rendering when custom content is empty

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/elements/EmailTemplatePreview.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/EmailTemplatePreview.tsx
@@ -56,7 +56,7 @@ const EmailTemplatePreviewComponent = ({
 
   const {
     data: params,
-    // isLoading: isLoadingParams,
+    isLoading: isLoadingParams,
     // refetch: refetchParams,
   } = useEmailPreviewDataForLock({
     lockAddress,
@@ -141,12 +141,13 @@ const EmailTemplatePreviewComponent = ({
               size="small"
               variant="outlined-primary"
               onClick={() => setShowPreview(true)}
+              disabled={isLoadingParams || !params}
             >
               Show email preview
             </Button>
           </div>
         )}
-        {showPreview && (
+        {showPreview && params && (
           <Modal empty isOpen={showPreview} setIsOpen={setShowPreview}>
             <div className="fixed inset-0 z-10 flex justify-center overflow-y-auto bg-white">
               <EmailPreview

--- a/unlock-app/src/hooks/useEmailPreview.ts
+++ b/unlock-app/src/hooks/useEmailPreview.ts
@@ -41,11 +41,13 @@ export const useEmailPreview = ({
         `${config.services.wedlocks.host}/preview/${templateId}`
       )
 
-      Object.entries(params).forEach(([key, value]) => {
-        if (value) {
-          url.searchParams.append(key, value.toString())
-        }
-      })
+      if (params) {
+        Object.entries(params).forEach(([key, value]) => {
+          if (value) {
+            url.searchParams.append(key, value.toString())
+          }
+        })
+      }
 
       return (
         await fetch(url, {
@@ -55,6 +57,7 @@ export const useEmailPreview = ({
         })
       ).json()
     },
+    enabled: !!templateId && !!params,
   })
 }
 
@@ -88,20 +91,28 @@ export const useEmailPreviewDataForLock = ({
         lockAddress
       )
 
+      // Fetch lock metadata to get the lock name
+      const { data: lockMetadata } = await locksmith.lockMetadata(
+        network,
+        lockAddress
+      )
+
       const params = {
         keychainUrl: `${config.unlockApp}/keychain`,
-        keyId: 5, // Placeholder!
         network,
         lockImage,
+        lockName: lockMetadata?.name,
         customContent: customContentHtml,
         ...eventDetails,
         // certificate details
         certificationDetail: '{Certification details}',
+        certificationUrl: `${config.unlockApp}/certification/${network}/${lockAddress}/#`,
+        isUserAddress: true,
       }
 
       return params
     },
-    enabled: !!customContent && !!lockAddress && !!network,
+    enabled: !!lockAddress && !!network,
   })
 }
 


### PR DESCRIPTION
# Description
This PR introduces a fix for the email preview failing to render when no content is added to the “custom” section.

## ScreenGrabs
![Screenshot 2025-03-10 at 13 25 57](https://github.com/user-attachments/assets/957c85ea-c844-452a-b36b-497963585e6b)
![Screenshot 2025-03-10 at 13 26 16](https://github.com/user-attachments/assets/ff04fe5d-d247-4171-b15c-6041fc5a9cc7)


# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread
