### PR TITLE
feature(unlock-app): Add CCPA/GDPR consent checkbox to metadata collection form

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -542,7 +542,7 @@ export function Metadata({ checkoutService }: Props) {
                     </div>
                     <div className="text-sm">
                       <label htmlFor="termsAccepted" className="cursor-pointer">
-                        I agree to Unlock{' '}
+                        I agree to the{' '}
                         <Link
                           target="_blank"
                           href={`${config.unlockStaticUrl}/terms`}


### PR DESCRIPTION
# Description
This PR introduces a required CCPA/GDPR consent checkbox on the metadata collection form during checkout. Users must agree to Unlock’s Terms of Service before their data can be shared with us and the lock manager.


## ScreenGrabs

Before
![Screenshot 2025-03-20 at 17 29 21](https://github.com/user-attachments/assets/754c7704-2441-46ac-98dd-1fdbd040d209)

After
![Screenshot 2025-03-20 at 17 29 02](https://github.com/user-attachments/assets/5d1deaef-1d7c-41ad-8b44-251000834051)


# Issues
Fixes #10044
Refs #10044

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread