### PR TITLE
fix(unlock-app): Increase concurrent subgraph requests limit

### DIFF
--- a/unlock-app/src/config/subgraph.ts
+++ b/unlock-app/src/config/subgraph.ts
@@ -1,8 +1,8 @@
 import { SubgraphService } from '@unlock-protocol/unlock-js'
 import pLimit from 'p-limit'
 
-// Use a limit of 2 to balance performance and request flooding prevention
-const limit = pLimit(2)
+// using a limit of 5 to balance performance and request flooding prevention
+const limit = pLimit(5)
 
 export const graphService = new SubgraphService({
   graphqlClientOptions: {


### PR DESCRIPTION
# Description
This PR introduces an update that increases the subgraph request concurrency from 2 to 5, addressing dashboard performance issues when listing user locks.

# Issues
Fixes #
Refs #

# Checklist:
- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the docs to reflect my changes if applicable
- [ ] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread