### PR TITLE
Fix renewal balance check and approval logic for accurate user feedback

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -86,7 +86,8 @@
     "maximevtush",
     "polytur",
     "arionrefat",
-    "kalidatony"
+    "kalidatony",
+    "austineblaise"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "
 }

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -66,7 +66,10 @@ const MembershipRenewal = ({
   const possible = BigInt(possibleRenewals)
   const approved = BigInt(approvedRenewals)
 
-  if (possible >= 0) {
+  const insufficientBalance = possible === BigInt(0) && approved > BigInt(0)
+  const insufficientApproval = approved === BigInt(0)
+
+  if (insufficientBalance) {
     return (
       <Detail className="py-2" label="Renewals:" inline justify={false}>
         User balance of {balance.amount} {balance.symbol} is too low to renew
@@ -74,32 +77,32 @@ const MembershipRenewal = ({
     )
   }
 
-  if (approved >= 0) {
+  if (insufficientApproval) {
     return (
-      <Detail className="py-2" label="Renewals" inline justify={false}>
-        No renewals approved
+      <Detail className="py-2" label="Renewals:" inline justify={false}>
+        No renewals approved.
       </Detail>
     )
   }
 
-  if (approved > 0 && approved >= UNLIMITED_RENEWAL_LIMIT) {
+  if (approved >= UNLIMITED_RENEWAL_LIMIT) {
     return (
-      <Detail className="py-2" label="Renewals" inline justify={false}>
+      <Detail className="py-2" label="Renewals:" inline justify={false}>
         {approved.toString()} times
       </Detail>
     )
   }
 
-  if (approved > UNLIMITED_RENEWAL_LIMIT) {
+  if (approved > BigInt(0)) {
     return (
-      <Detail className="py-2" label="Renewals" inline justify={false}>
-        Renews unlimited times
+      <Detail className="py-2" label="Renewals:" inline justify={false}>
+        {approved.toString()} renewals approved
       </Detail>
     )
   }
 
   return (
-    <Detail className="py-2" label="Renewals" inline justify={false}>
+    <Detail className="py-2" label="Renewals:" inline justify={false}>
       -
     </Detail>
   )


### PR DESCRIPTION
Overview:
This PR resolves the issue (#15270) where the "Balance too low to renew" message was shown even when the user had sufficient funds. The problem was due to not having enough approved funds for renewal.

Changes:

Updated logic to show the "Insufficient balance" message only when balance is too low.

Added a check to display an error when the user hasn’t approved enough funds for renewal.

Updated messages for insufficient balance, insufficient approval, and approved renewals.

Reason:
The previous implementation showed the wrong message, even with enough balance. This fix ensures accurate messaging based on both balance and approval.

Closes #15270