### PR TITLE
fix(locksmith): Fix contradictory renewal messages in key expiration emails

### DIFF
--- a/locksmith/src/operations/membershipOperations.ts
+++ b/locksmith/src/operations/membershipOperations.ts
@@ -40,9 +40,12 @@ export const getMembershipState = async ({
     const possible = BigInt(subscription.possibleRenewals)
     const approved = BigInt(subscription.approvedRenewals)
 
-    isAutoRenewable = approved >= 0 && possible >= 0
+    // Make conditions mutually exclusive
+    // Only auto-renewable if approved is positive and possible renewals exist
+    isAutoRenewable = approved > 0 && possible > 0
 
-    isRenewableIfReApproved = approved <= 0
+    // Only needs re-approval if approved is insufficient but renewal is possible
+    isRenewableIfReApproved = approved <= 0 && possible > 0
 
     currency = subscription.balance.symbol
   }


### PR DESCRIPTION
# Description
This PR introduces a fix for contradictory auto-renewal messages in key expiration emails.

# Issues
Fixes #15486
Refs #15486

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread