### PR TITLE
feature(unlock-app): Real-time metadata previews/renders on certificates

### DIFF
--- a/packages/ui/lib/components/Certificate/Certificate.tsx
+++ b/packages/ui/lib/components/Certificate/Certificate.tsx
@@ -19,6 +19,10 @@ interface CertificateProps {
   transactionsHash?: ReactNode
   externalUrl?: string
   isMobile?: boolean
+  customMetadata?: Array<{
+    trait_type: string
+    value: string | number | ReactNode
+  }>
 }
 
 interface Props {
@@ -133,6 +137,7 @@ export const Certificate = ({
   image,
   networkName,
   isMobile = false,
+  customMetadata = [],
 }: CertificateProps) => {
   const networkNameById = networks[network]?.name
 
@@ -221,6 +226,26 @@ export const Certificate = ({
                 </div>
               )}
             </div>
+
+            {customMetadata.length > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: isMobile ? 'column' : 'row',
+                  justifyContent: 'flex-start',
+                  gap: isMobile ? '16px' : '8px',
+                  marginTop: '24px',
+                  flexWrap: 'wrap',
+                }}
+              >
+                {customMetadata.map((attribute, index) => (
+                  <ValueWrapper key={index}>
+                    <CertificateLabel>{attribute.trait_type}</CertificateLabel>
+                    <CertificateValue>{attribute.value}</CertificateValue>
+                  </ValueWrapper>
+                ))}
+              </div>
+            )}
           </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/unlock-app/src/components/content/certification/CertificationPreview.tsx
+++ b/unlock-app/src/components/content/certification/CertificationPreview.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import Link from 'next/link'
+import { useMetadata } from '~/hooks/metadata'
+import { toFormData } from '~/components/interface/locks/metadata/utils'
+import { Icon, Placeholder, Certificate } from '@unlock-protocol/ui'
+import ReactMarkdown from 'react-markdown'
+import { RiExternalLinkLine as ExternalLinkIcon } from 'react-icons/ri'
+import { networks } from '@unlock-protocol/networks'
+import { addressMinify } from '~/utils/strings'
+import { expirationAsDate } from '~/utils/durations'
+import { MAX_UINT } from '~/constants'
+import LinkedinShareButton from './LinkedInShareButton'
+import { useCertification } from '~/hooks/useCertification'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
+
+interface CertificationPreviewProps {
+  lockAddress?: string
+  network?: number
+  tokenId?: string
+  expiration?: string | number
+}
+
+export const CertificationPreviewContent = ({
+  lockAddress,
+  network,
+  tokenId,
+}: CertificationPreviewProps) => {
+  const { account } = useAuthenticate()
+
+  // Get the metadata for the certification
+  const { data: metadata, isLoading: isMetadataLoading } = useMetadata({
+    lockAddress: lockAddress!,
+    network: network!,
+    keyId: tokenId!,
+  })
+
+  const { data: certification } = useCertification({
+    lockAddress: lockAddress!,
+    network: network!,
+    tokenId: tokenId!,
+  })
+
+  const loading = isMetadataLoading
+
+  // Show loading state while metadata is loading
+  if (loading) {
+    return (
+      <Placeholder.Root className="mt-8">
+        <Placeholder.Line size="sm" />
+        <Placeholder.Line size="sm" />
+        <Placeholder.Image className="h-[600px] w-full"></Placeholder.Image>
+        <Placeholder.Root>
+          <div className="flex justify-center gap-6">
+            <Placeholder.Image className="w-9 h-9" />
+            <Placeholder.Image className="w-9 h-9" />
+          </div>
+        </Placeholder.Root>
+      </Placeholder.Root>
+    )
+  }
+
+  const certificationData = toFormData(metadata!)
+
+  const transactionsHash: string = certification?.transactionsHash?.[0] || '22'
+
+  const isPlaceholderData = certification?.tokenId === '#'
+
+  const hasValidKey =
+    (certification && !isPlaceholderData) ||
+    (isPlaceholderData && !certification)
+
+  const TransactionHashButton = () => {
+    return (
+      <>
+        {isPlaceholderData ? (
+          transactionsHash
+        ) : (
+          <Link
+            className="flex items-center gap-2 hover:text-brand-ui-primary"
+            target="_blank"
+            rel="noreferrer"
+            href={
+              networks[network!].explorer?.urls?.transaction(
+                transactionsHash
+              ) || '#'
+            }
+          >
+            <span>{addressMinify(transactionsHash)}</span>
+            <Icon icon={ExternalLinkIcon} size={18} />
+          </Link>
+        )}
+      </>
+    )
+  }
+
+  const viewerIsOwner =
+    account?.toLowerCase() === certification?.owner?.toLowerCase()
+  const issuer = certificationData?.certification
+    ?.certification_issuer as string
+
+  const canShare = viewerIsOwner && certification && !isPlaceholderData
+
+  const showCertification = certification || (tokenId && certification)
+
+  const showExpiration = certification?.expiration !== MAX_UINT
+
+  const expiration = isPlaceholderData
+    ? certification?.expiration
+    : expirationAsDate(certification?.expiration)
+
+  const isMobile = window?.innerWidth < 768
+
+  // Get all custom metadata that aren't `minted` or `certification_issuer`
+
+  const customMetadata =
+    metadata?.attributes?.filter(
+      (attr: any) =>
+        attr.trait_type !== 'Minted' &&
+        attr.trait_type !== 'certification_issuer' &&
+        attr.trait_type &&
+        attr.value
+    ) || []
+
+  const certificateProps = {
+    tokenId: certification?.tokenId,
+    network: network!,
+    name: certificationData.name,
+    description: (
+      <ReactMarkdown>{certificationData?.description as string}</ReactMarkdown>
+    ),
+    image: certificationData?.image as string,
+    lockAddress: lockAddress!,
+    badge: isPlaceholderData ? (
+      <span className="text-xl">Preview</span>
+    ) : undefined,
+    issuer,
+    owner: !hasValidKey
+      ? certification?.owner
+      : addressMinify(certification?.owner),
+    expiration: showExpiration ? expiration : undefined,
+    transactionsHash: <TransactionHashButton />,
+    externalUrl: certificationData.external_url,
+    isMobile,
+    ...customMetadata,
+  }
+
+  return (
+    <main className="mt-8">
+      <div className="flex flex-col gap-6">
+        {showCertification && <Certificate {...certificateProps} />}
+
+        {canShare && (
+          <ul className="flex gap-4 mx-auto">
+            <li>
+              <LinkedinShareButton
+                metadata={metadata!}
+                lockAddress={lockAddress!}
+                network={network!}
+                tokenId={certification?.tokenId}
+              />
+            </li>
+          </ul>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/unlock-app/src/config/queryClient.ts
+++ b/unlock-app/src/config/queryClient.ts
@@ -58,7 +58,6 @@ export const queryClient = new QueryClient({
 })
 if (typeof window !== 'undefined') {
   window.addEventListener('locksmith.authenticated', async () => {
-    console.log('refetching queries')
     queryClient.refetchQueries()
   })
 }

--- a/unlock-app/src/hooks/useCertification.ts
+++ b/unlock-app/src/hooks/useCertification.ts
@@ -57,7 +57,8 @@ export const useCertification = ({
         if (key) {
           return key
         }
-        throw new Error('No valid certification for this token')
+        console.error('No valid certification for this token')
+        return placeholderData
       }
       return placeholderData
     },


### PR DESCRIPTION
# Description
This PR introduces support for real-time visibility of custom certificate metadata by lock managers. When metadata is added to a certificate, it now immediately reflects on the certificate UI, streamlining updates and verification.

## ScreenGrabs
![Screenshot 2025-03-24 at 10 21 08](https://github.com/user-attachments/assets/bdab5413-ecba-4f5f-bf01-465d41574766)

![Screenshot 2025-03-24 at 10 21 50](https://github.com/user-attachments/assets/01f16171-ee04-495b-83e6-009ee96ec365)


# Issues
Fixes #15485
Refs #15485

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread