### PR TITLE
fix(unlock-app): Fix markdown rendering issues in email templates

### DIFF
--- a/unlock-app/src/components/interface/locks/Settings/elements/EmailPreview.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/EmailPreview.tsx
@@ -91,11 +91,57 @@ export const EmailPreview = ({
           <ul>
             <li>Email subject: {email?.subject}</li>
           </ul>
+          <style>
+            {`
+              /* Custom content section styles */
+              section[style*="background: #F8FAFC"] {
+                /* Typography */
+                font-family: ui-sans-serif, system-ui, sans-serif !important;
+              }
+              
+              /* Headings */
+              section[style*="background: #F8FAFC"] h1,
+              section[style*="background: #F8FAFC"] h2,
+              section[style*="background: #F8FAFC"] h3 {
+                font-weight: bold;
+                margin-bottom: 0.5rem;
+                margin-top: 1rem;
+              }
+              
+              /* Lists */
+              section[style*="background: #F8FAFC"] ul { list-style-type: disc; }
+              section[style*="background: #F8FAFC"] ol { list-style-type: decimal; }
+              
+              section[style*="background: #F8FAFC"] ul,
+              section[style*="background: #F8FAFC"] ol {
+                padding-left: 1.5rem;
+                margin: 0.5rem 0;
+              }
+              
+              section[style*="background: #F8FAFC"] li {
+                margin-bottom: 0.25rem;
+              }
+              
+              /* Blockquotes */
+              section[style*="background: #F8FAFC"] blockquote {
+                border-left: 4px solid #e2e8f0;
+                padding-left: 1rem;
+                font-style: italic;
+                margin: 0.5rem 0;
+              }
+              
+              /* Horizontal rule */
+              section[style*="background: #F8FAFC"] hr {
+                margin: 1rem 0;
+                border: 0;
+                border-top: 1px solid #e2e8f0;
+              }
+            `}
+          </style>
           <div
             dangerouslySetInnerHTML={{
               __html: email?.html || '',
             }}
-            style={{ width: '200px' }}
             className="text-left"
           />
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
# Description
This PR introduces support for additional markdown elements in email templates, including H3 headers, blockquotes, ordered lists, unordered lists, horizontal rules, and line breaks. Previously, these elements were not rendered correctly, leading to formatting issues in email templates.


## ScreenGrabs

Before
<img width="524" alt="Screenshot 2025-03-18 at 12 10 07" src="https://github.com/user-attachments/assets/94c33ad9-1ecb-4a26-8740-fc2bb70fb731" />


After
<img width="526" alt="Screenshot 2025-03-18 at 12 10 27" src="https://github.com/user-attachments/assets/4bd967c2-587b-4cc7-998b-a9d79893e2a4" />



# Issues
Fixes #14451
Refs #14451

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread