### PR TITLE
feature(airdrops): Add required delegation step for airdrops campaign 

### DIFF
--- a/airdrops/components/hooks/useDelegation.ts
+++ b/airdrops/components/hooks/useDelegation.ts
@@ -1,0 +1,50 @@
+import { usePrivy, useWallets } from '@privy-io/react-auth'
+import { useQuery } from '@tanstack/react-query'
+import { AirdropData } from '../Campaigns'
+import { isEligible } from '../../src/utils/eligibility'
+import { hasClaimed } from '../CampaignDetailContent'
+import { hasDelegated } from '../../src/utils/delegation'
+
+export function useDelegation(airdrop: AirdropData) {
+  const { authenticated } = usePrivy()
+  const { wallets } = useWallets()
+
+  return useQuery({
+    queryKey: ['useDelegation', wallets, airdrop],
+    queryFn: async () => {
+      const address = wallets[0].address
+      const eligibleAmount = await isEligible(address, airdrop)
+      const alreadyClaimed =
+        eligibleAmount !== '0'
+          ? await hasClaimed(address, eligibleAmount, airdrop)
+          : false
+
+      const delegationStatus =
+        eligibleAmount !== '0'
+          ? await hasDelegated(
+              address,
+              airdrop.token?.address || '',
+              airdrop.chainId
+            )
+          : false
+
+      const canClaim =
+        eligibleAmount !== '0' && !alreadyClaimed && delegationStatus
+
+      return {
+        eligible: eligibleAmount,
+        claimed: alreadyClaimed,
+        hasDelegated: delegationStatus,
+        canClaim,
+      }
+    },
+    initialData: {
+      eligible: '0',
+      claimed: false,
+      hasDelegated: false,
+      canClaim: false,
+    },
+    enabled: !!(authenticated && wallets?.[0]),
+    refetchOnWindowFocus: false,
+  })
+}

--- a/airdrops/src/reducers/delegation/actions.ts
+++ b/airdrops/src/reducers/delegation/actions.ts
@@ -1,0 +1,38 @@
+import type { DelegationAction } from './types'
+
+export const delegationActions = {
+  startDelegating: (): DelegationAction => ({
+    type: 'START_DELEGATING',
+  }),
+
+  finishDelegating: (): DelegationAction => ({
+    type: 'FINISH_DELEGATING',
+  }),
+
+  setSelfDelegate: (isSelfDelegate: boolean): DelegationAction => ({
+    type: 'SET_SELF_DELEGATE',
+    payload: isSelfDelegate,
+  }),
+
+  startResolving: (): DelegationAction => ({
+    type: 'START_RESOLVING',
+  }),
+
+  setDelegateAddress: (address: string): DelegationAction => ({
+    type: 'SET_DELEGATE_ADDRESS',
+    payload: address,
+  }),
+
+  setDelegateError: (error: boolean): DelegationAction => ({
+    type: 'SET_DELEGATE_ERROR',
+    payload: error,
+  }),
+
+  clearDelegateError: (): DelegationAction => ({
+    type: 'CLEAR_DELEGATE_ERROR',
+  }),
+
+  finishResolving: (): DelegationAction => ({
+    type: 'FINISH_RESOLVING',
+  }),
+}

--- a/airdrops/src/reducers/delegation/index.ts
+++ b/airdrops/src/reducers/delegation/index.ts
@@ -1,0 +1,29 @@
+import { useReducer } from 'react'
+import { delegationReducer, initialState } from './reducer'
+import { delegationActions } from './actions'
+import type { DelegationState, DelegationAction } from './types'
+
+export function useDelegationReducer() {
+  const [state, dispatch] = useReducer(delegationReducer, initialState)
+
+  const actions = {
+    startDelegating: () => dispatch(delegationActions.startDelegating()),
+    finishDelegating: () => dispatch(delegationActions.finishDelegating()),
+    setSelfDelegate: (isSelfDelegate: boolean) =>
+      dispatch(delegationActions.setSelfDelegate(isSelfDelegate)),
+    startResolving: () => dispatch(delegationActions.startResolving()),
+    setDelegateAddress: (address: string) =>
+      dispatch(delegationActions.setDelegateAddress(address)),
+    setDelegateError: (error: boolean) =>
+      dispatch(delegationActions.setDelegateError(error)),
+    clearDelegateError: () => dispatch(delegationActions.clearDelegateError()),
+    finishResolving: () => dispatch(delegationActions.finishResolving()),
+  }
+
+  return {
+    state,
+    actions,
+  }
+}
+
+export type { DelegationState, DelegationAction }

--- a/airdrops/src/reducers/delegation/reducer.ts
+++ b/airdrops/src/reducers/delegation/reducer.ts
@@ -1,0 +1,43 @@
+import { DelegationState, DelegationAction } from './types'
+
+export const initialState: DelegationState = {
+  delegating: false,
+  isSelfDelegate: false,
+  delegateAddress: null,
+  delegateAddressError: null,
+  isResolving: false,
+}
+
+export function delegationReducer(
+  state: DelegationState,
+  action: DelegationAction
+): DelegationState {
+  switch (action.type) {
+    case 'START_DELEGATING':
+      return { ...state, delegating: true }
+    case 'FINISH_DELEGATING':
+      return { ...state, delegating: false }
+    case 'SET_SELF_DELEGATE':
+      return { ...state, isSelfDelegate: action.payload }
+    case 'START_RESOLVING':
+      return { ...state, isResolving: true }
+    case 'SET_DELEGATE_ADDRESS':
+      return {
+        ...state,
+        delegateAddress: action.payload,
+        delegateAddressError: null,
+      }
+    case 'SET_DELEGATE_ERROR':
+      return {
+        ...state,
+        delegateAddress: null,
+        delegateAddressError: action.payload,
+      }
+    case 'CLEAR_DELEGATE_ERROR':
+      return { ...state, delegateAddressError: null }
+    case 'FINISH_RESOLVING':
+      return { ...state, isResolving: false }
+    default:
+      return state
+  }
+}

--- a/airdrops/src/reducers/delegation/types.ts
+++ b/airdrops/src/reducers/delegation/types.ts
@@ -1,0 +1,17 @@
+export interface DelegationState {
+  delegating: boolean
+  isSelfDelegate: boolean
+  delegateAddress: string | null
+  delegateAddressError: boolean
+  isResolving: boolean
+}
+
+export type DelegationAction =
+  | { type: 'START_DELEGATING' }
+  | { type: 'FINISH_DELEGATING' }
+  | { type: 'SET_SELF_DELEGATE'; payload: boolean }
+  | { type: 'START_RESOLVING' }
+  | { type: 'SET_DELEGATE_ADDRESS'; payload: string }
+  | { type: 'SET_DELEGATE_ERROR'; payload: boolean }
+  | { type: 'CLEAR_DELEGATE_ERROR' }
+  | { type: 'FINISH_RESOLVING' }

--- a/airdrops/src/utils/delegation.ts
+++ b/airdrops/src/utils/delegation.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'ethers'
+
+/**
+ * Checks if an address is has delegated their tokens to another address
+ * Returns true if the address has delegated tokens, false otherwise
+ */
+export const hasDelegated = async (
+  address: string,
+  tokenAddress: string,
+  chainId: number
+): Promise<boolean> => {
+  try {
+    const provider = new ethers.JsonRpcProvider(
+      `https://rpc.unlock-protocol.com/${chainId}`
+    )
+    const delegationAbi = ['function delegates(address) view returns (address)']
+    const tokenContract = new ethers.Contract(
+      tokenAddress,
+      delegationAbi,
+      provider
+    )
+    const delegate = await tokenContract.delegates(address)
+    return delegate !== ethers.ZeroAddress
+  } catch (error) {
+    console.error('Error checking delegation status:', error)
+    return false
+  }
+}

--- a/airdrops/src/utils/delegation.ts
+++ b/airdrops/src/utils/delegation.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import { getProvider } from './provider'
 
 /**
  * Checks if an address is has delegated their tokens to another address
@@ -10,9 +11,7 @@ export const hasDelegated = async (
   chainId: number
 ): Promise<boolean> => {
   try {
-    const provider = new ethers.JsonRpcProvider(
-      `https://rpc.unlock-protocol.com/${chainId}`
-    )
+    const provider = getProvider(chainId)
     const delegationAbi = ['function delegates(address) view returns (address)']
     const tokenContract = new ethers.Contract(
       tokenAddress,

--- a/airdrops/src/utils/provider.ts
+++ b/airdrops/src/utils/provider.ts
@@ -1,0 +1,8 @@
+import { Web3Service } from '@unlock-protocol/unlock-js'
+import { networks } from '@unlock-protocol/networks'
+
+const web3Service = new Web3Service(networks)
+
+export const getProvider = (network: number) => {
+  return web3Service.providerForNetwork(network)
+}

--- a/airdrops/src/utils/stewards.ts
+++ b/airdrops/src/utils/stewards.ts
@@ -1,0 +1,42 @@
+export const communityStewards = [
+  {
+    address: '0xD2BC5cb641aE6f7A880c3dD5Aee0450b5210BE23',
+    name: 'Stella Achenbach',
+    description: 'Lead Steward',
+  },
+  {
+    address: '0xCA7632327567796e51920F6b16373e92c7823854',
+    name: 'Danny Thomx',
+    description: 'Liaison Engineer',
+  },
+  {
+    address: '0xFf4eC2057A4180A4Cd18FDEA144e53245e39869D',
+    name: 'Wonderwomancode',
+    description: 'Regular contributor',
+  },
+  {
+    address: '0xED59e0fB105F003e508A1f59Fe9F4AE5a755BDeD',
+    name: 'CaptainSouthpaw',
+    description: 'Regular contributor',
+  },
+  {
+    address: '0x4846162806B025Dcd0759cACF9ec6F9474274282',
+    name: 'PostArchitekt',
+    description: 'Regular contributor',
+  },
+  {
+    address: '0xaa3600788b72863ff51c8f0db5f10bb65fbfeab4',
+    name: 'Lana',
+    description: 'Regular contributor',
+  },
+  {
+    address: '0x38b826a4426a0d4d9b4377ac57c9af0308281c5d',
+    name: 'Ceci Sakura',
+    description: 'Regular contributor',
+  },
+  {
+    address: '0x8687ab2ff3188f961828fc2131b6150ee97bedce',
+    name: 'Kara Howard',
+    description: 'Regular contributor',
+  },
+]

--- a/airdrops/src/utils/stewards.ts
+++ b/airdrops/src/utils/stewards.ts
@@ -12,31 +12,31 @@ export const communityStewards = [
   {
     address: '0xFf4eC2057A4180A4Cd18FDEA144e53245e39869D',
     name: 'Wonderwomancode',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
   {
     address: '0xED59e0fB105F003e508A1f59Fe9F4AE5a755BDeD',
     name: 'CaptainSouthpaw',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
   {
     address: '0x4846162806B025Dcd0759cACF9ec6F9474274282',
     name: 'PostArchitekt',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
   {
     address: '0xaa3600788b72863ff51c8f0db5f10bb65fbfeab4',
     name: 'Lana',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
   {
     address: '0x38b826a4426a0d4d9b4377ac57c9af0308281c5d',
     name: 'Ceci Sakura',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
   {
     address: '0x8687ab2ff3188f961828fc2131b6150ee97bedce',
     name: 'Kara Howard',
-    description: 'Regular contributor',
+    description: 'Regular Contributor',
   },
 ]


### PR DESCRIPTION
<!--
Thank you for your contribution to Unlock Protocol!
-->

# Description
This PR introduces a required delegation step for addresses not delegated their tokens during airdrop claims. They can either delegate to themselves, choose from a list of community members, or enter a preferred address to delegate to.

https://github.com/user-attachments/assets/3eeea1bb-0891-4e15-bcb1-d7543fdc195f


# Issues

<!-- This PR should fix or reference at least one existing issue ID. Add or delete as appropriate. -->

Fixes #15709 
Refs #15709 

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

<!--
PS: [Read how to write the perfect pull request](https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/)
-->

## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
