### PR TITLE
feature(unlock-app): Certification preview page with token ID support

### DIFF
--- a/unlock-app/app/certification/[...slug]/page.tsx
+++ b/unlock-app/app/certification/[...slug]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from 'next/navigation'
+import { CertificationPreviewContent } from '~/components/content/certification/CertificationPreview'
+import { locksmith } from '~/config/locksmith'
+
+export interface CertificationPreviewPageProps {
+  params: {
+    slug: string[]
+  }
+}
+
+const CertificationPreviewPage = async ({
+  params,
+}: CertificationPreviewPageProps) => {
+  const [certSlug, tokenId] = params.slug
+
+  let lockAddress, network
+
+  try {
+    const certificationDetail = await locksmith.getLockSettingsBySlug(certSlug)
+
+    // Extract the data from certificationDetail response
+    if (certificationDetail?.data) {
+      lockAddress = certificationDetail.data.lockAddress
+      network = certificationDetail.data.network
+    }
+  } catch (err) {
+    console.error('Error fetching certificate by slug:', err)
+  }
+
+  // If we have both needed values, show the certificate
+  if (lockAddress && network) {
+    return (
+      <CertificationPreviewContent
+        lockAddress={lockAddress}
+        network={network}
+        tokenId={tokenId}
+      />
+    )
+  }
+
+  // Otherwise direct to a 404 page
+  notFound()
+}
+
+export default CertificationPreviewPage

--- a/unlock-app/src/components/content/certification/CertificationPreview.tsx
+++ b/unlock-app/src/components/content/certification/CertificationPreview.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import Link from 'next/link'
+import { useMetadata } from '~/hooks/metadata'
+import { toFormData } from '~/components/interface/locks/metadata/utils'
+import { Icon, Placeholder, Certificate } from '@unlock-protocol/ui'
+import ReactMarkdown from 'react-markdown'
+import { RiExternalLinkLine as ExternalLinkIcon } from 'react-icons/ri'
+import { networks } from '@unlock-protocol/networks'
+import { addressMinify } from '~/utils/strings'
+import { expirationAsDate } from '~/utils/durations'
+import { MAX_UINT } from '~/constants'
+import LinkedinShareButton from './LinkedInShareButton'
+import { useCertification } from '~/hooks/useCertification'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
+
+interface CertificationPreviewProps {
+  lockAddress?: string
+  network?: number
+  tokenId?: string
+  expiration?: string | number
+}
+
+export const CertificationPreviewContent = ({
+  lockAddress,
+  network,
+  tokenId,
+}: CertificationPreviewProps) => {
+  const { account } = useAuthenticate()
+
+  // Get the metadata for the certification
+  const { data: metadata, isLoading: isMetadataLoading } = useMetadata({
+    lockAddress: lockAddress!,
+    network: network!,
+    keyId: tokenId!,
+  })
+
+  const { data: certification } = useCertification({
+    lockAddress: lockAddress!,
+    network: network!,
+    tokenId: tokenId!,
+  })
+
+  const loading = isMetadataLoading
+
+  // Show loading state while metadata is loading
+  if (loading) {
+    return (
+      <Placeholder.Root className="mt-8">
+        <Placeholder.Line size="sm" />
+        <Placeholder.Line size="sm" />
+        <Placeholder.Image className="h-[600px] w-full"></Placeholder.Image>
+        <Placeholder.Root>
+          <div className="flex justify-center gap-6">
+            <Placeholder.Image className="w-9 h-9" />
+            <Placeholder.Image className="w-9 h-9" />
+          </div>
+        </Placeholder.Root>
+      </Placeholder.Root>
+    )
+  }
+
+  const certificationData = toFormData(metadata!)
+
+  const transactionsHash: string = certification?.transactionsHash?.[0] || '22'
+
+  const isPlaceholderData = certification?.tokenId === '#'
+
+  const hasValidKey =
+    (certification && !isPlaceholderData) ||
+    (isPlaceholderData && !certification)
+
+  const TransactionHashButton = () => {
+    return (
+      <>
+        {isPlaceholderData ? (
+          transactionsHash
+        ) : (
+          <Link
+            className="flex items-center gap-2 hover:text-brand-ui-primary"
+            target="_blank"
+            rel="noreferrer"
+            href={
+              networks[network!].explorer?.urls?.transaction(
+                transactionsHash
+              ) || '#'
+            }
+          >
+            <span>{addressMinify(transactionsHash)}</span>
+            <Icon icon={ExternalLinkIcon} size={18} />
+          </Link>
+        )}
+      </>
+    )
+  }
+
+  const viewerIsOwner =
+    account?.toLowerCase() === certification?.owner?.toLowerCase()
+  const issuer = certificationData?.certification
+    ?.certification_issuer as string
+
+  const canShare = viewerIsOwner && certification && !isPlaceholderData
+
+  const showCertification = certification || (tokenId && certification)
+
+  const showExpiration = certification?.expiration !== MAX_UINT
+
+  const expiration = isPlaceholderData
+    ? certification?.expiration
+    : expirationAsDate(certification?.expiration)
+
+  const isMobile = window?.innerWidth < 768
+
+  // Get all custom metadata that aren't `minted` or `certification_issuer`
+  const customMetadata =
+    metadata?.attributes?.filter(
+      (attr: any) =>
+        attr.trait_type !== 'Minted' &&
+        attr.trait_type !== 'certification_issuer' &&
+        attr.trait_type &&
+        attr.value
+    ) || []
+
+  const certificateProps = {
+    tokenId: certification?.tokenId,
+    network: network!,
+    name: certificationData.name,
+    description: (
+      <ReactMarkdown>{certificationData?.description as string}</ReactMarkdown>
+    ),
+    image: certificationData?.image as string,
+    lockAddress: lockAddress!,
+    badge: isPlaceholderData ? (
+      <span className="text-xl">Preview</span>
+    ) : undefined,
+    issuer,
+    owner: !hasValidKey
+      ? certification?.owner
+      : addressMinify(certification?.owner),
+    expiration: showExpiration ? expiration : undefined,
+    transactionsHash: <TransactionHashButton />,
+    externalUrl: certificationData.external_url,
+    isMobile,
+    customMetadata,
+  }
+
+  return (
+    <main className="mt-8">
+      <div className="flex flex-col gap-6">
+        {showCertification && <Certificate {...certificateProps} />}
+
+        {canShare && (
+          <ul className="flex gap-4 mx-auto">
+            <li>
+              <LinkedinShareButton
+                metadata={metadata!}
+                lockAddress={lockAddress!}
+                network={network!}
+                tokenId={certification?.tokenId}
+              />
+            </li>
+          </ul>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/unlock-app/src/hooks/useCertification.ts
+++ b/unlock-app/src/hooks/useCertification.ts
@@ -58,22 +58,6 @@ export const useCertification = ({
           return key
         }
         throw new Error('No valid certification for this token')
-      } else if (account) {
-        // Get the certification for the current user
-        const key = await graphService.key(
-          {
-            where: {
-              owner: account.toLowerCase(),
-              lock_in: [lockAddress.toLowerCase()],
-            },
-          },
-          {
-            network,
-          }
-        )
-        if (key) {
-          return key
-        }
       }
       return placeholderData
     },


### PR DESCRIPTION
# Description
This PR introduces a preview page for certifications. If a token ID is present in the slug, it renders the certificate for that specific token. If not, it defaults to a generic preview with placeholder data.

# ScreenGrab

- without token id
![Screenshot 2025-03-24 at 10 12 32](https://github.com/user-attachments/assets/4365bb03-5945-48cf-9907-b1c29b7cc1ea)

- with token id
![Screenshot 2025-03-24 at 10 13 33](https://github.com/user-attachments/assets/e5dd3edf-5f6b-4316-8a3e-cbe0aac0b843)


# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread


## Release Note Draft Snippet

<!--

If relevant, please write a summary of your change that will be suitable for inclusion in the Release Notes for the next Unlock release.

-->
