### PR TITLE
fix(unlock-app): Fix stuck minting screen on event page

### DIFF
--- a/unlock-app/src/components/content/event/Registration/WalletlessRegistration.tsx
+++ b/unlock-app/src/components/content/event/Registration/WalletlessRegistration.tsx
@@ -14,6 +14,7 @@ import { useRsvp } from '~/hooks/useRsvp'
 import { useReCaptcha } from 'next-recaptcha-v3'
 import { useMutation } from '@tanstack/react-query'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { useWeb3Service } from '~/utils/withWeb3Service'
 
 interface WalletlessRegistrationProps {
   lockAddress: string
@@ -37,8 +38,34 @@ const WalletlessRegistrationClaiming = ({
 }: WalletlessRegistrationProps) => {
   const [transactionStatus, setTransactionStatus] =
     useState<TransactionStatus>('PROCESSING')
-
+  const [tokenId, setTokenId] = useState<string | null>(null)
   const config = useConfig()
+  const web3Service = useWeb3Service()
+
+  // Wait for token ID
+  const waitForTokenId = async (owner: string): Promise<string | null> => {
+    try {
+      const latestTokenId = await web3Service.latestTokenOfOwner(
+        lockAddress,
+        owner,
+        network
+      )
+
+      if (latestTokenId) {
+        return latestTokenId.toString()
+      }
+
+      // If no token found, we'll retry in a second
+      return new Promise((resolve) => {
+        setTimeout(async () => {
+          resolve(await waitForTokenId(owner))
+        }, 1000)
+      })
+    } catch (error) {
+      console.error('Error fetching token ID:', error)
+      return null
+    }
+  }
 
   useEffect(() => {
     if (
@@ -47,6 +74,7 @@ const WalletlessRegistrationClaiming = ({
     ) {
       return
     }
+
     const waitForConfirmation = async () => {
       const provider = new ethers.JsonRpcProvider(
         config.networks[network].provider
@@ -62,10 +90,26 @@ const WalletlessRegistrationClaiming = ({
       } else {
         setTransactionStatus('FINISHED')
         ToastHelper.success('🎉 You have been added to the attendees list!')
+
+        // After successful transaction, fetch the tokenId
+        if (claimResult.owner) {
+          const newTokenId = await waitForTokenId(claimResult.owner)
+          if (newTokenId) {
+            setTokenId(newTokenId)
+          }
+        }
       }
     }
     waitForConfirmation()
-  }, [transactionStatus, network, claimResult?.hash, config.networks])
+  }, [
+    transactionStatus,
+    network,
+    claimResult?.hash,
+    claimResult?.owner,
+    config.networks,
+    lockAddress,
+    web3Service,
+  ])
 
   return (
     <div className="flex flex-col items-center justify-center h-full">
@@ -82,6 +126,7 @@ const WalletlessRegistrationClaiming = ({
             lockName={''}
             lockAddress={lockAddress}
             network={network}
+            tokenId={tokenId}
             states={{
               PROCESSING: {
                 text: 'Creating your ticket...',
@@ -133,6 +178,7 @@ export const WalletlessRegistrationClaim = ({
         metadata: data,
         captcha,
       })
+
       if (message) {
         ToastHelper.error(message)
         return

--- a/unlock-app/src/components/interface/checkout/Shell.tsx
+++ b/unlock-app/src/components/interface/checkout/Shell.tsx
@@ -84,8 +84,13 @@ export function TopNavigation({ onClose }: NavigationProps) {
   )
 }
 
-export function TransactionAnimation({ status }: Partial<Transaction>) {
-  const animationClass = 'w-28 sm:w-36 h-28 sm:h-36'
+export function TransactionAnimation({
+  status,
+  isCompact,
+}: Partial<Transaction> & { isCompact?: boolean }) {
+  const animationClass = isCompact
+    ? 'w-20 sm:w-24 h-20 sm:h-24'
+    : 'w-28 sm:w-36 h-28 sm:h-36'
   switch (status) {
     case 'PROCESSING':
       return (

--- a/unlock-app/src/components/interface/checkout/main/Minting.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Minting.tsx
@@ -60,7 +60,7 @@ export const MintingScreen = ({
 
   return (
     <div className="flex flex-col items-center justify-evenly h-full space-y-2">
-      <TransactionAnimation status={status} />
+      <TransactionAnimation status={status} isCompact={isCompact} />
       {mint?.transactionHash && (
         <a
           href={config.networks[transactionNetwork].explorer.urls.transaction(
@@ -72,7 +72,7 @@ export const MintingScreen = ({
         >
           <p
             className={`text-lg font-bold text-brand-ui-primary inline-flex items-center gap-2 ${
-              isCompact ? 'text-base text-center' : 'text-lg'
+              isCompact ? 'text-sm text-center' : 'text-lg'
             }`}
           >
             {/* 
@@ -102,6 +102,7 @@ export const MintingScreen = ({
           network={network}
           lockAddress={lockAddress}
           tokenId={tokenId.toString()}
+          isCompact={isCompact}
         />
       )}
     </div>

--- a/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
+++ b/unlock-app/src/components/interface/keychain/AddToPhoneWallet.tsx
@@ -1,4 +1,4 @@
-import { Box, Size } from '@unlock-protocol/ui'
+import { Box } from '@unlock-protocol/ui'
 import {
   generateAppleWalletPass,
   generateGoogleWalletPass,
@@ -17,7 +17,7 @@ interface AddToWalletProps {
   disabled?: boolean
   active?: boolean
   iconLeft?: JSX.Element
-  size?: Size
+  size?: 'small' | 'medium'
   variant?: string
   className?: string
 }
@@ -29,6 +29,7 @@ export const AddToPhoneWallet = ({
   network,
   handlePassUrl,
   platform,
+  size = 'medium',
   ...rest
 }: AddToWalletProps) => {
   const walletConfig = {
@@ -50,6 +51,11 @@ export const AddToPhoneWallet = ({
 
   const config = walletConfig[platform]
 
+  const imageDimensions = {
+    small: { width: 150, height: 12 },
+    medium: { width: 200, height: 16 },
+  } as const
+
   const handleClick = async () => {
     const generate = async () => {
       const passUrl = await config.generatePass(lockAddress, network, tokenId)
@@ -66,7 +72,11 @@ export const AddToPhoneWallet = ({
   }
   return (
     <Box as={as} {...rest} onClick={handleClick}>
-      <Image width="200" height="16" alt={config.altText} src={config.imgSrc} />
+      <Image
+        {...imageDimensions[size]}
+        alt={config.altText}
+        src={config.imgSrc}
+      />
     </Box>
   )
 }

--- a/unlock-app/src/components/interface/keychain/AddToWallet.tsx
+++ b/unlock-app/src/components/interface/keychain/AddToWallet.tsx
@@ -7,16 +7,22 @@ interface AddToWallet {
   network: number
   lockAddress: string
   tokenId: string
+  isCompact?: boolean
 }
 
-export const AddToWallet = ({ network, lockAddress, tokenId }: AddToWallet) => {
+export const AddToWallet = ({
+  network,
+  lockAddress,
+  tokenId,
+  isCompact,
+}: AddToWallet) => {
   return (
     <div className="w-full flex items-center justify-center px-4 py-1 gap-4">
       {!isIOS && (
         <AddToPhoneWallet
-          className="bg-transparent px-0 py-0 "
+          className="bg-transparent px-0 py-0"
           platform={Platform.GOOGLE}
-          size="medium"
+          size={isCompact ? 'small' : 'medium'}
           variant="secondary"
           as={Button}
           network={network}
@@ -29,9 +35,9 @@ export const AddToWallet = ({ network, lockAddress, tokenId }: AddToWallet) => {
       )}
       {!isAndroid && (
         <AddToPhoneWallet
-          className="bg-transparent px-0 py-0 "
+          className="bg-transparent px-0 py-0"
           platform={Platform.APPLE}
-          size="medium"
+          size={isCompact ? 'small' : 'medium'}
           variant="secondary"
           as={Button}
           network={network}


### PR DESCRIPTION
# Description
This PR introduces a fix for a bug where the ticket minting screen remained stuck on the “minting” status after a successful mint. The flow now correctly progresses, allowing users to add the ticket to their Apple/Google Wallet and close the screen post-mint.


## ScreenGrabs
<img width="443" alt="Screenshot 2025-03-26 at 11 52 13" src="https://github.com/user-attachments/assets/ab965eef-e73e-4306-b4d8-2ae2327bd554" />
<img width="439" alt="Screenshot 2025-03-26 at 11 52 22" src="https://github.com/user-attachments/assets/d8837a77-c3f5-4f68-88ef-ff022cdb1b23" />



# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [x] If my code involves visual changes, I am adding applicable screenshots to this thread