### PR TITLE
feature(unlock-app): Add `checkbox` metadata input type to checkout

### DIFF
--- a/docs/docs/tools/checkout/collecting-metadata.md
+++ b/docs/docs/tools/checkout/collecting-metadata.md
@@ -24,7 +24,7 @@ The members of this array should have the following shape:
 ```bash
 {
   name: string,
-  type: 'text' | 'date' | 'color' | 'email' | 'url' | 'hidden',
+  type: 'text' | 'date' | 'color' | 'email' | 'url' | 'hidden' | 'checkbox',
   required: boolean,
   defaultValue?: 'string',
   value?: 'string',
@@ -100,6 +100,13 @@ only really useful if the checkout config is built in a dynamic way.
           "type":"url",
           "required":false,
           "placeholder":"https://example-url.com",
+          "public":false
+       },
+       {
+          "name":"Subscribe to our mailing list",
+          "defaultValue":"false",
+          "type":"checkbox",
+          "required":false,
           "public":false
        }
     ]

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod'
 
 export const MetadataInput = z.object({
-  type: z.enum(['text', 'date', 'color', 'email', 'url', 'hidden'], {
-    description:
-      'The type field maps to a certain subset of HTML <input> types, which influences how the form renders. ',
-  }),
+  type: z.enum(
+    ['text', 'date', 'color', 'email', 'url', 'hidden', 'checkbox'],
+    {
+      description:
+        'The type field maps to a certain subset of HTML <input> types, which influences how the form renders. ',
+    }
+  ),
   name: z
     .string({
       description: 'Name of the attribute to collect.',

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -86,6 +86,7 @@ export const MetadataInputs = ({
   const {
     register,
     setValue,
+    control,
     formState: { errors },
   } = useFormContext<FormData>()
   const networkConfig = config.networks[lock.network]
@@ -286,15 +287,25 @@ export const MetadataInputs = ({
           // Handle checkbox type
           if (type === 'checkbox') {
             return (
-              <Checkbox
+              <Controller
                 key={name}
-                label={inputLabel}
-                disabled={disabled}
-                error={errors?.metadata?.[id]?.[name]?.message}
-                {...register(`metadata.${id}.${name}`, {
+                name={`metadata.${id}.${name}`}
+                control={control}
+                rules={{
                   required: required && `${inputLabel} is required`,
-                })}
-                defaultChecked={defaultValue === 'true' ? true : false}
+                }}
+                defaultValue={defaultValue === 'true' ? 'true' : 'false'}
+                render={({ field }) => (
+                  <Checkbox
+                    label={inputLabel}
+                    disabled={disabled}
+                    error={errors?.metadata?.[id]?.[name]?.message}
+                    checked={field.value === 'true'}
+                    onChange={(e) =>
+                      field.onChange(e.target.checked ? 'true' : 'false')
+                    }
+                  />
+                )}
               />
             )
           }

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -20,6 +20,7 @@ import {
   Input,
   Placeholder,
   isAddressOrEns,
+  Toggle,
 } from '@unlock-protocol/ui'
 import { twMerge } from 'tailwind-merge'
 import { formResultToMetadata } from '~/utils/userMetadata'
@@ -32,7 +33,6 @@ import { useQuery } from '@tanstack/react-query'
 import { Lock } from '~/unlockTypes'
 import { KeyManager } from '@unlock-protocol/unlock-js'
 import { useConfig } from '~/utils/withConfig'
-import { Toggle } from '@unlock-protocol/ui'
 import {
   MetadataInputType as MetadataInput,
   PaywallConfigType,
@@ -160,7 +160,7 @@ export const MetadataInputs = ({
                 <div className="w-32 text-sm truncate">{recipient}</div>
                 <Button
                   type="button"
-                  onClick={(event) => {
+                  onClick={(event: React.MouseEvent) => {
                     event.preventDefault()
                     setHideRecipientAddress(false)
                   }}
@@ -209,7 +209,7 @@ export const MetadataInputs = ({
                         <div className="text-sm">No wallet address?</div>
                         <Toggle
                           value={useEmail}
-                          onChange={(value) => {
+                          onChange={(value: boolean) => {
                             setUseEmail(value)
                           }}
                           size="small"
@@ -270,13 +270,32 @@ export const MetadataInputs = ({
                   <div className="w-32 text-sm truncate">{email}</div>
                   <Button
                     type="button"
-                    onClick={() => setHideEmailInput(false)}
+                    onClick={(event: React.MouseEvent) => {
+                      event.preventDefault()
+                      setHideEmailInput(false)
+                    }}
                     size="tiny"
                   >
                     Change
                   </Button>
                 </div>
               </div>
+            )
+          }
+
+          // Handle checkbox type
+          if (type === 'checkbox') {
+            return (
+              <Checkbox
+                key={name}
+                label={inputLabel}
+                disabled={disabled}
+                error={errors?.metadata?.[id]?.[name]?.message}
+                {...register(`metadata.${id}.${name}`, {
+                  required: required && `${inputLabel} is required`,
+                })}
+                defaultChecked={defaultValue === 'true' ? true : false}
+              />
             )
           }
 

--- a/unlock-app/src/utils/checkoutValidators.js
+++ b/unlock-app/src/utils/checkoutValidators.js
@@ -396,7 +396,15 @@ export const isValidBalance = (balance) => {
   }, true)
 }
 
-const allowedInputTypes = ['text', 'date', 'color', 'email', 'url', 'hidden']
+const allowedInputTypes = [
+  'text',
+  'date',
+  'color',
+  'email',
+  'url',
+  'hidden',
+  'checkbox',
+]
 
 /**
  * A valid metadata field looks like:


### PR DESCRIPTION
# Description
This PR introduces support for a new `checkbox` metadata type in the checkout flow. Checkbox fields can now be defined with a name, label, and required flag. When marked as required, the checkbox must be checked to proceed with checkout. This feature is integrated with the checkout builder and surfaces correctly in the dashboard for lock managers. The docs have also been updated accordingly.


## ScreenGrabs
- metadata collection setup in checkout builder
![Screenshot 2025-03-24 at 19 33 44](https://github.com/user-attachments/assets/ea55c6b7-5ba4-4928-b5ea-5305d54b1252)

- successful validation
![Screenshot 2025-03-24 at 19 14 45](https://github.com/user-attachments/assets/ddbc1ad9-8db7-44ca-9dfe-94008691d5a8)


- failed validation
![Screenshot 2025-03-24 at 19 14 10](https://github.com/user-attachments/assets/4f5baef4-6989-4a19-9597-30b41ec99538)

- lock manager view
![Screenshot 2025-03-24 at 19 30 08](https://github.com/user-attachments/assets/e4e333ab-a836-48dc-b733-26209ddfdbe1)



# Issues
Fixes #15746
Refs #15746

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread