### PR TITLE
feature(unlock-app): Update conditional rendering for email template settings

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ZeroAddress } from 'ethers'
 
 const LockTypeSchema = z.object({
   isEvent: z.boolean().default(false),
@@ -22,3 +23,36 @@ export const getLockTypeByMetadata = (metadata?: any): LockType => {
   }
 }
 export type LockType = z.infer<typeof LockTypeSchema>
+
+/**
+ * Determines if a lock is a subscription-type lock
+ * @param lock - The lock object
+ * @returns boolean - True if the lock is a subscription
+ */
+export const isLockForSub = (
+  lock:
+    | {
+        keyPrice?: string
+        currencyContractAddress?: string | null
+        expirationDuration?: number
+      }
+    | null
+    | undefined
+): boolean => {
+  if (!lock) return false
+
+  const isFree = Number(lock?.keyPrice) === 0
+  const isNative =
+    !lock?.currencyContractAddress ||
+    lock.currencyContractAddress === ZeroAddress
+  const isExpiring =
+    typeof lock.expirationDuration === 'number' &&
+    lock.expirationDuration !== -1 &&
+    lock.expirationDuration < 60 * 60 * 24 * 365 * 100
+
+  if (isFree || isNative || !isExpiring) {
+    return false
+  }
+
+  return true
+}

--- a/unlock-app/src/hooks/useLockData.ts
+++ b/unlock-app/src/hooks/useLockData.ts
@@ -36,6 +36,7 @@ export const useLockData = ({ lockAddress, network }: Options) => {
       }
     },
     refetchInterval: false,
+    enabled: !!lockAddress && !!network,
   })
   return {
     lock,


### PR DESCRIPTION
# Description
This PR introduces logic to conditionally render the subscription reminder email template setting only for subscription-based locks. Locks tied to events or certifications will no longer display this setting.



## ScreenGrabs
- email settings view for a subscription lock

![Screenshot 2025-03-25 at 15 52 17](https://github.com/user-attachments/assets/762b4dce-eaf9-4811-b9b7-3bb9c7f41914)

- email settings view for a non-subscription lock

![Screenshot 2025-03-25 at 15 53 02](https://github.com/user-attachments/assets/0bd986d4-2636-4595-aad2-f7dc90878707)


# Issues
Fixes #15718
Refs #15718

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread