### PR TITLE
feature(locksmith): Render tickets and certificates in pdf format

### DIFF
--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -6,7 +6,7 @@ import {
   getTemplates,
   getAttachments,
 } from '../../src/operations/wedlocksOperations'
-import { vi, expect, afterAll } from 'vitest'
+import { vi, expect } from 'vitest'
 import app from '../app'
 import request from 'supertest'
 import { loginRandomUser } from '../test-helpers/utils'
@@ -39,7 +39,8 @@ vi.mock('../../src/utils/ticket', async () => {
   const actual: any = await vi.importActual('../../src/utils/ticket')
   return {
     ...actual,
-    createTicket: async () => Promise.resolve('mock'),
+    createTicket: async () =>
+      Promise.resolve('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
   }
 })
 
@@ -53,7 +54,9 @@ vi.mock('../../src/utils/calendar', async () => {
 
 vi.mock('../../src/utils/certification', async () => {
   return {
-    createCertificate: vi.fn(async () => Promise.resolve('mock')),
+    createCertificate: vi.fn(async () =>
+      Promise.resolve('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+    ),
   }
 })
 
@@ -419,7 +422,7 @@ describe('Wedlocks operations', () => {
       })
 
       expect(
-        attachments.find((attachment) => attachment.filename === 'ticket.png')
+        attachments.find((attachment) => attachment.filename === 'ticket.pdf')
       ).toBeDefined()
       expect(
         attachments.find((attachment) => attachment.filename === 'calendar.ics')
@@ -442,7 +445,7 @@ describe('Wedlocks operations', () => {
 
       expect(
         attachments.find(
-          (attachment) => attachment.filename === 'certification.png'
+          (attachment) => attachment.filename === 'certification.pdf'
         )
       ).toBeDefined()
     })

--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -79,6 +79,7 @@
     "p-retry": "6.2.1",
     "passkit-generator": "3.2.0",
     "path-to-regexp": "8.2.0",
+    "pdf-lib": "1.17.1",
     "pdfmake": "0.2.18",
     "pg": "8.13.3",
     "rate-limiter-flexible": "5.0.5",

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -18,10 +18,10 @@ import {
 import { getLockMetadata, generateKeyMetadata } from './metadataOperations'
 import { LockType, getLockTypeByMetadata } from '@unlock-protocol/core'
 import { getCertificateLinkedinShareUrl } from '../utils/certificationHelpers'
-import { svgStringToDataURI } from '../utils/image'
 import { createCertificate } from '../utils/certification'
 import remarkParse from 'remark-parse'
 import remarkHtml from 'remark-html'
+import { svgStringToPdfURI } from '../utils/pdf'
 
 type Params = {
   [key: string]: string | number | undefined | boolean
@@ -228,8 +228,8 @@ export const getAttachments = async ({
       owner,
     })
     attachments.push({
-      path: svgStringToDataURI(ticket),
-      filename: 'ticket.png',
+      path: await svgStringToPdfURI(ticket),
+      filename: 'ticket.pdf',
     })
   }
 
@@ -261,8 +261,8 @@ export const getAttachments = async ({
     })
     if (certificate) {
       attachments.push({
-        path: svgStringToDataURI(certificate),
-        filename: 'certification.png',
+        path: await svgStringToPdfURI(certificate),
+        filename: 'certification.pdf',
       })
     }
   }

--- a/locksmith/src/utils/image.ts
+++ b/locksmith/src/utils/image.ts
@@ -1,6 +1,5 @@
 import logger from '../logger'
 import lockIcon from './lockIcon'
-import resvg from '@resvg/resvg-js'
 
 export const imageUrlToBase64 = async (url: string, lockAddress: string) => {
   // Fallback to the lock icon if the image is not available
@@ -32,12 +31,4 @@ export const imageURLToDataURI = async (url: string, fallbackURL?: string) => {
       throw err
     }
   }
-}
-
-export const svgStringToDataURI = (svgString: string) => {
-  const svg = new resvg.Resvg(svgString)
-  const pngData = svg.render()
-  const pngBuffer = pngData.asPng()
-  const dataURI = `data:image/png;base64,${pngBuffer.toString('base64')}`
-  return dataURI
 }

--- a/locksmith/src/utils/pdf.ts
+++ b/locksmith/src/utils/pdf.ts
@@ -1,0 +1,43 @@
+import logger from '../logger'
+import resvg from '@resvg/resvg-js'
+import { PDFDocument } from 'pdf-lib'
+
+export const svgStringToPdfURI = async (svgString: string): Promise<string> => {
+  try {
+    // First convert SVG to PNG using resvg
+    const svg = new resvg.Resvg(svgString)
+    const pngData = svg.render()
+    const pngBuffer = pngData.asPng()
+
+    // Get dimensions
+    const width = pngData.width
+    const height = pngData.height
+
+    // Create a new PDF document
+    const pdfDoc = await PDFDocument.create()
+
+    // Add a page with the same dimensions as the PNG
+    const page = pdfDoc.addPage([width, height])
+
+    // Embed the PNG image
+    const pngImage = await pdfDoc.embedPng(pngBuffer)
+
+    // Draw the image on the page
+    page.drawImage(pngImage, {
+      x: 0,
+      y: 0,
+      width: page.getWidth(),
+      height: page.getHeight(),
+    })
+
+    // Serialize the PDF to bytes
+    const pdfBytes = await pdfDoc.save()
+
+    // Convert to data URI
+    const dataURI = `data:application/pdf;base64,${Buffer.from(pdfBytes).toString('base64')}`
+    return dataURI
+  } catch (err) {
+    logger.error('Failed to convert SVG to PDF', { err })
+    throw err
+  }
+}

--- a/locksmith/src/utils/pdf.ts
+++ b/locksmith/src/utils/pdf.ts
@@ -4,8 +4,12 @@ import { PDFDocument } from 'pdf-lib'
 
 export const svgStringToPdfURI = async (svgString: string): Promise<string> => {
   try {
-    // First convert SVG to PNG using resvg
-    const svg = new resvg.Resvg(svgString)
+    const svg = new resvg.Resvg(svgString, {
+      dpi: 200,
+      fitTo: {
+        mode: 'original',
+      },
+    })
     const pngData = svg.render()
     const pngBuffer = pngData.asPng()
 
@@ -31,7 +35,9 @@ export const svgStringToPdfURI = async (svgString: string): Promise<string> => {
     })
 
     // Serialize the PDF to bytes
-    const pdfBytes = await pdfDoc.save()
+    const pdfBytes = await pdfDoc.save({
+      useObjectStreams: false,
+    })
 
     // Convert to data URI
     const dataURI = `data:application/pdf;base64,${Buffer.from(pdfBytes).toString('base64')}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -12171,6 +12171,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pdf-lib/standard-fonts@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@pdf-lib/standard-fonts@npm:1.0.0"
+  dependencies:
+    pako: "npm:^1.0.6"
+  checksum: 10/0dfcedbd16e3f48afcac321f153d81f49ea6030030fa1e05a07bde359629949e27b3d77b39a5c7b0b0ff8af09912765f62a911cd67d488d4dc0b3c1c5ca106f0
+  languageName: node
+  linkType: hard
+
+"@pdf-lib/upng@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@pdf-lib/upng@npm:1.0.1"
+  dependencies:
+    pako: "npm:^1.0.10"
+  checksum: 10/eecac72f36d51b67acb09f61a7bbb55577ceb6232aa0c1a827aea003126787cede07ad391c0c789ab36164a9a86d1634768c2cf941148743e155de7ed6c34fc3
+  languageName: node
+  linkType: hard
+
 "@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8":
   version: 2.3.15
   resolution: "@peculiar/asn1-schema@npm:2.3.15"
@@ -18429,6 +18447,7 @@ __metadata:
     parse-data-uri: "npm:0.2.0"
     passkit-generator: "npm:3.2.0"
     path-to-regexp: "npm:8.2.0"
+    pdf-lib: "npm:1.17.1"
     pdfmake: "npm:0.2.18"
     pg: "npm:8.13.3"
     rate-limiter-flexible: "npm:5.0.5"
@@ -40836,7 +40855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pako@npm:~1.0.2, pako@npm:~1.0.5":
+"pako@npm:^1.0.10, pako@npm:^1.0.11, pako@npm:^1.0.6, pako@npm:~1.0.2, pako@npm:~1.0.5":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
   checksum: 10/1ad07210e894472685564c4d39a08717e84c2a68a70d3c1d9e657d32394ef1670e22972a433cbfe48976cb98b154ba06855dcd3fcfba77f60f1777634bec48c0
@@ -41360,6 +41379,18 @@ __metadata:
     safe-buffer: "npm:^5.0.1"
     sha.js: "npm:^2.4.8"
   checksum: 10/40bdf30df1c9bb1ae41ec50c11e480cf0d36484b7c7933bf55e4451d1d0e3f09589df70935c56e7fccc5702779a0d7b842d012be8c08a187b44eb24d55bb9460
+  languageName: node
+  linkType: hard
+
+"pdf-lib@npm:1.17.1":
+  version: 1.17.1
+  resolution: "pdf-lib@npm:1.17.1"
+  dependencies:
+    "@pdf-lib/standard-fonts": "npm:^1.0.0"
+    "@pdf-lib/upng": "npm:^1.0.1"
+    pako: "npm:^1.0.11"
+    tslib: "npm:^1.11.1"
+  checksum: 10/ea8c2c0c813d89ca359a0c831cb2e8a581c569ed44b074316f917942b5baa101f878ce922f1cb87e6f41a035008ba75b52267480aee5d65a5e68c445ee83bc37
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
This PR introduces a change to render and send tickets and certificates as pdfs rather than pngs.


# Issues
Fixes #12964
Refs #12964

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread