### PR TITLE
feature(unlock-app): Update LinkedIn share link to use actual certificate URL

### DIFF
--- a/locksmith/__tests__/utils/certificationHelper.test.ts
+++ b/locksmith/__tests__/utils/certificationHelper.test.ts
@@ -1,8 +1,13 @@
-import { it, expect } from 'vitest'
+import { it, expect, vi, describe } from 'vitest'
 import { getCertificateLinkedinShareUrl } from '../../src/utils/certificationHelpers'
 
-const lockAddress = '0xDd4356111193f7B28A20b5FC2Dc7750c249E55d2'
-const network = 10
+// Mock the config module
+vi.mock('../../src/config/config', () => ({
+  default: {
+    unlockApp: 'https://mock-app.unlock-protocol.com',
+  },
+}))
+
 const tokenId = '2'
 
 const metadata = {
@@ -22,13 +27,11 @@ describe('getCertificateLinkedinShareUrl', () => {
   it('create correct linkedin share url with slug', () => {
     expect.assertions(1)
     const url = getCertificateLinkedinShareUrl({
-      lockAddress,
-      network,
       tokenId,
       metadata,
     })
     expect(url).toBe(
-      'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Example+with+metadata&organizationName=UnlockProcol+-+Demo&certUrl=https%3A%2F%2Fstaging-app.unlock-protocol.com%2Fcertification%3Fs%3Dtest-demo&certId=2'
+      'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Example+with+metadata&organizationName=UnlockProcol+-+Demo&certUrl=https%3A%2F%2Fmock-app.unlock-protocol.com%2Fcertification%2Ftest-demo&certId=2'
     )
   })
 })

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -443,8 +443,6 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
         network
       )
       const certificationUrl = getCertificateLinkedinShareUrl({
-        lockAddress,
-        network,
         tokenId,
         metadata: keyData,
       })

--- a/locksmith/src/utils/certificationHelpers.ts
+++ b/locksmith/src/utils/certificationHelpers.ts
@@ -2,34 +2,28 @@ import { toFormData } from '@unlock-protocol/core'
 import config from '../config/config'
 
 interface LinkedinShareProps {
-  lockAddress: string
-  network: number
   tokenId: string
   metadata: any
 }
 
 const getCertificationPath = ({
   metadata,
-  lockAddress,
-  network,
   tokenId,
 }: LinkedinShareProps): string => {
   const slug = metadata?.slug
 
   if (slug) {
-    return `${config.unlockApp}/certification?s=${slug}`
+    return `${config.unlockApp}/certification/${slug}`
   }
 
   if (tokenId) {
-    return `${config.unlockApp}/certification?lockAddress=${lockAddress}&network=${network}&tokenId=${tokenId}`
+    return `${config.unlockApp}/certification/${slug}/${tokenId}`
   }
 
-  return `${config.unlockApp}/certification?lockAddress=${lockAddress}&network=${network}`
+  return `${config.unlockApp}/certification/${slug}`
 }
 
 export const getCertificateLinkedinShareUrl = ({
-  lockAddress,
-  network,
   tokenId,
   metadata,
 }: LinkedinShareProps): string | null => {
@@ -37,8 +31,6 @@ export const getCertificateLinkedinShareUrl = ({
 
   const certificationUrl = getCertificationPath({
     metadata,
-    lockAddress,
-    network,
     tokenId,
   })
 

--- a/unlock-app/src/components/content/certification/utils.tsx
+++ b/unlock-app/src/components/content/certification/utils.tsx
@@ -9,19 +9,17 @@ interface CertificationUrlProps {
 
 export const getCertificationPath = ({
   metadata,
-  lockAddress,
-  network,
   tokenId,
 }: CertificationUrlProps): string => {
   const slug = metadata?.slug
 
   if (slug) {
-    return `/certification?s=${slug}`
+    return `/certification/${slug}`
   }
 
   if (tokenId) {
-    return `/certification?lockAddress=${lockAddress}&network=${network}&tokenId=${tokenId}`
+    return `/certification/${slug}/${tokenId}`
   }
 
-  return `/certification?lockAddress=${lockAddress}&network=${network}`
+  return `/certification/${slug}`
 }


### PR DESCRIPTION
# Description
This PR introduces a fix to ensure the LinkedIn share link and that in the certification email notifications points to the recipient’s actual certificate, replacing the incorrect placeholder URL.

## ScreenGrab
![Screenshot 2025-03-24 at 18 19 53](https://github.com/user-attachments/assets/aa1803fb-8434-47f1-aba4-bdda710d0110)


# Issues
Fixes #15523
Refs #15523

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread