### PR TITLE
feat: add governance proposal write flows

### DIFF
--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -72,7 +72,20 @@ export default async function ProposalDetailPage({
                 {proposal.title}
               </h2>
               <div className="prose prose-sm text-brand-ui-primary/72">
-                <ReactMarkdown>{proposal.description}</ReactMarkdown>
+                <ReactMarkdown
+                  components={{
+                    // Proposal descriptions are user-controlled (on-chain). Open
+                    // links in a new tab with noopener noreferrer to prevent
+                    // tab-napping and mitigate phishing via crafted hrefs.
+                    a: ({ href, children }) => (
+                      <a href={href} rel="noopener noreferrer" target="_blank">
+                        {children}
+                      </a>
+                    ),
+                  }}
+                >
+                  {proposal.description}
+                </ReactMarkdown>
               </div>
             </div>
             <div className="rounded-3xl bg-ui-secondary-200 px-4 py-3 text-sm text-brand-ui-primary/70">

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -100,6 +100,8 @@ export default async function ProposalDetailPage({
                     img: ({ alt }) => <span>{alt}</span>,
                   }}
                 >
+                  {/* Strip the first line (the title) — it's already shown in
+                      the <h2> above. Handles \n, \r\n, and single-line bodies. */}
                   {proposal.description.replace(/^[^\r\n]*[\r\n]*/, '')}
                 </ReactMarkdown>
               </div>
@@ -198,14 +200,18 @@ export default async function ProposalDetailPage({
                   Transaction
                 </dt>
                 <dd className="mt-1 font-medium text-brand-ui-primary">
-                  <a
-                    className="underline hover:text-brand-ui-primary/70"
-                    href={txExplorerUrl(proposal.transactionHash) ?? '#'}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Proposal submission transaction
-                  </a>
+                  {txExplorerUrl(proposal.transactionHash) ? (
+                    <a
+                      className="underline hover:text-brand-ui-primary/70"
+                      href={txExplorerUrl(proposal.transactionHash)!}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Proposal submission transaction
+                    </a>
+                  ) : (
+                    <span>Proposal submission transaction</span>
+                  )}
                 </dd>
               </div>
             </dl>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function ProposalDetailPage({
                     },
                   }}
                 >
-                  {proposal.description}
+                  {proposal.description.replace(/^[^\n]*\n?/, '')}
                 </ReactMarkdown>
               </div>
             </div>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { AddressLink } from '~/components/AddressLink'
 import { TruncatedId } from '~/components/TruncatedId'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
@@ -74,14 +75,13 @@ export default async function ProposalDetailPage({
               </h2>
               <div className="prose prose-sm break-words text-brand-ui-primary/72">
                 <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
                   components={{
                     // Proposal descriptions are user-controlled (on-chain).
-                    // Only allow http/https — data: and other non-http schemes
-                    // are not blocked by React 18 and could be abused.
+                    // Only allow https — http leaks over mixed-content and
+                    // data: / other non-http schemes can be abused.
                     a: ({ href, children }) => {
-                      const safe =
-                        href?.startsWith('https://') ||
-                        href?.startsWith('http://')
+                      const safe = href?.startsWith('https://')
                       return safe ? (
                         <a
                           href={href}
@@ -94,17 +94,13 @@ export default async function ProposalDetailPage({
                         <span>{children}</span>
                       )
                     },
-                    // Block images from arbitrary URLs — tracking pixels,
-                    // fingerprinting beacons, and NSFW content are all possible.
-                    img: ({ src, alt }) => {
-                      const safe =
-                        src?.startsWith('https://') ||
-                        src?.startsWith('http://')
-                      return safe ? <img alt={alt ?? ''} src={src} /> : null
-                    },
+                    // Strip all images — proposal content is user-controlled
+                    // on-chain data; any https:// image is a potential tracking
+                    // pixel or fingerprinting beacon shown to every visitor.
+                    img: ({ alt }) => <span>{alt}</span>,
                   }}
                 >
-                  {proposal.description.replace(/^[^\r\n]*[\r\n]+/, '')}
+                  {proposal.description.replace(/^[^\r\n]*[\r\n]*/, '')}
                 </ReactMarkdown>
               </div>
             </div>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -75,8 +75,8 @@ export default async function ProposalDetailPage({
                 <ReactMarkdown
                   components={{
                     // Proposal descriptions are user-controlled (on-chain).
-                    // Only allow http/https hrefs — data: and other non-http
-                    // schemes are not blocked by React 18 and could be abused.
+                    // Only allow http/https — data: and other non-http schemes
+                    // are not blocked by React 18 and could be abused.
                     a: ({ href, children }) => {
                       const safe =
                         href?.startsWith('https://') ||
@@ -92,6 +92,14 @@ export default async function ProposalDetailPage({
                       ) : (
                         <span>{children}</span>
                       )
+                    },
+                    // Block images from arbitrary URLs — tracking pixels,
+                    // fingerprinting beacons, and NSFW content are all possible.
+                    img: ({ src, alt }) => {
+                      const safe =
+                        src?.startsWith('https://') ||
+                        src?.startsWith('http://')
+                      return safe ? <img alt={alt ?? ''} src={src} /> : null
                     },
                   }}
                 >

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -230,13 +230,11 @@ export default async function ProposalDetailPage({
               calldatas={proposal.calldatas}
               descriptionHash={proposal.descriptionHash}
               etaSeconds={proposal.etaSeconds?.toString() || null}
-              latestTimestamp={overview.latestTimestamp.toString()}
               proposalId={proposal.id}
               state={proposal.state}
               targets={proposal.targets}
               tokenSymbol={overview.tokenSymbol}
               values={proposal.values.map((value) => value.toString())}
-              voteStartTimestamp={proposal.voteStartTimestamp.toString()}
             />
           </aside>
         </div>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
-import { Address } from '@unlock-protocol/ui'
+import { AddressLink } from '~/components/AddressLink'
 import { TruncatedId } from '~/components/TruncatedId'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
 import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
@@ -110,7 +110,7 @@ export default async function ProposalDetailPage({
             </div>
             <div className="rounded-3xl bg-ui-secondary-200 px-4 py-3 text-sm text-brand-ui-primary/70">
               Proposed by{' '}
-              <Address
+              <AddressLink
                 address={proposal.proposer}
                 externalLinkUrl={addressExplorerUrl(proposal.proposer)}
                 showExternalLink

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   getProposalById,
 } from '~/lib/governance/proposals'
 import { isExecutable } from '~/lib/governance/state'
+import { txExplorerUrl } from '~/config/governance'
 
 export const dynamic = 'force-dynamic'
 
@@ -189,10 +190,21 @@ export default async function ProposalDetailPage({
                 label="Voting period"
                 value={formatDuration(overview.votingPeriod)}
               />
-              <DetailRow
-                label="Transaction"
-                value={truncateAddress(proposal.transactionHash, 8)}
-              />
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
+                  Transaction
+                </dt>
+                <dd className="mt-1 font-medium text-brand-ui-primary">
+                  <a
+                    className="underline hover:text-brand-ui-primary/70"
+                    href={txExplorerUrl(proposal.transactionHash)}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {truncateAddress(proposal.transactionHash, 8)}
+                  </a>
+                </dd>
+              </div>
             </dl>
           </section>
         </aside>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
 import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
+import { ProposalWritePanel } from '~/components/proposals/ProposalWritePanel'
+import { governanceConfig } from '~/config/governance'
 import {
   formatDateTime,
   formatRelativeTime,
@@ -225,24 +227,17 @@ export default async function ProposalDetailPage({
               </dl>
             </section>
 
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-                Lifecycle action
-              </h3>
-              <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
-                <div className="text-lg font-semibold text-brand-ui-primary">
-                  {proposal.state === 'Succeeded'
-                    ? 'Queue proposal'
-                    : proposal.state === 'Queued'
-                      ? 'Execute proposal'
-                      : 'No action available'}
-                </div>
-                <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                  Write flows land in a later slice. This page already derives
-                  the live action state, including queued execution readiness.
-                </p>
-              </div>
-            </section>
+            <ProposalWritePanel
+              calldatas={proposal.calldatas}
+              descriptionHash={proposal.descriptionHash}
+              etaSeconds={proposal.etaSeconds?.toString() || null}
+              latestTimestamp={overview.latestTimestamp.toString()}
+              proposalId={proposal.id}
+              state={proposal.state}
+              targets={proposal.targets}
+              values={proposal.values.map((value) => value.toString())}
+              voteStartTimestamp={proposal.voteStartTimestamp.toString()}
+            />
           </aside>
         </div>
       </section>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -71,7 +71,7 @@ export default async function ProposalDetailPage({
               <h2 className="text-2xl font-semibold text-brand-ui-primary sm:text-4xl">
                 {proposal.title}
               </h2>
-              <div className="prose prose-sm text-brand-ui-primary/72">
+              <div className="prose prose-sm break-words text-brand-ui-primary/72">
                 <ReactMarkdown
                   components={{
                     // Proposal descriptions are user-controlled (on-chain).

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -74,14 +74,25 @@ export default async function ProposalDetailPage({
               <div className="prose prose-sm text-brand-ui-primary/72">
                 <ReactMarkdown
                   components={{
-                    // Proposal descriptions are user-controlled (on-chain). Open
-                    // links in a new tab with noopener noreferrer to prevent
-                    // tab-napping and mitigate phishing via crafted hrefs.
-                    a: ({ href, children }) => (
-                      <a href={href} rel="noopener noreferrer" target="_blank">
-                        {children}
-                      </a>
-                    ),
+                    // Proposal descriptions are user-controlled (on-chain).
+                    // Only allow http/https hrefs — data: and other non-http
+                    // schemes are not blocked by React 18 and could be abused.
+                    a: ({ href, children }) => {
+                      const safe =
+                        href?.startsWith('https://') ||
+                        href?.startsWith('http://')
+                      return safe ? (
+                        <a
+                          href={href}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {children}
+                        </a>
+                      ) : (
+                        <span>{children}</span>
+                      )
+                    },
                   }}
                 >
                   {proposal.description}

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -67,7 +67,12 @@ export default async function ProposalDetailPage({
               <div className="flex flex-wrap items-center gap-2">
                 <ProposalStateBadge state={proposal.state} />
                 <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-ui-primary/45">
-                  Proposal <TruncatedId id={proposal.id} keep={4} />
+                  Proposal{' '}
+                  <TruncatedId
+                    id={proposal.id}
+                    keep={4}
+                    label="Copy full proposal ID"
+                  />
                 </span>
               </div>
               <h2 className="text-2xl font-semibold text-brand-ui-primary sm:text-4xl">
@@ -78,10 +83,11 @@ export default async function ProposalDetailPage({
                   remarkPlugins={[remarkGfm]}
                   components={{
                     // Proposal descriptions are user-controlled (on-chain).
-                    // Only allow https — http leaks over mixed-content and
-                    // data: / other non-http schemes can be abused.
+                    // Allow https:// external links and #anchor links.
+                    // http:, data:, javascript: and other schemes are blocked.
                     a: ({ href, children }) => {
-                      const safe = href?.startsWith('https://')
+                      const safe =
+                        href?.startsWith('https://') || href?.startsWith('#')
                       return safe ? (
                         <a
                           href={href}

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -146,22 +146,29 @@ export default async function ProposalDetailPage({
                 label="Voting closes"
                 value={formatDateTime(proposal.voteEndTimestamp)}
               />
-              <TimelineRow
-                label="Queued / ETA"
-                value={
-                  proposal.etaSeconds
-                    ? `${formatDateTime(proposal.etaSeconds)} (${executeLabel})`
-                    : 'Not queued'
-                }
-              />
-              <TimelineRow
-                label="Executed"
-                value={formatDateTime(proposal.executedAt)}
-              />
-              <TimelineRow
-                label="Canceled"
-                value={formatDateTime(proposal.canceledAt)}
-              />
+              {proposal.etaSeconds ? (
+                <TimelineRow
+                  label="Queued / ETA"
+                  value={`${formatDateTime(proposal.etaSeconds)} (${executeLabel})`}
+                />
+              ) : proposal.state === 'Succeeded' ? (
+                <TimelineRow
+                  label="Queued / ETA"
+                  value="Not yet queued — queue this proposal to start the timelock."
+                />
+              ) : null}
+              {proposal.executedAt ? (
+                <TimelineRow
+                  label="Executed"
+                  value={formatDateTime(proposal.executedAt)}
+                />
+              ) : null}
+              {proposal.canceledAt ? (
+                <TimelineRow
+                  label="Canceled"
+                  value={formatDateTime(proposal.canceledAt)}
+                />
+              ) : null}
             </div>
           </section>
 

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -84,21 +84,29 @@ export default async function ProposalDetailPage({
                   components={{
                     // Proposal descriptions are user-controlled (on-chain).
                     // Allow https:// external links and #anchor links.
-                    // http:, data:, javascript: and other schemes are blocked.
+                    // http:, data:, javascript: and other schemes are blocked
+                    // (rendered as plain text — no indication shown since the
+                    // text content is preserved and the intent is still clear).
                     a: ({ href, children }) => {
-                      const safe =
-                        href?.startsWith('https://') || href?.startsWith('#')
-                      return safe ? (
-                        <a
-                          href={href}
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          {children}
-                        </a>
-                      ) : (
-                        <span>{children}</span>
-                      )
+                      const isExternal = href?.startsWith('https://')
+                      const isAnchor = href?.startsWith('#')
+                      if (isExternal) {
+                        return (
+                          <a
+                            href={href}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            {children}
+                          </a>
+                        )
+                      }
+                      if (isAnchor) {
+                        // Same-page anchor — no target="_blank" (would open a
+                        // new tab without the fragment resolving correctly).
+                        return <a href={href}>{children}</a>
+                      }
+                      return <span>{children}</span>
                     },
                     // Strip all images — proposal content is user-controlled
                     // on-chain data; any https:// image is a potential tracking

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
 import { ProposalWritePanel } from '~/components/proposals/ProposalWritePanel'
 import {
   formatDateTime,
+  formatDuration,
   formatRelativeTime,
   formatTokenAmount,
   percentage,
@@ -53,194 +54,192 @@ export default async function ProposalDetailPage({
       : 'Not queued'
 
     return (
-      <section className="space-y-8">
-        <div className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-8 shadow-sm">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center gap-3">
+      // 3-item DOM order: [header] → [aside] → [main]
+      // Mobile stacks in that order: title → cast vote → breakdown/calls
+      // Desktop: 2-col grid — header (col1 row1), aside (col2 row1-2), main (col1 row2)
+      <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,2fr)_360px]">
+        {/* Col 1, Row 1 — proposal header */}
+        <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-8">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
                 <ProposalStateBadge state={proposal.state} />
                 <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-ui-primary/45">
                   Proposal <TruncatedId id={proposal.id} keep={4} />
                 </span>
               </div>
-              <h2 className="text-4xl font-semibold text-brand-ui-primary">
+              <h2 className="text-2xl font-semibold text-brand-ui-primary sm:text-4xl">
                 {proposal.title}
               </h2>
-              <div className="prose prose-sm max-w-3xl text-brand-ui-primary/72">
+              <div className="prose prose-sm text-brand-ui-primary/72">
                 <ReactMarkdown>{proposal.description}</ReactMarkdown>
               </div>
             </div>
-            <div className="rounded-3xl bg-ui-secondary-200 px-5 py-4 text-sm text-brand-ui-primary/70">
+            <div className="rounded-3xl bg-ui-secondary-200 px-4 py-3 text-sm text-brand-ui-primary/70">
               Proposed by {truncateAddress(proposal.proposer)}
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,2fr)_360px]">
-          <div className="space-y-6">
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-8 shadow-sm">
-              <div className="flex items-center justify-between gap-4">
-                <h3 className="text-2xl font-semibold text-brand-ui-primary">
-                  Vote breakdown
-                </h3>
-                <div className="text-sm text-brand-ui-primary/60">
-                  Quorum counts {overview.tokenSymbol} votes for + abstain
-                </div>
-              </div>
-              <div className="mt-6 grid gap-4 md:grid-cols-3">
-                <VotePanel
-                  label="For"
-                  percentageLabel={percentage(proposal.forVotes, totalVotes)}
-                  value={proposal.forVotes}
-                />
-                <VotePanel
-                  label="Against"
-                  percentageLabel={percentage(
-                    proposal.againstVotes,
-                    totalVotes
-                  )}
-                  value={proposal.againstVotes}
-                />
-                <VotePanel
-                  label="Abstain"
-                  percentageLabel={percentage(
-                    proposal.abstainVotes,
-                    totalVotes
-                  )}
-                  value={proposal.abstainVotes}
-                />
-              </div>
-              <div className="mt-6 rounded-3xl bg-ui-secondary-200 p-5">
-                <div className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
-                  Quorum progress
-                </div>
-                <div className="mt-2 text-lg font-semibold text-brand-ui-primary">
-                  {formatTokenAmount(quorumVotes)} /{' '}
-                  {formatTokenAmount(proposal.quorum)} {overview.tokenSymbol}
-                </div>
-              </div>
-            </section>
+        {/* Col 2, Rows 1–2 — actions sidebar (shown after title on mobile) */}
+        <aside className="space-y-6 lg:row-span-2">
+          <ProposalWritePanel
+            calldatas={proposal.calldatas}
+            descriptionHash={proposal.descriptionHash}
+            etaSeconds={proposal.etaSeconds?.toString() || null}
+            proposalId={proposal.id}
+            state={proposal.state}
+            targets={proposal.targets}
+            tokenSymbol={overview.tokenSymbol}
+            values={proposal.values.map((value) => value.toString())}
+          />
 
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-8 shadow-sm">
-              <h3 className="text-2xl font-semibold text-brand-ui-primary">
-                Proposed calls
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-6">
+            <h3 className="text-lg font-semibold text-brand-ui-primary">
+              Lifecycle
+            </h3>
+            <div className="mt-4 space-y-3">
+              <TimelineRow
+                label="Submitted"
+                value={formatDateTime(proposal.createdAtTimestamp)}
+              />
+              <TimelineRow
+                label="Voting opens"
+                value={`${formatDateTime(proposal.voteStartTimestamp)} (${formatRelativeTime(
+                  proposal.voteStartTimestamp,
+                  overview.latestTimestamp
+                )})`}
+              />
+              <TimelineRow
+                label="Voting closes"
+                value={formatDateTime(proposal.voteEndTimestamp)}
+              />
+              <TimelineRow
+                label="Queued / ETA"
+                value={
+                  proposal.etaSeconds
+                    ? `${formatDateTime(proposal.etaSeconds)} (${executeLabel})`
+                    : 'Not queued'
+                }
+              />
+              <TimelineRow
+                label="Executed"
+                value={formatDateTime(proposal.executedAt)}
+              />
+              <TimelineRow
+                label="Canceled"
+                value={formatDateTime(proposal.canceledAt)}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-6">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+              Governance settings
+            </h3>
+            <dl className="mt-4 space-y-4 text-sm text-brand-ui-primary/72">
+              <DetailRow
+                label="Proposal threshold"
+                value={`${formatTokenAmount(proposal.proposalThreshold)} ${overview.tokenSymbol}`}
+              />
+              <DetailRow
+                label="Voting delay"
+                value={formatDuration(overview.votingDelay)}
+              />
+              <DetailRow
+                label="Voting period"
+                value={formatDuration(overview.votingPeriod)}
+              />
+              <DetailRow
+                label="Transaction"
+                value={truncateAddress(proposal.transactionHash, 8)}
+              />
+            </dl>
+          </section>
+        </aside>
+
+        {/* Col 1, Row 2 — vote breakdown + proposed calls */}
+        <div className="space-y-6">
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-8">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h3 className="text-xl font-semibold text-brand-ui-primary sm:text-2xl">
+                Vote breakdown
               </h3>
-              <div className="mt-6 space-y-4">
-                {decodedCalls.map((call, index) => (
-                  <div
-                    key={`${proposal.id}-${index}`}
-                    className="rounded-3xl bg-ui-secondary-200 p-5"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
-                        Call {index + 1}
+              <div className="text-sm text-brand-ui-primary/60">
+                Quorum: for + abstain
+              </div>
+            </div>
+            <div className="mt-5 grid grid-cols-3 gap-3 sm:gap-4">
+              <VotePanel
+                label="For"
+                percentageLabel={percentage(proposal.forVotes, totalVotes)}
+                value={proposal.forVotes}
+              />
+              <VotePanel
+                label="Against"
+                percentageLabel={percentage(proposal.againstVotes, totalVotes)}
+                value={proposal.againstVotes}
+              />
+              <VotePanel
+                label="Abstain"
+                percentageLabel={percentage(proposal.abstainVotes, totalVotes)}
+                value={proposal.abstainVotes}
+              />
+            </div>
+            <div className="mt-5 rounded-3xl bg-ui-secondary-200 p-4 sm:p-5">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
+                Quorum progress
+              </div>
+              <div className="mt-2 text-lg font-semibold text-brand-ui-primary">
+                {formatTokenAmount(quorumVotes)} /{' '}
+                {formatTokenAmount(proposal.quorum)} {overview.tokenSymbol}
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-8">
+            <h3 className="text-xl font-semibold text-brand-ui-primary sm:text-2xl">
+              Proposed calls
+            </h3>
+            <div className="mt-5 space-y-4">
+              {decodedCalls.map((call, index) => (
+                <div
+                  key={`${proposal.id}-${index}`}
+                  className="rounded-3xl bg-ui-secondary-200 p-4 sm:p-5"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
+                      Call {index + 1}
+                    </div>
+                    <div className="text-sm text-brand-ui-primary/65">
+                      Value: {formatTokenAmount(call.value)} ETH
+                    </div>
+                  </div>
+                  {call.kind === 'decoded' ? (
+                    <div className="mt-3 space-y-2">
+                      <div className="text-base font-semibold text-brand-ui-primary sm:text-lg">
+                        {call.contractLabel}.{call.functionName}()
                       </div>
-                      <div className="text-sm text-brand-ui-primary/65">
-                        Value: {formatTokenAmount(call.value)} ETH
+                      <div className="text-sm text-brand-ui-primary/70">
+                        {call.args.length
+                          ? call.args.join(', ')
+                          : 'No arguments'}
                       </div>
                     </div>
-                    {call.kind === 'decoded' ? (
-                      <div className="mt-3 space-y-2">
-                        <div className="text-lg font-semibold text-brand-ui-primary">
-                          {call.contractLabel}.{call.functionName}()
-                        </div>
-                        <div className="text-sm text-brand-ui-primary/70">
-                          {call.args.length
-                            ? call.args.join(', ')
-                            : 'No arguments'}
-                        </div>
+                  ) : (
+                    <div className="mt-3 space-y-2 text-sm text-brand-ui-primary/70">
+                      <div className="break-all">{call.target}</div>
+                      <div className="break-all font-mono text-xs">
+                        {call.calldata}
                       </div>
-                    ) : (
-                      <div className="mt-3 space-y-2 text-sm text-brand-ui-primary/70">
-                        <div>Target: {call.target}</div>
-                        <div className="break-all font-mono text-xs">
-                          {call.calldata}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </section>
-          </div>
-
-          <aside className="space-y-6">
-            <ProposalWritePanel
-              calldatas={proposal.calldatas}
-              descriptionHash={proposal.descriptionHash}
-              etaSeconds={proposal.etaSeconds?.toString() || null}
-              proposalId={proposal.id}
-              state={proposal.state}
-              targets={proposal.targets}
-              tokenSymbol={overview.tokenSymbol}
-              values={proposal.values.map((value) => value.toString())}
-            />
-
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-              <h3 className="text-2xl font-semibold text-brand-ui-primary">
-                Lifecycle
-              </h3>
-              <div className="mt-4 space-y-3">
-                <TimelineRow
-                  label="Submitted"
-                  value={formatDateTime(proposal.createdAtTimestamp)}
-                />
-                <TimelineRow
-                  label="Voting opens"
-                  value={`${formatDateTime(proposal.voteStartTimestamp)} (${formatRelativeTime(
-                    proposal.voteStartTimestamp,
-                    overview.latestTimestamp
-                  )})`}
-                />
-                <TimelineRow
-                  label="Voting closes"
-                  value={formatDateTime(proposal.voteEndTimestamp)}
-                />
-                <TimelineRow
-                  label="Queued / ETA"
-                  value={
-                    proposal.etaSeconds
-                      ? `${formatDateTime(proposal.etaSeconds)} (${executeLabel})`
-                      : 'Not queued'
-                  }
-                />
-                <TimelineRow
-                  label="Executed"
-                  value={formatDateTime(proposal.executedAt)}
-                />
-                <TimelineRow
-                  label="Canceled"
-                  value={formatDateTime(proposal.canceledAt)}
-                />
-              </div>
-            </section>
-
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-                Governance settings
-              </h3>
-              <dl className="mt-4 space-y-4 text-sm text-brand-ui-primary/72">
-                <DetailRow
-                  label="Proposal threshold"
-                  value={`${formatTokenAmount(proposal.proposalThreshold)} ${overview.tokenSymbol}`}
-                />
-                <DetailRow
-                  label="Voting delay"
-                  value={`${overview.votingDelay.toString()} seconds`}
-                />
-                <DetailRow
-                  label="Voting period"
-                  value={`${overview.votingPeriod.toString()} seconds`}
-                />
-                <DetailRow
-                  label="Transaction"
-                  value={truncateAddress(proposal.transactionHash, 8)}
-                />
-              </dl>
-            </section>
-          </aside>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
         </div>
-      </section>
+      </div>
     )
   } catch (error) {
     console.error('[proposals/[id]/page] governance data load failed:', error)

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
+import { Address } from '@unlock-protocol/ui'
 import { TruncatedId } from '~/components/TruncatedId'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
 import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
@@ -10,7 +11,6 @@ import {
   formatRelativeTime,
   formatTokenAmount,
   percentage,
-  truncateAddress,
 } from '~/lib/governance/format'
 import {
   decodeProposalCalldatas,
@@ -18,7 +18,7 @@ import {
   getProposalById,
 } from '~/lib/governance/proposals'
 import { isExecutable } from '~/lib/governance/state'
-import { txExplorerUrl } from '~/config/governance'
+import { addressExplorerUrl, txExplorerUrl } from '~/config/governance'
 
 export const dynamic = 'force-dynamic'
 
@@ -109,7 +109,12 @@ export default async function ProposalDetailPage({
               </div>
             </div>
             <div className="rounded-3xl bg-ui-secondary-200 px-4 py-3 text-sm text-brand-ui-primary/70">
-              Proposed by {truncateAddress(proposal.proposer)}
+              Proposed by{' '}
+              <Address
+                address={proposal.proposer}
+                externalLinkUrl={addressExplorerUrl(proposal.proposer)}
+                showExternalLink
+              />
             </div>
           </div>
         </section>
@@ -201,7 +206,7 @@ export default async function ProposalDetailPage({
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    {truncateAddress(proposal.transactionHash, 8)}
+                    Proposal submission transaction
                   </a>
                 </dd>
               </div>
@@ -212,14 +217,9 @@ export default async function ProposalDetailPage({
         {/* Col 1, Row 2 — vote breakdown + proposed calls */}
         <div className="space-y-6">
           <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-8">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <h3 className="text-xl font-semibold text-brand-ui-primary sm:text-2xl">
-                Vote breakdown
-              </h3>
-              <div className="text-sm text-brand-ui-primary/60">
-                Quorum: for + abstain
-              </div>
-            </div>
+            <h3 className="text-xl font-semibold text-brand-ui-primary sm:text-2xl">
+              Vote breakdown
+            </h3>
             <div className="mt-5 grid grid-cols-3 gap-3 sm:gap-4">
               <VotePanel
                 label="For"
@@ -237,15 +237,11 @@ export default async function ProposalDetailPage({
                 value={proposal.abstainVotes}
               />
             </div>
-            <div className="mt-5 rounded-3xl bg-ui-secondary-200 p-4 sm:p-5">
-              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
-                Quorum progress
-              </div>
-              <div className="mt-2 text-lg font-semibold text-brand-ui-primary">
-                {formatTokenAmount(quorumVotes)} /{' '}
-                {formatTokenAmount(proposal.quorum)} {overview.tokenSymbol}
-              </div>
-            </div>
+            <QuorumPanel
+              quorum={proposal.quorum}
+              quorumVotes={quorumVotes}
+              tokenSymbol={overview.tokenSymbol}
+            />
           </section>
 
           <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-5 shadow-sm sm:p-8">
@@ -329,6 +325,57 @@ function TimelineRow({ label, value }: { label: string; value: string }) {
         {label}
       </div>
       <div className="mt-1 text-sm text-brand-ui-primary/75">{value}</div>
+    </div>
+  )
+}
+
+function QuorumPanel({
+  quorum,
+  quorumVotes,
+  tokenSymbol,
+}: {
+  quorum: bigint
+  quorumVotes: bigint
+  tokenSymbol: string
+}) {
+  const reached = quorum === 0n || quorumVotes >= quorum
+  const progressPct =
+    quorum === 0n
+      ? 100
+      : Math.min(100, Number((quorumVotes * 10000n) / quorum) / 100)
+
+  return (
+    <div className="mt-5 rounded-3xl bg-ui-secondary-200 p-4 sm:p-5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
+          Quorum
+        </div>
+        {reached && (
+          <span className="rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">
+            Reached
+          </span>
+        )}
+      </div>
+      <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-brand-ui-primary/10">
+        <div
+          className={`h-full rounded-full transition-all ${reached ? 'bg-emerald-500' : 'bg-brand-ui-primary/40'}`}
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+      <div className="mt-2 text-sm text-brand-ui-primary/65">
+        {reached ? (
+          <>
+            {formatTokenAmount(quorumVotes)} {tokenSymbol} voted (quorum:{' '}
+            {formatTokenAmount(quorum)})
+          </>
+        ) : (
+          <>
+            {formatTokenAmount(quorumVotes)} / {formatTokenAmount(quorum)}{' '}
+            {tokenSymbol} — {formatTokenAmount(quorum - quorumVotes)} more
+            needed
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -1,4 +1,6 @@
 import { notFound } from 'next/navigation'
+import ReactMarkdown from 'react-markdown'
+import { TruncatedId } from '~/components/TruncatedId'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
 import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
 import { ProposalWritePanel } from '~/components/proposals/ProposalWritePanel'
@@ -58,15 +60,15 @@ export default async function ProposalDetailPage({
               <div className="flex flex-wrap items-center gap-3">
                 <ProposalStateBadge state={proposal.state} />
                 <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-ui-primary/45">
-                  Proposal {proposal.id}
+                  Proposal <TruncatedId id={proposal.id} keep={4} />
                 </span>
               </div>
               <h2 className="text-4xl font-semibold text-brand-ui-primary">
                 {proposal.title}
               </h2>
-              <p className="max-w-3xl whitespace-pre-wrap text-base leading-7 text-brand-ui-primary/72">
-                {proposal.description}
-              </p>
+              <div className="prose prose-sm max-w-3xl text-brand-ui-primary/72">
+                <ReactMarkdown>{proposal.description}</ReactMarkdown>
+              </div>
             </div>
             <div className="rounded-3xl bg-ui-secondary-200 px-5 py-4 text-sm text-brand-ui-primary/70">
               Proposed by {truncateAddress(proposal.proposer)}
@@ -74,7 +76,7 @@ export default async function ProposalDetailPage({
           </div>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_360px]">
+        <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,2fr)_360px]">
           <div className="space-y-6">
             <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-8 shadow-sm">
               <div className="flex items-center justify-between gap-4">
@@ -116,45 +118,6 @@ export default async function ProposalDetailPage({
                   {formatTokenAmount(quorumVotes)} /{' '}
                   {formatTokenAmount(proposal.quorum)} {overview.tokenSymbol}
                 </div>
-              </div>
-            </section>
-
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-8 shadow-sm">
-              <h3 className="text-2xl font-semibold text-brand-ui-primary">
-                Lifecycle
-              </h3>
-              <div className="mt-6 space-y-4">
-                <TimelineRow
-                  label="Submitted"
-                  value={formatDateTime(proposal.createdAtTimestamp)}
-                />
-                <TimelineRow
-                  label="Voting opens"
-                  value={`${formatDateTime(proposal.voteStartTimestamp)} (${formatRelativeTime(
-                    proposal.voteStartTimestamp,
-                    overview.latestTimestamp
-                  )})`}
-                />
-                <TimelineRow
-                  label="Voting closes"
-                  value={formatDateTime(proposal.voteEndTimestamp)}
-                />
-                <TimelineRow
-                  label="Queued / ETA"
-                  value={
-                    proposal.etaSeconds
-                      ? `${formatDateTime(proposal.etaSeconds)} (${executeLabel})`
-                      : 'Not queued'
-                  }
-                />
-                <TimelineRow
-                  label="Executed"
-                  value={formatDateTime(proposal.executedAt)}
-                />
-                <TimelineRow
-                  label="Canceled"
-                  value={formatDateTime(proposal.canceledAt)}
-                />
               </div>
             </section>
 
@@ -202,6 +165,56 @@ export default async function ProposalDetailPage({
           </div>
 
           <aside className="space-y-6">
+            <ProposalWritePanel
+              calldatas={proposal.calldatas}
+              descriptionHash={proposal.descriptionHash}
+              etaSeconds={proposal.etaSeconds?.toString() || null}
+              proposalId={proposal.id}
+              state={proposal.state}
+              targets={proposal.targets}
+              tokenSymbol={overview.tokenSymbol}
+              values={proposal.values.map((value) => value.toString())}
+            />
+
+            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+              <h3 className="text-2xl font-semibold text-brand-ui-primary">
+                Lifecycle
+              </h3>
+              <div className="mt-4 space-y-3">
+                <TimelineRow
+                  label="Submitted"
+                  value={formatDateTime(proposal.createdAtTimestamp)}
+                />
+                <TimelineRow
+                  label="Voting opens"
+                  value={`${formatDateTime(proposal.voteStartTimestamp)} (${formatRelativeTime(
+                    proposal.voteStartTimestamp,
+                    overview.latestTimestamp
+                  )})`}
+                />
+                <TimelineRow
+                  label="Voting closes"
+                  value={formatDateTime(proposal.voteEndTimestamp)}
+                />
+                <TimelineRow
+                  label="Queued / ETA"
+                  value={
+                    proposal.etaSeconds
+                      ? `${formatDateTime(proposal.etaSeconds)} (${executeLabel})`
+                      : 'Not queued'
+                  }
+                />
+                <TimelineRow
+                  label="Executed"
+                  value={formatDateTime(proposal.executedAt)}
+                />
+                <TimelineRow
+                  label="Canceled"
+                  value={formatDateTime(proposal.canceledAt)}
+                />
+              </div>
+            </section>
+
             <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
               <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
                 Governance settings
@@ -225,17 +238,6 @@ export default async function ProposalDetailPage({
                 />
               </dl>
             </section>
-
-            <ProposalWritePanel
-              calldatas={proposal.calldatas}
-              descriptionHash={proposal.descriptionHash}
-              etaSeconds={proposal.etaSeconds?.toString() || null}
-              proposalId={proposal.id}
-              state={proposal.state}
-              targets={proposal.targets}
-              tokenSymbol={overview.tokenSymbol}
-              values={proposal.values.map((value) => value.toString())}
-            />
           </aside>
         </div>
       </section>

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation'
 import { ProposalStateBadge } from '~/components/proposals/ProposalStateBadge'
 import { ProposalErrorState } from '~/components/proposals/ProposalErrorState'
 import { ProposalWritePanel } from '~/components/proposals/ProposalWritePanel'
-import { governanceConfig } from '~/config/governance'
 import {
   formatDateTime,
   formatRelativeTime,
@@ -235,6 +234,7 @@ export default async function ProposalDetailPage({
               proposalId={proposal.id}
               state={proposal.state}
               targets={proposal.targets}
+              tokenSymbol={overview.tokenSymbol}
               values={proposal.values.map((value) => value.toString())}
               voteStartTimestamp={proposal.voteStartTimestamp.toString()}
             />

--- a/governance-app/app/proposals/[id]/page.tsx
+++ b/governance-app/app/proposals/[id]/page.tsx
@@ -104,7 +104,7 @@ export default async function ProposalDetailPage({
                     },
                   }}
                 >
-                  {proposal.description.replace(/^[^\n]*\n?/, '')}
+                  {proposal.description.replace(/^[^\r\n]*[\r\n]+/, '')}
                 </ReactMarkdown>
               </div>
             </div>
@@ -112,7 +112,9 @@ export default async function ProposalDetailPage({
               Proposed by{' '}
               <AddressLink
                 address={proposal.proposer}
-                externalLinkUrl={addressExplorerUrl(proposal.proposer)}
+                externalLinkUrl={
+                  addressExplorerUrl(proposal.proposer) ?? undefined
+                }
                 showExternalLink
               />
             </div>
@@ -202,7 +204,7 @@ export default async function ProposalDetailPage({
                 <dd className="mt-1 font-medium text-brand-ui-primary">
                   <a
                     className="underline hover:text-brand-ui-primary/70"
-                    href={txExplorerUrl(proposal.transactionHash)}
+                    href={txExplorerUrl(proposal.transactionHash) ?? '#'}
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/governance-app/package.json
+++ b/governance-app/package.json
@@ -17,7 +17,8 @@
     "next": "14.2.35",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-markdown": "10.1.0"
+    "react-markdown": "10.1.0",
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@types/node": "22.13.10",

--- a/governance-app/package.json
+++ b/governance-app/package.json
@@ -16,7 +16,8 @@
     "ethers": "6.15.0",
     "next": "14.2.35",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-markdown": "10.1.0"
   },
   "devDependencies": {
     "@types/node": "22.13.10",

--- a/governance-app/src/components/AddressLink.tsx
+++ b/governance-app/src/components/AddressLink.tsx
@@ -1,0 +1,5 @@
+// ABOUTME: Client wrapper for the @unlock-protocol/ui Address component.
+// ABOUTME: Required because the UI package bundle lacks "use client" directives.
+'use client'
+
+export { Address as AddressLink } from '@unlock-protocol/ui'

--- a/governance-app/src/components/TruncatedId.tsx
+++ b/governance-app/src/components/TruncatedId.tsx
@@ -19,9 +19,13 @@ export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
   async function handleCopy(e: React.MouseEvent) {
     e.preventDefault()
     e.stopPropagation()
-    await navigator.clipboard.writeText(id)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    try {
+      await navigator.clipboard.writeText(id)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable (non-HTTPS or permission denied) — fail silently.
+    }
   }
 
   return (

--- a/governance-app/src/components/TruncatedId.tsx
+++ b/governance-app/src/components/TruncatedId.tsx
@@ -8,9 +8,14 @@ import { MdContentCopy as CopyIcon, MdCheck as CheckIcon } from 'react-icons/md'
 type TruncatedIdProps = {
   id: string
   keep?: number
+  label?: string
 }
 
-export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
+export function TruncatedId({
+  id,
+  keep = 4,
+  label = 'Copy full ID',
+}: TruncatedIdProps) {
   const [copied, setCopied] = useState(false)
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -40,7 +45,7 @@ export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
     <span className="inline-flex items-center gap-1">
       <span className="font-mono">{display}</span>
       <button
-        aria-label="Copy full proposal ID"
+        aria-label={label}
         className="text-brand-ui-primary/40 transition-colors hover:text-brand-ui-primary"
         onClick={handleCopy}
         type="button"

--- a/governance-app/src/components/TruncatedId.tsx
+++ b/governance-app/src/components/TruncatedId.tsx
@@ -1,0 +1,44 @@
+// ABOUTME: Client component that displays a truncated ID with a copy-to-clipboard button.
+// Shows first and last N characters separated by "…" and copies the full value on click.
+'use client'
+
+import { useState } from 'react'
+import { MdContentCopy as CopyIcon, MdCheck as CheckIcon } from 'react-icons/md'
+
+type TruncatedIdProps = {
+  id: string
+  keep?: number
+}
+
+export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
+  const [copied, setCopied] = useState(false)
+
+  const display =
+    id.length <= keep * 2 + 1 ? id : `${id.slice(0, keep)}…${id.slice(-keep)}`
+
+  async function handleCopy(e: React.MouseEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+    await navigator.clipboard.writeText(id)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="font-mono">{display}</span>
+      <button
+        aria-label="Copy full proposal ID"
+        className="text-brand-ui-primary/40 transition-colors hover:text-brand-ui-primary"
+        onClick={handleCopy}
+        type="button"
+      >
+        {copied ? (
+          <CheckIcon className="text-green-500" size={14} />
+        ) : (
+          <CopyIcon size={14} />
+        )}
+      </button>
+    </span>
+  )
+}

--- a/governance-app/src/components/TruncatedId.tsx
+++ b/governance-app/src/components/TruncatedId.tsx
@@ -2,7 +2,7 @@
 // Shows first and last N characters separated by "…" and copies the full value on click.
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { MdContentCopy as CopyIcon, MdCheck as CheckIcon } from 'react-icons/md'
 
 type TruncatedIdProps = {
@@ -12,6 +12,13 @@ type TruncatedIdProps = {
 
 export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
   const [copied, setCopied] = useState(false)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+    }
+  }, [])
 
   const display =
     id.length <= keep * 2 + 1 ? id : `${id.slice(0, keep)}…${id.slice(-keep)}`
@@ -22,7 +29,8 @@ export function TruncatedId({ id, keep = 4 }: TruncatedIdProps) {
     try {
       await navigator.clipboard.writeText(id)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = setTimeout(() => setCopied(false), 2000)
     } catch {
       // Clipboard API unavailable (non-HTTPS or permission denied) — fail silently.
     }

--- a/governance-app/src/components/proposals/ProposalCard.tsx
+++ b/governance-app/src/components/proposals/ProposalCard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { TruncatedId } from '~/components/TruncatedId'
 import {
   formatDateTime,
   formatRelativeTime,
@@ -37,7 +38,7 @@ export function ProposalCard({
           <div className="flex flex-wrap items-center gap-3">
             <ProposalStateBadge state={proposal.state} />
             <span className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
-              Proposal {proposal.id}
+              Proposal <TruncatedId id={proposal.id} keep={4} />
             </span>
           </div>
           <h2 className="text-2xl font-semibold text-brand-ui-primary">

--- a/governance-app/src/components/proposals/ProposalCard.tsx
+++ b/governance-app/src/components/proposals/ProposalCard.tsx
@@ -38,7 +38,12 @@ export function ProposalCard({
           <div className="flex flex-wrap items-center gap-3">
             <ProposalStateBadge state={proposal.state} />
             <span className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/45">
-              Proposal <TruncatedId id={proposal.id} keep={4} />
+              Proposal{' '}
+              <TruncatedId
+                id={proposal.id}
+                keep={4}
+                label="Copy full proposal ID"
+              />
             </span>
           </div>
           <h2 className="text-2xl font-semibold text-brand-ui-primary">

--- a/governance-app/src/components/proposals/ProposalStateBadge.tsx
+++ b/governance-app/src/components/proposals/ProposalStateBadge.tsx
@@ -5,6 +5,7 @@ const stateClassNames: Record<ProposalState, string> = {
   Canceled: 'bg-slate-200 text-slate-700',
   Defeated: 'bg-rose-100 text-rose-700',
   Executed: 'bg-sky-100 text-sky-700',
+  Expired: 'bg-slate-200 text-slate-700',
   Pending: 'bg-amber-100 text-amber-700',
   Queued: 'bg-violet-100 text-violet-700',
   Succeeded: 'bg-teal-100 text-teal-700',

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -8,6 +8,7 @@ import { Contract, isError } from 'ethers'
 import { useRouter } from 'next/navigation'
 import { governanceEnv } from '~/config/env'
 import { governanceConfig } from '~/config/governance'
+import { useConnectModal } from '~/hooks/useConnectModal'
 import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
 import { formatRelativeTime, formatTokenAmount } from '~/lib/governance/format'
 import { getRpcProvider, governorAbi } from '~/lib/governance/rpc'
@@ -52,8 +53,8 @@ function ProposalWritePanelConnected({
   tokenSymbol,
   values,
 }: ProposalWritePanelProps) {
-  const { address, authenticated, connect, getSigner, isReady } =
-    useGovernanceWallet()
+  const { address, authenticated, getSigner, isReady } = useGovernanceWallet()
+  const { openConnectModal } = useConnectModal()
   const router = useRouter()
   const queryClient = useQueryClient()
   const [reason, setReason] = useState('')
@@ -191,7 +192,7 @@ function ProposalWritePanelConnected({
     <>
       {!authenticated ? (
         <WalletStateCard
-          action={<Button onClick={() => connect()}>Connect wallet</Button>}
+          action={<Button onClick={openConnectModal}>Connect wallet</Button>}
           title="Connect a wallet to interact with this proposal"
           description="Voting, queueing, and execution all require a connected wallet on Base."
         />

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -342,51 +342,44 @@ function ProposalWritePanelConnected({
             </>
           ) : null}
 
-          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-              Lifecycle action
-            </h3>
-            <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
-              <div className="text-lg font-semibold text-brand-ui-primary">
-                {canQueue
-                  ? 'Queue proposal'
-                  : state === 'Queued'
-                    ? canExecute
+          {(canQueue || state === 'Queued') && (
+            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+                Lifecycle action
+              </h3>
+              <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+                <div className="text-lg font-semibold text-brand-ui-primary">
+                  {canQueue
+                    ? 'Queue proposal'
+                    : canExecute
                       ? 'Execute proposal'
-                      : 'Waiting for timelock'
-                    : 'No action available'}
-              </div>
-              <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                {canQueue
-                  ? 'This proposal passed and can now be queued in the timelock.'
-                  : state === 'Queued' && etaSeconds
-                    ? canExecute
+                      : 'Waiting for timelock'}
+                </div>
+                <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                  {canQueue
+                    ? 'This proposal passed and can now be queued in the timelock.'
+                    : canExecute
                       ? 'The timelock delay has elapsed. Execution is now available.'
-                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), now)}.`
-                    : 'Queueing and execution become available only after a proposal succeeds.'}
-              </p>
-            </div>
+                      : etaSeconds
+                        ? `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), now)}.`
+                        : 'Queued — waiting for the timelock ETA to be set.'}
+                </p>
+              </div>
 
-            <div className="mt-5">
-              <Button
-                disabled={
-                  (!canQueue && !canExecute) || actionMutation.isPending
-                }
-                loading={actionMutation.isPending}
-                onClick={() =>
-                  actionMutation.mutate(canQueue ? 'queue' : 'execute')
-                }
-              >
-                {canQueue
-                  ? 'Queue proposal'
-                  : canExecute
-                    ? 'Execute proposal'
-                    : state === 'Queued'
-                      ? 'Waiting for timelock'
-                      : 'No action available'}
-              </Button>
-            </div>
-          </section>
+              {(canQueue || canExecute) && (
+                <div className="mt-5">
+                  <Button
+                    loading={actionMutation.isPending}
+                    onClick={() =>
+                      actionMutation.mutate(canQueue ? 'queue' : 'execute')
+                    }
+                  >
+                    {canQueue ? 'Queue proposal' : 'Execute proposal'}
+                  </Button>
+                </div>
+              )}
+            </section>
+          )}
         </>
       ) : null}
     </>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -17,13 +17,11 @@ type ProposalWritePanelProps = {
   calldatas: string[]
   descriptionHash: string
   etaSeconds: string | null
-  latestTimestamp: string
   proposalId: string
   state: ProposalState
   targets: string[]
   tokenSymbol: string
   values: string[]
-  voteStartTimestamp: string
 }
 
 type VoteStatus = {
@@ -50,19 +48,16 @@ function ProposalWritePanelConnected({
   calldatas,
   descriptionHash,
   etaSeconds,
-  latestTimestamp,
   proposalId,
   state,
   targets,
   tokenSymbol,
   values,
-  voteStartTimestamp,
 }: ProposalWritePanelProps) {
   const { address, authenticated, connect, getSigner, isReady } =
     useGovernanceWallet()
   const router = useRouter()
   const [reason, setReason] = useState('')
-  const now = BigInt(latestTimestamp)
 
   const voteStatusQuery = useQuery({
     enabled: Boolean(address),
@@ -77,17 +72,21 @@ function ProposalWritePanelConnected({
         governorAbi,
         provider
       )
+      // proposalSnapshot returns the block number used as the voting snapshot —
+      // use it as fromBlock to avoid scanning from genesis (RPC providers cap ranges).
+      const snapshotBlock = (await governor.proposalSnapshot(
+        BigInt(proposalId)
+      )) as bigint
       const [votingPower, voteEvents, voteWithParamsEvents] = await Promise.all(
         [
-          governor.getVotes(
-            address,
-            BigInt(voteStartTimestamp)
-          ) as Promise<bigint>,
+          governor.getVotes(address, snapshotBlock) as Promise<bigint>,
           governor.queryFilter(
-            governor.filters.VoteCast(address, BigInt(proposalId))
+            governor.filters.VoteCast(address, BigInt(proposalId)),
+            snapshotBlock
           ),
           governor.queryFilter(
-            governor.filters.VoteCastWithParams(address, BigInt(proposalId))
+            governor.filters.VoteCastWithParams(address, BigInt(proposalId)),
+            snapshotBlock
           ),
         ]
       )
@@ -134,7 +133,7 @@ function ProposalWritePanelConnected({
       )
     },
     onSuccess: async () => {
-      ToastHelper.success('Vote recorded on Base.')
+      ToastHelper.success(`Vote recorded on ${governanceConfig.chainName}.`)
       setReason('')
       await voteStatusQuery.refetch()
       router.refresh()
@@ -192,8 +191,10 @@ function ProposalWritePanelConnected({
     userSupport === null
 
   const canQueue = state === 'Succeeded'
+  // Use live client-side time so the button activates without a page reload.
+  const nowLive = BigInt(Math.floor(Date.now() / 1000))
   const canExecute =
-    state === 'Queued' && !!etaSeconds && now >= BigInt(etaSeconds)
+    state === 'Queued' && !!etaSeconds && nowLive >= BigInt(etaSeconds)
 
   return (
     <>
@@ -223,18 +224,21 @@ function ProposalWritePanelConnected({
                 Voting power at snapshot
               </div>
               <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
-                {formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)}{' '}
-                {tokenSymbol}
+                {voteStatusQuery.isLoading
+                  ? 'Loading…'
+                  : `${formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)} ${tokenSymbol}`}
               </div>
               <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                {userSupport !== null
-                  ? `You voted ${supportLabel(userSupport)}.`
-                  : state !== 'Active'
-                    ? 'Voting is not currently active for this proposal.'
-                    : voteStatusQuery.data &&
-                        voteStatusQuery.data.votingPower === 0n
-                      ? 'You had no voting power at the proposal snapshot.'
-                      : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                {voteStatusQuery.isLoading
+                  ? 'Fetching your voting power…'
+                  : userSupport !== null
+                    ? `You voted ${supportLabel(userSupport)}.`
+                    : state !== 'Active'
+                      ? 'Voting is not currently active for this proposal.'
+                      : voteStatusQuery.data &&
+                          voteStatusQuery.data.votingPower === 0n
+                        ? 'You had no voting power at the proposal snapshot.'
+                        : 'Choose For, Against, or Abstain and optionally include a reason.'}
               </p>
             </div>
 
@@ -297,7 +301,7 @@ function ProposalWritePanelConnected({
                   : state === 'Queued' && etaSeconds
                     ? canExecute
                       ? 'The timelock delay has elapsed. Execution is now available.'
-                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), now)}.`
+                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), nowLive)}.`
                     : 'Queueing and execution become available only after a proposal succeeds.'}
               </p>
             </div>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -113,7 +113,8 @@ function ProposalWritePanelConnected({
         : await governor.castVote(BigInt(proposalId), support)
 
       ToastHelper.success('Vote transaction submitted.')
-      await tx.wait()
+      const receipt = await tx.wait()
+      if (receipt?.status === 0) throw new Error('Vote transaction reverted.')
     },
     onError: (error) => {
       setPendingSupport(null)
@@ -158,7 +159,12 @@ function ProposalWritePanelConnected({
           ? 'Queue transaction submitted.'
           : 'Execution transaction submitted.'
       )
-      await tx.wait()
+      const receipt = await tx.wait()
+      if (receipt?.status === 0) {
+        throw new Error(
+          `${action === 'queue' ? 'Queue' : 'Execution'} transaction reverted.`
+        )
+      }
     },
     onError: (error) => {
       ToastHelper.error(
@@ -346,11 +352,12 @@ async function fetchVoteFromSubgraph(
 ): Promise<number | null> {
   // Vote ID in the subgraph is "<proposalId>-<lowercaseAddress>" (from Address.toHexString()).
   const id = `${proposalId}-${voter.toLowerCase()}`
-  const query = `{ vote(id: "${id}") { support } }`
+  // Use variables to avoid GraphQL string injection.
+  const query = `query ($id: ID!) { vote(id: $id) { support } }`
   const response = await fetch(governanceConfig.subgraphUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ query, variables: { id } }),
   })
   if (!response.ok) return null
   const json = await response.json()

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -7,7 +7,7 @@ import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
 import { Contract, isError } from 'ethers'
 import { useRouter } from 'next/navigation'
 import { governanceEnv } from '~/config/env'
-import { governanceConfig } from '~/config/governance'
+import { governanceConfig, txExplorerUrl } from '~/config/governance'
 import { useConnectModal } from '~/hooks/useConnectModal'
 import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
 import {
@@ -279,9 +279,14 @@ function ProposalWritePanelConnected({
                   </p>
                 )}
                 {castVote.transactionHash && (
-                  <p className="mt-1 break-all font-mono text-xs text-brand-ui-primary/50">
+                  <a
+                    className="mt-1 block break-all font-mono text-xs text-brand-ui-primary/50 underline hover:text-brand-ui-primary"
+                    href={txExplorerUrl(castVote.transactionHash)}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
                     {castVote.transactionHash}
-                  </p>
+                  </a>
                 )}
               </div>
             </section>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -369,8 +369,10 @@ async function fetchVoteFromSubgraph(
   const json = await response.json()
   if (json?.errors?.length)
     throw new Error(`Subgraph error: ${json.errors[0].message}`)
+  // Validate that the response has the expected shape before reading data.
+  if (!json?.data) throw new Error('Unexpected subgraph response: missing data')
   // null means the vote entity does not exist — user has not voted.
-  const vote = json?.data?.vote
+  const vote = json.data.vote
   if (!vote) return null
   const support = Number(vote.support)
   return [0, 1, 2].includes(support) ? support : null

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -120,7 +120,7 @@ function ProposalWritePanelConnected({
       )
     },
     onSuccess: async (_, support) => {
-      ToastHelper.success(`Vote recorded on ${governanceConfig.chainName}.`)
+      ToastHelper.success(`Vote confirmed on ${governanceConfig.chainName}.`)
       setPendingSupport(null)
       setReason('')
       // Optimistically update the query cache — the subgraph lags behind chain
@@ -349,7 +349,9 @@ async function fetchVoteFromSubgraph(
   proposalId: string,
   voter: string
 ): Promise<number | null> {
-  // Vote ID in the subgraph is "<proposalId>-<lowercaseAddress>" (from Address.toHexString()).
+  // Vote ID in the subgraph is "<proposalId>-<lowercaseAddress>".
+  // Format defined in subgraph/src/governance.ts createVote():
+  //   new Vote(proposalId.toString().concat('-').concat(voter.toHexString()))
   const id = `${proposalId}-${voter.toLowerCase()}`
   // Use variables to avoid GraphQL string injection.
   const query = `query ($id: ID!) { vote(id: $id) { support } }`

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -34,7 +34,8 @@ type ProposalWritePanelProps = {
 }
 
 type CastVote = {
-  support: number
+  // null when voted on-chain but subgraph hasn't indexed the vote yet
+  support: number | null
   createdAt: bigint
   transactionHash: string
 }
@@ -102,11 +103,21 @@ function ProposalWritePanelConnected({
         BigInt(proposalId)
       )) as bigint
       if (!address) return { castVote: null, tokenBalance: 0n, votingPower: 0n }
-      const [votingPower, tokenBalance, castVote] = await Promise.all([
-        governor.getVotes(address, snapshotBlock) as Promise<bigint>,
-        getTokenContract().balanceOf(address) as Promise<bigint>,
-        fetchVoteFromSubgraph(proposalId, address),
-      ])
+      const [votingPower, tokenBalance, hasVoted, castVoteFromSubgraph] =
+        await Promise.all([
+          governor.getVotes(address, snapshotBlock) as Promise<bigint>,
+          getTokenContract().balanceOf(address) as Promise<bigint>,
+          governor.hasVoted(BigInt(proposalId), address) as Promise<boolean>,
+          fetchVoteFromSubgraph(proposalId, address),
+        ])
+
+      // hasVoted is authoritative — if on-chain says voted but subgraph hasn't
+      // indexed it yet, return a partial castVote so the form is never shown.
+      const castVote =
+        castVoteFromSubgraph ??
+        (hasVoted
+          ? { support: null, createdAt: 0n, transactionHash: '' }
+          : null)
 
       return { castVote, tokenBalance, votingPower }
     },
@@ -233,12 +244,6 @@ function ProposalWritePanelConnected({
   })
 
   const castVote = voteStatusQuery.data?.castVote ?? null
-  const canVote =
-    state === 'Active' &&
-    !voteStatusQuery.isLoading &&
-    voteStatusQuery.data &&
-    voteStatusQuery.data.votingPower > 0n &&
-    castVote === null
 
   const canQueue = state === 'Succeeded'
   const canExecute =
@@ -271,8 +276,15 @@ function ProposalWritePanelConnected({
               </h3>
               <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
                 <div className="text-2xl font-semibold text-brand-ui-primary">
-                  {supportLabel(castVote.support)}
+                  {castVote.support !== null
+                    ? supportLabel(castVote.support)
+                    : 'Vote recorded'}
                 </div>
+                {castVote.support === null && (
+                  <p className="mt-1 text-sm text-brand-ui-primary/65">
+                    Confirming on the subgraph…
+                  </p>
+                )}
                 {castVote.createdAt > 0n && (
                   <p className="mt-1 text-sm text-brand-ui-primary/65">
                     {formatDateTime(castVote.createdAt)}

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -1,0 +1,362 @@
+'use client'
+
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
+import { Contract, JsonRpcProvider } from 'ethers'
+import { useRouter } from 'next/navigation'
+import { governanceEnv } from '~/config/env'
+import { governanceConfig } from '~/config/governance'
+import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
+import { formatRelativeTime, formatTokenAmount } from '~/lib/governance/format'
+import { governorAbi } from '~/lib/governance/rpc'
+import type { ProposalState } from '~/lib/governance/types'
+
+type ProposalWritePanelProps = {
+  calldatas: string[]
+  descriptionHash: string
+  etaSeconds: string | null
+  latestTimestamp: string
+  proposalId: string
+  state: ProposalState
+  targets: string[]
+  values: string[]
+  voteStartTimestamp: string
+}
+
+type VoteStatus = {
+  support: number | null
+  votingPower: bigint
+}
+
+export function ProposalWritePanel(props: ProposalWritePanelProps) {
+  if (!governanceEnv.privyAppId) {
+    return (
+      <>
+        <WalletStateCard
+          title="Wallet actions require Privy configuration"
+          description="Set NEXT_PUBLIC_PRIVY_APP_ID to enable voting, queueing, and execution flows locally."
+        />
+      </>
+    )
+  }
+
+  return <ProposalWritePanelConnected {...props} />
+}
+
+function ProposalWritePanelConnected({
+  calldatas,
+  descriptionHash,
+  etaSeconds,
+  latestTimestamp,
+  proposalId,
+  state,
+  targets,
+  values,
+  voteStartTimestamp,
+}: ProposalWritePanelProps) {
+  const { address, authenticated, canConnect, connect, getSigner, isReady } =
+    useGovernanceWallet()
+  const router = useRouter()
+  const [reason, setReason] = useState('')
+  const now = BigInt(latestTimestamp)
+
+  const voteStatusQuery = useQuery({
+    enabled: Boolean(address),
+    queryKey: ['proposal-vote-status', proposalId, address],
+    queryFn: async (): Promise<VoteStatus> => {
+      const provider = new JsonRpcProvider(
+        governanceConfig.rpcUrl,
+        governanceConfig.chainId
+      )
+      const governor = new Contract(
+        governanceConfig.governorAddress,
+        governorAbi,
+        provider
+      )
+      const [votingPower, voteEvents, voteWithParamsEvents] = await Promise.all(
+        [
+          governor.getVotes(
+            address,
+            BigInt(voteStartTimestamp)
+          ) as Promise<bigint>,
+          governor.queryFilter(
+            governor.filters.VoteCast(address, BigInt(proposalId))
+          ),
+          governor.queryFilter(
+            governor.filters.VoteCastWithParams(address, BigInt(proposalId))
+          ),
+        ]
+      )
+
+      const latestVoteEvent = [...voteEvents, ...voteWithParamsEvents].sort(
+        (left, right) => right.blockNumber - left.blockNumber
+      )[0]
+      const parsedVote = latestVoteEvent
+        ? governor.interface.parseLog(latestVoteEvent)
+        : null
+
+      return {
+        support:
+          parsedVote && 'support' in parsedVote.args
+            ? Number(parsedVote.args.support)
+            : null,
+        votingPower,
+      }
+    },
+  })
+
+  const voteMutation = useMutation({
+    mutationFn: async (support: 0 | 1 | 2) => {
+      const signer = await getSigner()
+      const governor = new Contract(
+        governanceConfig.governorAddress,
+        governorAbi,
+        signer
+      )
+      const tx = reason.trim()
+        ? await governor.castVoteWithReason(
+            BigInt(proposalId),
+            support,
+            reason.trim()
+          )
+        : await governor.castVote(BigInt(proposalId), support)
+
+      ToastHelper.success('Vote transaction submitted.')
+      await tx.wait()
+    },
+    onError: (error) => {
+      ToastHelper.error(
+        error instanceof Error ? error.message : 'Unable to cast vote.'
+      )
+    },
+    onSuccess: async () => {
+      ToastHelper.success('Vote recorded on Base.')
+      setReason('')
+      await voteStatusQuery.refetch()
+      router.refresh()
+    },
+  })
+
+  const actionMutation = useMutation({
+    mutationFn: async (action: 'queue' | 'execute') => {
+      const signer = await getSigner()
+      const governor = new Contract(
+        governanceConfig.governorAddress,
+        governorAbi,
+        signer
+      )
+      const tx =
+        action === 'queue'
+          ? await governor.queue(
+              targets,
+              values.map((value) => BigInt(value)),
+              calldatas,
+              descriptionHash
+            )
+          : await governor.execute(
+              targets,
+              values.map((value) => BigInt(value)),
+              calldatas,
+              descriptionHash
+            )
+
+      ToastHelper.success(
+        action === 'queue'
+          ? 'Queue transaction submitted.'
+          : 'Execution transaction submitted.'
+      )
+      await tx.wait()
+    },
+    onError: (error) => {
+      ToastHelper.error(
+        error instanceof Error ? error.message : 'Unable to submit action.'
+      )
+    },
+    onSuccess: async (_, action) => {
+      ToastHelper.success(
+        action === 'queue' ? 'Proposal queued.' : 'Proposal executed.'
+      )
+      router.refresh()
+    },
+  })
+
+  const userSupport = voteStatusQuery.data?.support ?? null
+  const canVote =
+    state === 'Active' &&
+    voteStatusQuery.data &&
+    voteStatusQuery.data.votingPower > 0n &&
+    userSupport === null
+
+  const canQueue = state === 'Succeeded'
+  const canExecute =
+    state === 'Queued' && !!etaSeconds && now >= BigInt(etaSeconds)
+
+  return (
+    <>
+      {!canConnect ? (
+        <WalletStateCard
+          title="Wallet actions are unavailable"
+          description="Privy is not configured in this environment."
+        />
+      ) : null}
+
+      {canConnect && !authenticated ? (
+        <WalletStateCard
+          action={<Button onClick={() => connect()}>Connect wallet</Button>}
+          title="Connect a wallet to interact with this proposal"
+          description="Voting, queueing, and execution all require a connected wallet on Base."
+        />
+      ) : null}
+
+      {canConnect && authenticated && !address ? (
+        <WalletStateCard
+          title={isReady ? 'Select a wallet in Privy' : 'Loading wallet state'}
+          description="Once a wallet is connected, this page will load your vote status and enable governance actions."
+        />
+      ) : null}
+
+      {address ? (
+        <>
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+              Cast vote
+            </h3>
+            <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+              <div className="text-sm text-brand-ui-primary/65">
+                Voting power at snapshot
+              </div>
+              <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
+                {formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)}{' '}
+                {governanceConfig.tokenSymbol}
+              </div>
+              <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                {userSupport !== null
+                  ? `You voted ${supportLabel(userSupport)}.`
+                  : state !== 'Active'
+                    ? 'Voting is not currently active for this proposal.'
+                    : voteStatusQuery.data &&
+                        voteStatusQuery.data.votingPower === 0n
+                      ? 'You had no voting power at the proposal snapshot.'
+                      : 'Choose For, Against, or Abstain and optionally include a reason.'}
+              </p>
+            </div>
+
+            <div className="mt-5">
+              <TextBox
+                description="Optional reason submitted on-chain with your vote."
+                disabled={!canVote || voteMutation.isPending}
+                label="Vote reason"
+                onChange={(event) => setReason(event.target.value)}
+                placeholder="Share your rationale"
+                rows={4}
+                value={reason}
+              />
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <Button
+                disabled={!canVote}
+                loading={voteMutation.isPending}
+                onClick={() => voteMutation.mutate(1)}
+              >
+                Vote For
+              </Button>
+              <Button
+                disabled={!canVote}
+                loading={voteMutation.isPending}
+                onClick={() => voteMutation.mutate(0)}
+                variant="outlined-primary"
+              >
+                Vote Against
+              </Button>
+              <Button
+                disabled={!canVote}
+                loading={voteMutation.isPending}
+                onClick={() => voteMutation.mutate(2)}
+                variant="secondary"
+              >
+                Abstain
+              </Button>
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+              Lifecycle action
+            </h3>
+            <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+              <div className="text-lg font-semibold text-brand-ui-primary">
+                {canQueue
+                  ? 'Queue proposal'
+                  : state === 'Queued'
+                    ? canExecute
+                      ? 'Execute proposal'
+                      : 'Waiting for timelock'
+                    : 'No action available'}
+              </div>
+              <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                {canQueue
+                  ? 'This proposal passed and can now be queued in the timelock.'
+                  : state === 'Queued' && etaSeconds
+                    ? canExecute
+                      ? 'The timelock delay has elapsed. Execution is now available.'
+                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), now)}.`
+                    : 'Queueing and execution become available only after a proposal succeeds.'}
+              </p>
+            </div>
+
+            <div className="mt-5">
+              <Button
+                disabled={!canQueue && !canExecute}
+                loading={actionMutation.isPending}
+                onClick={() =>
+                  actionMutation.mutate(canQueue ? 'queue' : 'execute')
+                }
+              >
+                {canQueue
+                  ? 'Queue proposal'
+                  : canExecute
+                    ? 'Execute proposal'
+                    : 'No action available'}
+              </Button>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+function WalletStateCard({
+  action,
+  description,
+  title,
+}: {
+  action?: ReactNode
+  description: string
+  title: string
+}) {
+  return (
+    <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+      <h3 className="text-xl font-semibold text-brand-ui-primary">{title}</h3>
+      <p className="mt-3 text-sm leading-6 text-brand-ui-primary/70">
+        {description}
+      </p>
+      {action ? <div className="mt-5">{action}</div> : null}
+    </section>
+  )
+}
+
+function supportLabel(support: number) {
+  if (support === 0) {
+    return 'Against'
+  }
+
+  if (support === 1) {
+    return 'For'
+  }
+
+  return 'Abstain'
+}

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -237,6 +237,9 @@ function ProposalWritePanelConnected({
   const castVote = voteStatusQuery.data?.castVote ?? null
 
   const canQueue = state === 'Succeeded'
+  // canExecute uses the client-side clock — if subgraph state lags, the button
+  // may appear prematurely. The on-chain pre-flight in actionMutation.mutationFn
+  // is the authoritative check and will revert before any gas is spent.
   const canExecute =
     state === 'Queued' &&
     etaSeconds !== null &&
@@ -345,9 +348,10 @@ function ProposalWritePanelConnected({
 
                 <div className="mt-5">
                   <TextBox
-                    description="Optional reason submitted on-chain with your vote."
+                    description="Optional reason submitted on-chain with your vote. Max 1000 characters."
                     disabled={voteMutation.isPending}
                     label="Vote reason"
+                    maxLength={1000}
                     onChange={(event) => setReason(event.target.value)}
                     placeholder="Share your rationale"
                     rows={4}

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -56,13 +56,14 @@ function ProposalWritePanelConnected({
     useGovernanceWallet()
   const router = useRouter()
   const [reason, setReason] = useState('')
-  // Tick every minute while Queued so canExecute activates without a reload.
+  const [pendingSupport, setPendingSupport] = useState<0 | 1 | 2 | null>(null)
+  // Tick every 15s while Queued so canExecute activates without a reload.
   const [now, setNow] = useState(() => BigInt(Math.floor(Date.now() / 1000)))
   useEffect(() => {
     if (state !== 'Queued') return
     const id = setInterval(
       () => setNow(BigInt(Math.floor(Date.now() / 1000))),
-      60_000
+      15_000
     )
     return () => clearInterval(id)
   }, [state])
@@ -80,21 +81,24 @@ function ProposalWritePanelConnected({
         governorAbi,
         provider
       )
-      // proposalSnapshot returns the block number used as the voting snapshot —
-      // use it as fromBlock to avoid scanning from genesis (RPC providers cap ranges).
-      const snapshotBlock = (await governor.proposalSnapshot(
-        BigInt(proposalId)
-      )) as bigint
+      // Bound queryFilter to the voting period to stay within RPC provider
+      // block-range caps (typically 2,000–10,000 blocks).
+      const [snapshotBlock, deadlineBlock] = await Promise.all([
+        governor.proposalSnapshot(BigInt(proposalId)) as Promise<bigint>,
+        governor.proposalDeadline(BigInt(proposalId)) as Promise<bigint>,
+      ])
       const [votingPower, voteEvents, voteWithParamsEvents] = await Promise.all(
         [
           governor.getVotes(address, snapshotBlock) as Promise<bigint>,
           governor.queryFilter(
             governor.filters.VoteCast(address, BigInt(proposalId)),
-            snapshotBlock
+            snapshotBlock,
+            deadlineBlock
           ),
           governor.queryFilter(
             governor.filters.VoteCastWithParams(address, BigInt(proposalId)),
-            snapshotBlock
+            snapshotBlock,
+            deadlineBlock
           ),
         ]
       )
@@ -118,6 +122,7 @@ function ProposalWritePanelConnected({
 
   const voteMutation = useMutation({
     mutationFn: async (support: 0 | 1 | 2) => {
+      setPendingSupport(support)
       const signer = await getSigner()
       const governor = new Contract(
         governanceConfig.governorAddress,
@@ -136,12 +141,14 @@ function ProposalWritePanelConnected({
       await tx.wait()
     },
     onError: (error) => {
+      setPendingSupport(null)
       ToastHelper.error(
         error instanceof Error ? error.message : 'Unable to cast vote.'
       )
     },
     onSuccess: async () => {
       ToastHelper.success(`Vote recorded on ${governanceConfig.chainName}.`)
+      setPendingSupport(null)
       setReason('')
       await voteStatusQuery.refetch()
       router.refresh()
@@ -266,23 +273,23 @@ function ProposalWritePanelConnected({
 
             <div className="mt-5 grid gap-3 sm:grid-cols-3">
               <Button
-                disabled={!canVote}
-                loading={voteMutation.isPending}
+                disabled={!canVote || voteMutation.isPending}
+                loading={pendingSupport === 1 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(1)}
               >
                 Vote For
               </Button>
               <Button
-                disabled={!canVote}
-                loading={voteMutation.isPending}
+                disabled={!canVote || voteMutation.isPending}
+                loading={pendingSupport === 0 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(0)}
                 variant="outlined-primary"
               >
                 Vote Against
               </Button>
               <Button
-                disabled={!canVote}
-                loading={voteMutation.isPending}
+                disabled={!canVote || voteMutation.isPending}
+                loading={pendingSupport === 2 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(2)}
                 variant="secondary"
               >

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -126,12 +126,14 @@ function ProposalWritePanelConnected({
       // Optimistically update the query cache — the subgraph lags behind chain
       // state, so refetching immediately would return stale data and re-enable
       // the vote buttons. Setting the cache directly keeps the UI consistent.
+      // router.refresh() is intentionally omitted here: RSC page data does not
+      // change when a vote is cast, and calling it would race against the
+      // optimistic update by triggering a background refetch of stale data.
       queryClient.setQueryData(
         ['proposal-vote-status', proposalId, address],
         (prev: VoteStatus | undefined) =>
           prev ? { ...prev, support } : undefined
       )
-      router.refresh()
     },
   })
 

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -304,9 +304,7 @@ function ProposalWritePanelConnected({
             <div className="mt-5">
               <Button
                 disabled={
-                  (!canQueue && !canExecute) ||
-                  actionMutation.isPending ||
-                  actionMutation.isSuccess
+                  (!canQueue && !canExecute) || actionMutation.isPending
                 }
                 loading={actionMutation.isPending}
                 onClick={() =>
@@ -372,7 +370,9 @@ async function fetchVoteFromSubgraph(
     throw new Error(`Subgraph error: ${json.errors[0].message}`)
   // null means the vote entity does not exist — user has not voted.
   const vote = json?.data?.vote
-  return vote ? Number(vote.support) : null
+  if (!vote) return null
+  const support = Number(vote.support)
+  return [0, 1, 2].includes(support) ? support : null
 }
 
 function toUserMessage(error: unknown, fallback: string): string {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
-import { Contract } from 'ethers'
+import { Contract, isError } from 'ethers'
 import { useRouter } from 'next/navigation'
 import { governanceEnv } from '~/config/env'
 import { governanceConfig } from '~/config/governance'
@@ -219,7 +219,7 @@ function ProposalWritePanelConnected({
                   ? 'Loading…'
                   : voteStatusQuery.isError
                     ? 'Unavailable'
-                    : `${formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)} ${tokenSymbol}`}
+                    : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
               </div>
               <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
                 {voteStatusQuery.isLoading
@@ -378,8 +378,10 @@ async function fetchVoteFromSubgraph(
 function toUserMessage(error: unknown, fallback: string): string {
   if (!(error instanceof Error)) return fallback
   // ethers ACTION_REJECTED = user cancelled the wallet popup
-  if ((error as any).code === 'ACTION_REJECTED') return 'Transaction rejected.'
-  return error.message.slice(0, 120)
+  if (isError(error, 'ACTION_REJECTED')) return 'Transaction rejected.'
+  // Trim verbose RPC/revert data before showing to the user.
+  const msg = error.message.replace(/\s*\(.*\)\s*$/, '').trim()
+  return msg.slice(0, 120) || fallback
 }
 
 function supportLabel(support: number) {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -21,6 +21,7 @@ type ProposalWritePanelProps = {
   proposalId: string
   state: ProposalState
   targets: string[]
+  tokenSymbol: string
   values: string[]
   voteStartTimestamp: string
 }
@@ -53,6 +54,7 @@ function ProposalWritePanelConnected({
   proposalId,
   state,
   targets,
+  tokenSymbol,
   values,
   voteStartTimestamp,
 }: ProposalWritePanelProps) {
@@ -229,7 +231,7 @@ function ProposalWritePanelConnected({
               </div>
               <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
                 {formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)}{' '}
-                {governanceConfig.tokenSymbol}
+                {tokenSymbol}
               </div>
               <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
                 {userSupport !== null

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -83,9 +83,10 @@ function ProposalWritePanelConnected({
       const snapshotBlock = (await governor.proposalSnapshot(
         BigInt(proposalId)
       )) as bigint
+      if (!address) return { support: null, votingPower: 0n }
       const [votingPower, voteData] = await Promise.all([
         governor.getVotes(address, snapshotBlock) as Promise<bigint>,
-        fetchVoteFromSubgraph(proposalId, address!),
+        fetchVoteFromSubgraph(proposalId, address),
       ])
 
       return { support: voteData, votingPower }
@@ -115,9 +116,7 @@ function ProposalWritePanelConnected({
     },
     onError: (error) => {
       setPendingSupport(null)
-      ToastHelper.error(
-        error instanceof Error ? error.message : 'Unable to cast vote.'
-      )
+      ToastHelper.error(toUserMessage(error, 'Unable to cast vote.'))
     },
     onSuccess: async (_, support) => {
       ToastHelper.success(`Vote confirmed on ${governanceConfig.chainName}.`)
@@ -164,9 +163,7 @@ function ProposalWritePanelConnected({
       await tx.wait()
     },
     onError: (error) => {
-      ToastHelper.error(
-        error instanceof Error ? error.message : 'Unable to submit action.'
-      )
+      ToastHelper.error(toUserMessage(error, 'Unable to submit action.'))
     },
     onSuccess: async (_, action) => {
       ToastHelper.success(
@@ -307,7 +304,9 @@ function ProposalWritePanelConnected({
             <div className="mt-5">
               <Button
                 disabled={
-                  (!canQueue && !canExecute) || actionMutation.isPending
+                  (!canQueue && !canExecute) ||
+                  actionMutation.isPending ||
+                  actionMutation.isSuccess
                 }
                 loading={actionMutation.isPending}
                 onClick={() =>
@@ -364,6 +363,7 @@ async function fetchVoteFromSubgraph(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables: { id } }),
+    signal: AbortSignal.timeout(10_000),
   })
   if (!response.ok)
     throw new Error(`Subgraph request failed: ${response.status}`)
@@ -373,6 +373,13 @@ async function fetchVoteFromSubgraph(
   // null means the vote entity does not exist — user has not voted.
   const vote = json?.data?.vote
   return vote ? Number(vote.support) : null
+}
+
+function toUserMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) return fallback
+  // ethers ACTION_REJECTED = user cancelled the wallet popup
+  if ((error as any).code === 'ACTION_REJECTED') return 'Transaction rejected.'
+  return error.message.slice(0, 120)
 }
 
 function supportLabel(support: number) {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -30,6 +30,8 @@ type VoteStatus = {
   votingPower: bigint
 }
 
+// ProposalWritePanel intentionally contains no hooks — the early-return guard
+// below is only safe because of this. All hooks live in ProposalWritePanelConnected.
 export function ProposalWritePanel(props: ProposalWritePanelProps) {
   if (!governanceEnv.privyAppId) {
     return (
@@ -149,13 +151,13 @@ function ProposalWritePanelConnected({
         action === 'queue'
           ? await governor.queue(
               targets,
-              values.map((value) => BigInt(value)),
+              values.map((value) => BigInt(value || '0')),
               calldatas,
               descriptionHash
             )
           : await governor.execute(
               targets,
-              values.map((value) => BigInt(value)),
+              values.map((value) => BigInt(value || '0')),
               calldatas,
               descriptionHash
             )

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -254,11 +254,12 @@ function ProposalWritePanelConnected({
               />
             </div>
 
-            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            <div className="mt-5 grid grid-cols-3 gap-2">
               <Button
                 disabled={!canVote || voteMutation.isPending}
                 loading={pendingSupport === 1 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(1)}
+                size="small"
               >
                 Vote For
               </Button>
@@ -266,6 +267,7 @@ function ProposalWritePanelConnected({
                 disabled={!canVote || voteMutation.isPending}
                 loading={pendingSupport === 0 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(0)}
+                size="small"
                 variant="outlined-primary"
               >
                 Vote Against
@@ -274,6 +276,7 @@ function ProposalWritePanelConnected({
                 disabled={!canVote || voteMutation.isPending}
                 loading={pendingSupport === 2 && voteMutation.isPending}
                 onClick={() => voteMutation.mutate(2)}
+                size="small"
                 variant="secondary"
               >
                 Abstain

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -79,15 +79,22 @@ function ProposalWritePanelConnected({
   const [reason, setReason] = useState('')
   const [pendingSupport, setPendingSupport] = useState<0 | 1 | 2 | null>(null)
   // Tick every 15s while Queued so canExecute activates without a reload.
+  // The interval stops once canExecute becomes true (ETA has passed).
   const [now, setNow] = useState(() => BigInt(Math.floor(Date.now() / 1000)))
   useEffect(() => {
     if (state !== 'Queued') return
+    if (
+      etaSeconds !== null &&
+      BigInt(etaSeconds) > 0n &&
+      now >= BigInt(etaSeconds)
+    )
+      return
     const id = setInterval(
       () => setNow(BigInt(Math.floor(Date.now() / 1000))),
       15_000
     )
     return () => clearInterval(id)
-  }, [state])
+  }, [state, etaSeconds, now])
 
   const voteStatusQuery = useQuery({
     enabled: Boolean(address),

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -247,7 +247,10 @@ function ProposalWritePanelConnected({
 
   const canQueue = state === 'Succeeded'
   const canExecute =
-    state === 'Queued' && !!etaSeconds && now >= BigInt(etaSeconds)
+    state === 'Queued' &&
+    etaSeconds !== null &&
+    BigInt(etaSeconds) > 0n &&
+    now >= BigInt(etaSeconds)
 
   return (
     <>
@@ -290,16 +293,17 @@ function ProposalWritePanelConnected({
                     {formatDateTime(castVote.createdAt)}
                   </p>
                 )}
-                {castVote.transactionHash && (
-                  <a
-                    className="mt-2 block text-sm text-brand-ui-primary/65 underline hover:text-brand-ui-primary"
-                    href={txExplorerUrl(castVote.transactionHash)}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    View in block explorer
-                  </a>
-                )}
+                {castVote.transactionHash &&
+                  txExplorerUrl(castVote.transactionHash) && (
+                    <a
+                      className="mt-2 block text-sm text-brand-ui-primary/65 underline hover:text-brand-ui-primary"
+                      href={txExplorerUrl(castVote.transactionHash)!}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      View in block explorer
+                    </a>
+                  )}
               </div>
             </section>
           ) : /* While loading, show nothing to avoid a flash of the vote form. */
@@ -419,6 +423,7 @@ function ProposalWritePanelConnected({
               {(canQueue || canExecute) && (
                 <div className="mt-5">
                   <Button
+                    disabled={actionMutation.isPending}
                     loading={actionMutation.isPending}
                     onClick={() =>
                       actionMutation.mutate(canQueue ? 'queue' : 'execute')

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -98,6 +98,7 @@ function ProposalWritePanelConnected({
   const voteMutation = useMutation({
     mutationFn: async (support: 0 | 1 | 2) => {
       setPendingSupport(support)
+      // getSigner() calls ensureBaseNetwork() which switches to Base or throws.
       const signer = await getSigner()
       const governor = new Contract(
         governanceConfig.governorAddress,
@@ -359,8 +360,12 @@ async function fetchVoteFromSubgraph(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables: { id } }),
   })
-  if (!response.ok) return null
+  if (!response.ok)
+    throw new Error(`Subgraph request failed: ${response.status}`)
   const json = await response.json()
+  if (json?.errors?.length)
+    throw new Error(`Subgraph error: ${json.errors[0].message}`)
+  // null means the vote entity does not exist — user has not voted.
   const vote = json?.data?.vote
   return vote ? Number(vote.support) : null
 }

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -58,7 +58,7 @@ function ProposalWritePanelConnected({
   values,
   voteStartTimestamp,
 }: ProposalWritePanelProps) {
-  const { address, authenticated, canConnect, connect, getSigner, isReady } =
+  const { address, authenticated, connect, getSigner, isReady } =
     useGovernanceWallet()
   const router = useRouter()
   const [reason, setReason] = useState('')
@@ -197,14 +197,7 @@ function ProposalWritePanelConnected({
 
   return (
     <>
-      {!canConnect ? (
-        <WalletStateCard
-          title="Wallet actions are unavailable"
-          description="Privy is not configured in this environment."
-        />
-      ) : null}
-
-      {canConnect && !authenticated ? (
+      {!authenticated ? (
         <WalletStateCard
           action={<Button onClick={() => connect()}>Connect wallet</Button>}
           title="Connect a wallet to interact with this proposal"
@@ -212,7 +205,7 @@ function ProposalWritePanelConnected({
         />
       ) : null}
 
-      {canConnect && authenticated && !address ? (
+      {authenticated && !address ? (
         <WalletStateCard
           title={isReady ? 'Select a wallet in Privy' : 'Loading wallet state'}
           description="Once a wallet is connected, this page will load your vote status and enable governance actions."

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -147,6 +147,31 @@ function ProposalWritePanelConnected({
         governorAbi,
         signer
       )
+
+      // Pre-flight: read on-chain state to give a clear error before spending
+      // gas. The subgraph state can lag, so this catches state mismatches early.
+      const onChainState = (await governor.state(BigInt(proposalId))) as bigint
+      const expectedState = action === 'queue' ? 4n : 5n // 4=Succeeded, 5=Queued
+      if (onChainState !== expectedState) {
+        const stateLabels: Record<string, string> = {
+          '0': 'Pending',
+          '1': 'Active',
+          '2': 'Canceled',
+          '3': 'Defeated',
+          '4': 'Succeeded',
+          '5': 'Queued',
+          '6': 'Expired',
+          '7': 'Executed',
+        }
+        const label =
+          stateLabels[onChainState.toString()] ?? `state ${onChainState}`
+        throw new Error(
+          action === 'queue'
+            ? `Cannot queue: proposal is ${label} on-chain (expected Succeeded).`
+            : `Cannot execute: proposal is ${label} on-chain (expected Queued).`
+        )
+      }
+
       const tx =
         action === 'queue'
           ? await governor.queue(
@@ -392,9 +417,12 @@ function toUserMessage(error: unknown, fallback: string): string {
   if (!(error instanceof Error)) return fallback
   // ethers ACTION_REJECTED = user cancelled the wallet popup
   if (isError(error, 'ACTION_REJECTED')) return 'Transaction rejected.'
-  // Trim verbose RPC/revert data before showing to the user.
-  const msg = error.message.replace(/\s*\(.*\)\s*$/, '').trim()
-  return msg.slice(0, 120) || fallback
+  // ethers CALL_EXCEPTION carries a clean reason string — use it directly.
+  if (isError(error, 'CALL_EXCEPTION') && error.reason) return error.reason
+  // For other errors, strip only verbose RPC context that appears after a
+  // newline, keeping the first line which usually has the useful message.
+  const firstLine = error.message.split('\n')[0].trim()
+  return firstLine.slice(0, 160) || fallback
 }
 
 function supportLabel(support: number) {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -172,6 +172,9 @@ function ProposalWritePanelConnected({
       ToastHelper.success(
         action === 'queue' ? 'Proposal queued.' : 'Proposal executed.'
       )
+      queryClient.invalidateQueries({
+        queryKey: ['proposal-vote-status', proposalId, address],
+      })
       router.refresh()
     },
   })
@@ -315,7 +318,9 @@ function ProposalWritePanelConnected({
                   ? 'Queue proposal'
                   : canExecute
                     ? 'Execute proposal'
-                    : 'No action available'}
+                    : state === 'Queued'
+                      ? 'Waiting for timelock'
+                      : 'No action available'}
               </Button>
             </div>
           </section>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -20,6 +20,7 @@ import {
   getRpcProvider,
   governorAbi,
 } from '~/lib/governance/rpc'
+import { ON_CHAIN_STATE } from '~/lib/governance/proposals'
 import type { ProposalState } from '~/lib/governance/types'
 
 type ProposalWritePanelProps = {
@@ -190,18 +191,8 @@ function ProposalWritePanelConnected({
       const onChainState = (await governor.state(BigInt(proposalId))) as bigint
       const expectedState = action === 'queue' ? 4n : 5n // 4=Succeeded, 5=Queued
       if (onChainState !== expectedState) {
-        const stateLabels: Record<string, string> = {
-          '0': 'Pending',
-          '1': 'Active',
-          '2': 'Canceled',
-          '3': 'Defeated',
-          '4': 'Succeeded',
-          '5': 'Queued',
-          '6': 'Expired',
-          '7': 'Executed',
-        }
         const label =
-          stateLabels[onChainState.toString()] ?? `state ${onChainState}`
+          ON_CHAIN_STATE[Number(onChainState)] ?? `state ${onChainState}`
         throw new Error(
           action === 'queue'
             ? `Cannot queue: proposal is ${label} on-chain (expected Succeeded).`
@@ -213,13 +204,13 @@ function ProposalWritePanelConnected({
         action === 'queue'
           ? await governor.queue(
               targets,
-              values.map((value) => BigInt(value || '0')),
+              values.map((value) => BigInt(value || 0)),
               calldatas,
               descriptionHash
             )
           : await governor.execute(
               targets,
-              values.map((value) => BigInt(value || '0')),
+              values.map((value) => BigInt(value || 0)),
               calldatas,
               descriptionHash
             )

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -4,13 +4,13 @@ import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
-import { Contract, JsonRpcProvider } from 'ethers'
+import { Contract } from 'ethers'
 import { useRouter } from 'next/navigation'
 import { governanceEnv } from '~/config/env'
 import { governanceConfig } from '~/config/governance'
 import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
 import { formatRelativeTime, formatTokenAmount } from '~/lib/governance/format'
-import { governorAbi } from '~/lib/governance/rpc'
+import { getRpcProvider, governorAbi } from '~/lib/governance/rpc'
 import type { ProposalState } from '~/lib/governance/types'
 
 type ProposalWritePanelProps = {
@@ -72,14 +72,10 @@ function ProposalWritePanelConnected({
     enabled: Boolean(address),
     queryKey: ['proposal-vote-status', proposalId, address],
     queryFn: async (): Promise<VoteStatus> => {
-      const provider = new JsonRpcProvider(
-        governanceConfig.rpcUrl,
-        governanceConfig.chainId
-      )
       const governor = new Contract(
         governanceConfig.governorAddress,
         governorAbi,
-        provider
+        getRpcProvider()
       )
       // Query votingPower and the user's cast vote in parallel.
       // Vote lookup uses the subgraph to avoid queryFilter block-range limits.
@@ -114,8 +110,7 @@ function ProposalWritePanelConnected({
         : await governor.castVote(BigInt(proposalId), support)
 
       ToastHelper.success('Vote transaction submitted.')
-      const receipt = await tx.wait()
-      if (receipt?.status === 0) throw new Error('Vote transaction reverted.')
+      await tx.wait()
     },
     onError: (error) => {
       setPendingSupport(null)
@@ -160,12 +155,7 @@ function ProposalWritePanelConnected({
           ? 'Queue transaction submitted.'
           : 'Execution transaction submitted.'
       )
-      const receipt = await tx.wait()
-      if (receipt?.status === 0) {
-        throw new Error(
-          `${action === 'queue' ? 'Queue' : 'Execution'} transaction reverted.`
-        )
-      }
+      await tx.wait()
     },
     onError: (error) => {
       ToastHelper.error(
@@ -307,7 +297,9 @@ function ProposalWritePanelConnected({
 
             <div className="mt-5">
               <Button
-                disabled={!canQueue && !canExecute}
+                disabled={
+                  (!canQueue && !canExecute) || actionMutation.isPending
+                }
                 loading={actionMutation.isPending}
                 onClick={() =>
                   actionMutation.mutate(canQueue ? 'queue' : 'execute')

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -10,7 +10,11 @@ import { governanceEnv } from '~/config/env'
 import { governanceConfig } from '~/config/governance'
 import { useConnectModal } from '~/hooks/useConnectModal'
 import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
-import { formatRelativeTime, formatTokenAmount } from '~/lib/governance/format'
+import {
+  formatDateTime,
+  formatRelativeTime,
+  formatTokenAmount,
+} from '~/lib/governance/format'
 import {
   getTokenContract,
   getRpcProvider,
@@ -29,8 +33,14 @@ type ProposalWritePanelProps = {
   values: string[]
 }
 
+type CastVote = {
+  support: number
+  createdAt: bigint
+  transactionHash: string
+}
+
 type VoteStatus = {
-  support: number | null
+  castVote: CastVote | null
   tokenBalance: bigint
   votingPower: bigint
 }
@@ -91,14 +101,14 @@ function ProposalWritePanelConnected({
       const snapshotBlock = (await governor.proposalSnapshot(
         BigInt(proposalId)
       )) as bigint
-      if (!address) return { support: null, tokenBalance: 0n, votingPower: 0n }
-      const [votingPower, tokenBalance, voteData] = await Promise.all([
+      if (!address) return { castVote: null, tokenBalance: 0n, votingPower: 0n }
+      const [votingPower, tokenBalance, castVote] = await Promise.all([
         governor.getVotes(address, snapshotBlock) as Promise<bigint>,
         getTokenContract().balanceOf(address) as Promise<bigint>,
         fetchVoteFromSubgraph(proposalId, address),
       ])
 
-      return { support: voteData, tokenBalance, votingPower }
+      return { castVote, tokenBalance, votingPower }
     },
   })
 
@@ -140,7 +150,17 @@ function ProposalWritePanelConnected({
       queryClient.setQueryData(
         ['proposal-vote-status', proposalId, address],
         (prev: VoteStatus | undefined) =>
-          prev ? { ...prev, support } : undefined
+          prev
+            ? {
+                ...prev,
+                castVote: {
+                  support,
+                  // Approximate timestamp; subgraph will have the real value on next fetch.
+                  createdAt: BigInt(Math.floor(Date.now() / 1000)),
+                  transactionHash: '',
+                },
+              }
+            : undefined
       )
     },
   })
@@ -212,12 +232,13 @@ function ProposalWritePanelConnected({
     },
   })
 
-  const userSupport = voteStatusQuery.data?.support ?? null
+  const castVote = voteStatusQuery.data?.castVote ?? null
   const canVote =
     state === 'Active' &&
+    !voteStatusQuery.isLoading &&
     voteStatusQuery.data &&
     voteStatusQuery.data.votingPower > 0n &&
-    userSupport === null
+    castVote === null
 
   const canQueue = state === 'Succeeded'
   const canExecute =
@@ -242,107 +263,116 @@ function ProposalWritePanelConnected({
 
       {address ? (
         <>
-          {/* Show cast vote only when voting is open or the user already voted. */}
-          {state === 'Active' || userSupport !== null ? (
-            <>
-              {/* User already voted — show confirmation, no form. */}
-              {userSupport !== null ? (
-                <WalletStateCard
-                  title={`You voted ${supportLabel(userSupport)}`}
-                  description="Your vote has been recorded on-chain for this proposal."
-                />
-              ) : /* No voting power — either no tokens or tokens not delegated. */
-              !voteStatusQuery.isLoading &&
-                !voteStatusQuery.isError &&
-                voteStatusQuery.data?.votingPower === 0n ? (
-                <WalletStateCard
-                  title="No voting power"
-                  description={
-                    voteStatusQuery.data.tokenBalance > 0n
-                      ? `You held ${formatTokenAmount(voteStatusQuery.data.tokenBalance)} ${tokenSymbol} but had not delegated at the proposal snapshot. Delegate your tokens before the next proposal to participate.`
-                      : `You held no ${tokenSymbol} at the proposal snapshot block.`
-                  }
-                  action={
-                    voteStatusQuery.data.tokenBalance > 0n ? (
-                      <Button
-                        as="a"
-                        href="/delegates"
-                        size="small"
-                        variant="outlined-primary"
-                      >
-                        Delegate tokens
-                      </Button>
-                    ) : undefined
-                  }
-                />
-              ) : (
-                <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-                  <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-                    Cast vote
-                  </h3>
-                  <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
-                    <div className="text-sm text-brand-ui-primary/65">
-                      Voting power at snapshot
-                    </div>
-                    <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
-                      {voteStatusQuery.isLoading
-                        ? 'Loading…'
-                        : voteStatusQuery.isError
-                          ? 'Unavailable'
-                          : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
-                    </div>
-                    <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                      {voteStatusQuery.isLoading
-                        ? 'Fetching your voting power…'
-                        : voteStatusQuery.isError
-                          ? 'Could not load vote status. Check your connection and reload.'
-                          : 'Choose For, Against, or Abstain and optionally include a reason.'}
-                    </p>
-                  </div>
-
-                  <div className="mt-5">
-                    <TextBox
-                      description="Optional reason submitted on-chain with your vote."
-                      disabled={voteMutation.isPending}
-                      label="Vote reason"
-                      onChange={(event) => setReason(event.target.value)}
-                      placeholder="Share your rationale"
-                      rows={4}
-                      value={reason}
-                    />
-                  </div>
-
-                  <div className="mt-5 grid grid-cols-3 gap-2">
+          {/* Already voted — show confirmation with date and tx. Never show form. */}
+          {castVote !== null ? (
+            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+                Your vote
+              </h3>
+              <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+                <div className="text-2xl font-semibold text-brand-ui-primary">
+                  {supportLabel(castVote.support)}
+                </div>
+                {castVote.createdAt > 0n && (
+                  <p className="mt-1 text-sm text-brand-ui-primary/65">
+                    {formatDateTime(castVote.createdAt)}
+                  </p>
+                )}
+                {castVote.transactionHash && (
+                  <p className="mt-1 break-all font-mono text-xs text-brand-ui-primary/50">
+                    {castVote.transactionHash}
+                  </p>
+                )}
+              </div>
+            </section>
+          ) : /* While loading, show nothing to avoid a flash of the vote form. */
+          voteStatusQuery.isLoading ? null : state === 'Active' ? (
+            /* No voting power — either no tokens or tokens not delegated. */
+            !voteStatusQuery.isError &&
+            voteStatusQuery.data?.votingPower === 0n ? (
+              <WalletStateCard
+                title="No voting power"
+                description={
+                  voteStatusQuery.data.tokenBalance > 0n
+                    ? `You held ${formatTokenAmount(voteStatusQuery.data.tokenBalance)} ${tokenSymbol} but had not delegated at the proposal snapshot. Delegate your tokens before the next proposal to participate.`
+                    : `You held no ${tokenSymbol} at the proposal snapshot block.`
+                }
+                action={
+                  voteStatusQuery.data.tokenBalance > 0n ? (
                     <Button
-                      disabled={voteMutation.isPending}
-                      loading={pendingSupport === 1 && voteMutation.isPending}
-                      onClick={() => voteMutation.mutate(1)}
-                      size="small"
-                    >
-                      Vote For
-                    </Button>
-                    <Button
-                      disabled={voteMutation.isPending}
-                      loading={pendingSupport === 0 && voteMutation.isPending}
-                      onClick={() => voteMutation.mutate(0)}
+                      as="a"
+                      href="/delegates"
                       size="small"
                       variant="outlined-primary"
                     >
-                      Vote Against
+                      Delegate tokens
                     </Button>
-                    <Button
-                      disabled={voteMutation.isPending}
-                      loading={pendingSupport === 2 && voteMutation.isPending}
-                      onClick={() => voteMutation.mutate(2)}
-                      size="small"
-                      variant="secondary"
-                    >
-                      Abstain
-                    </Button>
+                  ) : undefined
+                }
+              />
+            ) : (
+              <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+                  Cast vote
+                </h3>
+                <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+                  <div className="text-sm text-brand-ui-primary/65">
+                    Voting power at snapshot
                   </div>
-                </section>
-              )}
-            </>
+                  <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
+                    {voteStatusQuery.isError
+                      ? 'Unavailable'
+                      : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                    {voteStatusQuery.isError
+                      ? 'Could not load vote status. Check your connection and reload.'
+                      : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                  </p>
+                </div>
+
+                <div className="mt-5">
+                  <TextBox
+                    description="Optional reason submitted on-chain with your vote."
+                    disabled={voteMutation.isPending}
+                    label="Vote reason"
+                    onChange={(event) => setReason(event.target.value)}
+                    placeholder="Share your rationale"
+                    rows={4}
+                    value={reason}
+                  />
+                </div>
+
+                <div className="mt-5 grid grid-cols-3 gap-2">
+                  <Button
+                    disabled={voteMutation.isPending}
+                    loading={pendingSupport === 1 && voteMutation.isPending}
+                    onClick={() => voteMutation.mutate(1)}
+                    size="small"
+                  >
+                    Vote For
+                  </Button>
+                  <Button
+                    disabled={voteMutation.isPending}
+                    loading={pendingSupport === 0 && voteMutation.isPending}
+                    onClick={() => voteMutation.mutate(0)}
+                    size="small"
+                    variant="outlined-primary"
+                  >
+                    Vote Against
+                  </Button>
+                  <Button
+                    disabled={voteMutation.isPending}
+                    loading={pendingSupport === 2 && voteMutation.isPending}
+                    onClick={() => voteMutation.mutate(2)}
+                    size="small"
+                    variant="secondary"
+                  >
+                    Abstain
+                  </Button>
+                </div>
+              </section>
+            )
           ) : null}
 
           {(canQueue || state === 'Queued') && (
@@ -412,13 +442,13 @@ function WalletStateCard({
 async function fetchVoteFromSubgraph(
   proposalId: string,
   voter: string
-): Promise<number | null> {
+): Promise<CastVote | null> {
   // Vote ID in the subgraph is "<proposalId>-<lowercaseAddress>".
   // Format defined in subgraph/src/governance.ts createVote():
   //   new Vote(proposalId.toString().concat('-').concat(voter.toHexString()))
   const id = `${proposalId}-${voter.toLowerCase()}`
   // Use variables to avoid GraphQL string injection.
-  const query = `query ($id: ID!) { vote(id: $id) { support } }`
+  const query = `query ($id: ID!) { vote(id: $id) { support createdAt transactionHash } }`
   const response = await fetch(governanceConfig.subgraphUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -436,7 +466,12 @@ async function fetchVoteFromSubgraph(
   const vote = json.data.vote
   if (!vote) return null
   const support = Number(vote.support)
-  return [0, 1, 2].includes(support) ? support : null
+  if (![0, 1, 2].includes(support)) return null
+  return {
+    support,
+    createdAt: BigInt(vote.createdAt ?? 0),
+    transactionHash: vote.transactionHash ?? '',
+  }
 }
 
 function toUserMessage(error: unknown, fallback: string): string {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -211,78 +211,81 @@ function ProposalWritePanelConnected({
 
       {address ? (
         <>
-          <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-              Cast vote
-            </h3>
-            <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
-              <div className="text-sm text-brand-ui-primary/65">
-                Voting power at snapshot
+          {/* Show cast vote only when voting is open or the user already voted. */}
+          {state === 'Active' || userSupport !== null ? (
+            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+                Cast vote
+              </h3>
+              <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+                <div className="text-sm text-brand-ui-primary/65">
+                  Voting power at snapshot
+                </div>
+                <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
+                  {voteStatusQuery.isLoading
+                    ? 'Loading…'
+                    : voteStatusQuery.isError
+                      ? 'Unavailable'
+                      : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
+                </div>
+                <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                  {voteStatusQuery.isLoading
+                    ? 'Fetching your voting power…'
+                    : voteStatusQuery.isError
+                      ? 'Could not load vote status. Check your connection and reload.'
+                      : userSupport !== null
+                        ? `You voted ${supportLabel(userSupport)}.`
+                        : state !== 'Active'
+                          ? 'Voting is not currently active for this proposal.'
+                          : voteStatusQuery.data &&
+                              voteStatusQuery.data.votingPower === 0n
+                            ? 'You had no voting power at the proposal snapshot.'
+                            : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                </p>
               </div>
-              <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
-                {voteStatusQuery.isLoading
-                  ? 'Loading…'
-                  : voteStatusQuery.isError
-                    ? 'Unavailable'
-                    : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
+
+              <div className="mt-5">
+                <TextBox
+                  description="Optional reason submitted on-chain with your vote."
+                  disabled={!canVote || voteMutation.isPending}
+                  label="Vote reason"
+                  onChange={(event) => setReason(event.target.value)}
+                  placeholder="Share your rationale"
+                  rows={4}
+                  value={reason}
+                />
               </div>
-              <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                {voteStatusQuery.isLoading
-                  ? 'Fetching your voting power…'
-                  : voteStatusQuery.isError
-                    ? 'Could not load vote status. Check your connection and reload.'
-                    : userSupport !== null
-                      ? `You voted ${supportLabel(userSupport)}.`
-                      : state !== 'Active'
-                        ? 'Voting is not currently active for this proposal.'
-                        : voteStatusQuery.data &&
-                            voteStatusQuery.data.votingPower === 0n
-                          ? 'You had no voting power at the proposal snapshot.'
-                          : 'Choose For, Against, or Abstain and optionally include a reason.'}
-              </p>
-            </div>
 
-            <div className="mt-5">
-              <TextBox
-                description="Optional reason submitted on-chain with your vote."
-                disabled={!canVote || voteMutation.isPending}
-                label="Vote reason"
-                onChange={(event) => setReason(event.target.value)}
-                placeholder="Share your rationale"
-                rows={4}
-                value={reason}
-              />
-            </div>
-
-            <div className="mt-5 grid grid-cols-3 gap-2">
-              <Button
-                disabled={!canVote || voteMutation.isPending}
-                loading={pendingSupport === 1 && voteMutation.isPending}
-                onClick={() => voteMutation.mutate(1)}
-                size="small"
-              >
-                Vote For
-              </Button>
-              <Button
-                disabled={!canVote || voteMutation.isPending}
-                loading={pendingSupport === 0 && voteMutation.isPending}
-                onClick={() => voteMutation.mutate(0)}
-                size="small"
-                variant="outlined-primary"
-              >
-                Vote Against
-              </Button>
-              <Button
-                disabled={!canVote || voteMutation.isPending}
-                loading={pendingSupport === 2 && voteMutation.isPending}
-                onClick={() => voteMutation.mutate(2)}
-                size="small"
-                variant="secondary"
-              >
-                Abstain
-              </Button>
-            </div>
-          </section>
+              <div className="mt-5 grid grid-cols-3 gap-2">
+                <Button
+                  disabled={!canVote || voteMutation.isPending}
+                  loading={pendingSupport === 1 && voteMutation.isPending}
+                  onClick={() => voteMutation.mutate(1)}
+                  size="small"
+                >
+                  Vote For
+                </Button>
+                <Button
+                  disabled={!canVote || voteMutation.isPending}
+                  loading={pendingSupport === 0 && voteMutation.isPending}
+                  onClick={() => voteMutation.mutate(0)}
+                  size="small"
+                  variant="outlined-primary"
+                >
+                  Vote Against
+                </Button>
+                <Button
+                  disabled={!canVote || voteMutation.isPending}
+                  loading={pendingSupport === 2 && voteMutation.isPending}
+                  onClick={() => voteMutation.mutate(2)}
+                  size="small"
+                  variant="secondary"
+                >
+                  Abstain
+                </Button>
+              </div>
+            </section>
+          ) : null}
 
           <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
             <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -81,42 +81,17 @@ function ProposalWritePanelConnected({
         governorAbi,
         provider
       )
-      // Bound queryFilter to the voting period to stay within RPC provider
-      // block-range caps (typically 2,000–10,000 blocks).
-      const [snapshotBlock, deadlineBlock] = await Promise.all([
-        governor.proposalSnapshot(BigInt(proposalId)) as Promise<bigint>,
-        governor.proposalDeadline(BigInt(proposalId)) as Promise<bigint>,
+      // Query votingPower and the user's cast vote in parallel.
+      // Vote lookup uses the subgraph to avoid queryFilter block-range limits.
+      const snapshotBlock = (await governor.proposalSnapshot(
+        BigInt(proposalId)
+      )) as bigint
+      const [votingPower, voteData] = await Promise.all([
+        governor.getVotes(address, snapshotBlock) as Promise<bigint>,
+        fetchVoteFromSubgraph(proposalId, address!),
       ])
-      const [votingPower, voteEvents, voteWithParamsEvents] = await Promise.all(
-        [
-          governor.getVotes(address, snapshotBlock) as Promise<bigint>,
-          governor.queryFilter(
-            governor.filters.VoteCast(address, BigInt(proposalId)),
-            snapshotBlock,
-            deadlineBlock
-          ),
-          governor.queryFilter(
-            governor.filters.VoteCastWithParams(address, BigInt(proposalId)),
-            snapshotBlock,
-            deadlineBlock
-          ),
-        ]
-      )
 
-      const latestVoteEvent = [...voteEvents, ...voteWithParamsEvents].sort(
-        (left, right) => right.blockNumber - left.blockNumber
-      )[0]
-      const parsedVote = latestVoteEvent
-        ? governor.interface.parseLog(latestVoteEvent)
-        : null
-
-      return {
-        support:
-          parsedVote && 'support' in parsedVote.args
-            ? Number(parsedVote.args.support)
-            : null,
-        votingPower,
-      }
+      return { support: voteData, votingPower }
     },
   })
 
@@ -363,6 +338,24 @@ function WalletStateCard({
       {action ? <div className="mt-5">{action}</div> : null}
     </section>
   )
+}
+
+async function fetchVoteFromSubgraph(
+  proposalId: string,
+  voter: string
+): Promise<number | null> {
+  // Vote ID in the subgraph is "<proposalId>-<lowercaseAddress>" (from Address.toHexString()).
+  const id = `${proposalId}-${voter.toLowerCase()}`
+  const query = `{ vote(id: "${id}") { support } }`
+  const response = await fetch(governanceConfig.subgraphUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  })
+  if (!response.ok) return null
+  const json = await response.json()
+  const vote = json?.data?.vote
+  return vote ? Number(vote.support) : null
 }
 
 function supportLabel(support: number) {

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
@@ -32,12 +32,10 @@ type VoteStatus = {
 export function ProposalWritePanel(props: ProposalWritePanelProps) {
   if (!governanceEnv.privyAppId) {
     return (
-      <>
-        <WalletStateCard
-          title="Wallet actions require Privy configuration"
-          description="Set NEXT_PUBLIC_PRIVY_APP_ID to enable voting, queueing, and execution flows locally."
-        />
-      </>
+      <WalletStateCard
+        title="Wallet actions require Privy configuration"
+        description="Set NEXT_PUBLIC_PRIVY_APP_ID to enable voting, queueing, and execution flows locally."
+      />
     )
   }
 
@@ -58,6 +56,16 @@ function ProposalWritePanelConnected({
     useGovernanceWallet()
   const router = useRouter()
   const [reason, setReason] = useState('')
+  // Tick every minute while Queued so canExecute activates without a reload.
+  const [now, setNow] = useState(() => BigInt(Math.floor(Date.now() / 1000)))
+  useEffect(() => {
+    if (state !== 'Queued') return
+    const id = setInterval(
+      () => setNow(BigInt(Math.floor(Date.now() / 1000))),
+      60_000
+    )
+    return () => clearInterval(id)
+  }, [state])
 
   const voteStatusQuery = useQuery({
     enabled: Boolean(address),
@@ -191,10 +199,8 @@ function ProposalWritePanelConnected({
     userSupport === null
 
   const canQueue = state === 'Succeeded'
-  // Use live client-side time so the button activates without a page reload.
-  const nowLive = BigInt(Math.floor(Date.now() / 1000))
   const canExecute =
-    state === 'Queued' && !!etaSeconds && nowLive >= BigInt(etaSeconds)
+    state === 'Queued' && !!etaSeconds && now >= BigInt(etaSeconds)
 
   return (
     <>
@@ -226,19 +232,23 @@ function ProposalWritePanelConnected({
               <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
                 {voteStatusQuery.isLoading
                   ? 'Loading…'
-                  : `${formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)} ${tokenSymbol}`}
+                  : voteStatusQuery.isError
+                    ? 'Unavailable'
+                    : `${formatTokenAmount(voteStatusQuery.data?.votingPower || 0n)} ${tokenSymbol}`}
               </div>
               <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
                 {voteStatusQuery.isLoading
                   ? 'Fetching your voting power…'
-                  : userSupport !== null
-                    ? `You voted ${supportLabel(userSupport)}.`
-                    : state !== 'Active'
-                      ? 'Voting is not currently active for this proposal.'
-                      : voteStatusQuery.data &&
-                          voteStatusQuery.data.votingPower === 0n
-                        ? 'You had no voting power at the proposal snapshot.'
-                        : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                  : voteStatusQuery.isError
+                    ? 'Could not load vote status. Check your connection and reload.'
+                    : userSupport !== null
+                      ? `You voted ${supportLabel(userSupport)}.`
+                      : state !== 'Active'
+                        ? 'Voting is not currently active for this proposal.'
+                        : voteStatusQuery.data &&
+                            voteStatusQuery.data.votingPower === 0n
+                          ? 'You had no voting power at the proposal snapshot.'
+                          : 'Choose For, Against, or Abstain and optionally include a reason.'}
               </p>
             </div>
 
@@ -301,7 +311,7 @@ function ProposalWritePanelConnected({
                   : state === 'Queued' && etaSeconds
                     ? canExecute
                       ? 'The timelock delay has elapsed. Execution is now available.'
-                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), nowLive)}.`
+                      : `Execution unlocks ${formatRelativeTime(BigInt(etaSeconds), now)}.`
                     : 'Queueing and execution become available only after a proposal succeeds.'}
               </p>
             </div>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -245,11 +245,16 @@ function ProposalWritePanelConnected({
           {/* Show cast vote only when voting is open or the user already voted. */}
           {state === 'Active' || userSupport !== null ? (
             <>
-              {/* No voting power — either no tokens at all, or tokens not delegated. */}
-              {!voteStatusQuery.isLoading &&
-              !voteStatusQuery.isError &&
-              userSupport === null &&
-              voteStatusQuery.data?.votingPower === 0n ? (
+              {/* User already voted — show confirmation, no form. */}
+              {userSupport !== null ? (
+                <WalletStateCard
+                  title={`You voted ${supportLabel(userSupport)}`}
+                  description="Your vote has been recorded on-chain for this proposal."
+                />
+              ) : /* No voting power — either no tokens or tokens not delegated. */
+              !voteStatusQuery.isLoading &&
+                !voteStatusQuery.isError &&
+                voteStatusQuery.data?.votingPower === 0n ? (
                 <WalletStateCard
                   title="No voting power"
                   description={
@@ -291,16 +296,14 @@ function ProposalWritePanelConnected({
                         ? 'Fetching your voting power…'
                         : voteStatusQuery.isError
                           ? 'Could not load vote status. Check your connection and reload.'
-                          : userSupport !== null
-                            ? `You voted ${supportLabel(userSupport)}.`
-                            : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                          : 'Choose For, Against, or Abstain and optionally include a reason.'}
                     </p>
                   </div>
 
                   <div className="mt-5">
                     <TextBox
                       description="Optional reason submitted on-chain with your vote."
-                      disabled={!canVote || voteMutation.isPending}
+                      disabled={voteMutation.isPending}
                       label="Vote reason"
                       onChange={(event) => setReason(event.target.value)}
                       placeholder="Share your rationale"
@@ -311,7 +314,7 @@ function ProposalWritePanelConnected({
 
                   <div className="mt-5 grid grid-cols-3 gap-2">
                     <Button
-                      disabled={!canVote || voteMutation.isPending}
+                      disabled={voteMutation.isPending}
                       loading={pendingSupport === 1 && voteMutation.isPending}
                       onClick={() => voteMutation.mutate(1)}
                       size="small"
@@ -319,7 +322,7 @@ function ProposalWritePanelConnected({
                       Vote For
                     </Button>
                     <Button
-                      disabled={!canVote || voteMutation.isPending}
+                      disabled={voteMutation.isPending}
                       loading={pendingSupport === 0 && voteMutation.isPending}
                       onClick={() => voteMutation.mutate(0)}
                       size="small"
@@ -328,7 +331,7 @@ function ProposalWritePanelConnected({
                       Vote Against
                     </Button>
                     <Button
-                      disabled={!canVote || voteMutation.isPending}
+                      disabled={voteMutation.isPending}
                       loading={pendingSupport === 2 && voteMutation.isPending}
                       onClick={() => voteMutation.mutate(2)}
                       size="small"

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Button, TextBox, ToastHelper } from '@unlock-protocol/ui'
 import { Contract } from 'ethers'
 import { useRouter } from 'next/navigation'
@@ -55,6 +55,7 @@ function ProposalWritePanelConnected({
   const { address, authenticated, connect, getSigner, isReady } =
     useGovernanceWallet()
   const router = useRouter()
+  const queryClient = useQueryClient()
   const [reason, setReason] = useState('')
   const [pendingSupport, setPendingSupport] = useState<0 | 1 | 2 | null>(null)
   // Tick every 15s while Queued so canExecute activates without a reload.
@@ -109,7 +110,7 @@ function ProposalWritePanelConnected({
           )
         : await governor.castVote(BigInt(proposalId), support)
 
-      ToastHelper.success('Vote transaction submitted.')
+      ToastHelper.success(`Vote submitted — tx: ${tx.hash.slice(0, 10)}…`)
       await tx.wait()
     },
     onError: (error) => {
@@ -118,11 +119,18 @@ function ProposalWritePanelConnected({
         error instanceof Error ? error.message : 'Unable to cast vote.'
       )
     },
-    onSuccess: async () => {
+    onSuccess: async (_, support) => {
       ToastHelper.success(`Vote recorded on ${governanceConfig.chainName}.`)
       setPendingSupport(null)
       setReason('')
-      await voteStatusQuery.refetch()
+      // Optimistically update the query cache — the subgraph lags behind chain
+      // state, so refetching immediately would return stale data and re-enable
+      // the vote buttons. Setting the cache directly keeps the UI consistent.
+      queryClient.setQueryData(
+        ['proposal-vote-status', proposalId, address],
+        (prev: VoteStatus | undefined) =>
+          prev ? { ...prev, support } : undefined
+      )
       router.refresh()
     },
   })
@@ -151,9 +159,7 @@ function ProposalWritePanelConnected({
             )
 
       ToastHelper.success(
-        action === 'queue'
-          ? 'Queue transaction submitted.'
-          : 'Execution transaction submitted.'
+        `${action === 'queue' ? 'Queue' : 'Execution'} submitted — tx: ${tx.hash.slice(0, 10)}…`
       )
       await tx.wait()
     },

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -292,12 +292,12 @@ function ProposalWritePanelConnected({
                 )}
                 {castVote.transactionHash && (
                   <a
-                    className="mt-1 block break-all font-mono text-xs text-brand-ui-primary/50 underline hover:text-brand-ui-primary"
+                    className="mt-2 block text-sm text-brand-ui-primary/65 underline hover:text-brand-ui-primary"
                     href={txExplorerUrl(castVote.transactionHash)}
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    {castVote.transactionHash}
+                    View in block explorer
                   </a>
                 )}
               </div>

--- a/governance-app/src/components/proposals/ProposalWritePanel.tsx
+++ b/governance-app/src/components/proposals/ProposalWritePanel.tsx
@@ -11,7 +11,11 @@ import { governanceConfig } from '~/config/governance'
 import { useConnectModal } from '~/hooks/useConnectModal'
 import { useGovernanceWallet } from '~/hooks/useGovernanceWallet'
 import { formatRelativeTime, formatTokenAmount } from '~/lib/governance/format'
-import { getRpcProvider, governorAbi } from '~/lib/governance/rpc'
+import {
+  getTokenContract,
+  getRpcProvider,
+  governorAbi,
+} from '~/lib/governance/rpc'
 import type { ProposalState } from '~/lib/governance/types'
 
 type ProposalWritePanelProps = {
@@ -27,6 +31,7 @@ type ProposalWritePanelProps = {
 
 type VoteStatus = {
   support: number | null
+  tokenBalance: bigint
   votingPower: bigint
 }
 
@@ -86,13 +91,14 @@ function ProposalWritePanelConnected({
       const snapshotBlock = (await governor.proposalSnapshot(
         BigInt(proposalId)
       )) as bigint
-      if (!address) return { support: null, votingPower: 0n }
-      const [votingPower, voteData] = await Promise.all([
+      if (!address) return { support: null, tokenBalance: 0n, votingPower: 0n }
+      const [votingPower, tokenBalance, voteData] = await Promise.all([
         governor.getVotes(address, snapshotBlock) as Promise<bigint>,
+        getTokenContract().balanceOf(address) as Promise<bigint>,
         fetchVoteFromSubgraph(proposalId, address),
       ])
 
-      return { support: voteData, votingPower }
+      return { support: voteData, tokenBalance, votingPower }
     },
   })
 
@@ -238,78 +244,102 @@ function ProposalWritePanelConnected({
         <>
           {/* Show cast vote only when voting is open or the user already voted. */}
           {state === 'Active' || userSupport !== null ? (
-            <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
-                Cast vote
-              </h3>
-              <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
-                <div className="text-sm text-brand-ui-primary/65">
-                  Voting power at snapshot
-                </div>
-                <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
-                  {voteStatusQuery.isLoading
-                    ? 'Loading…'
-                    : voteStatusQuery.isError
-                      ? 'Unavailable'
-                      : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
-                </div>
-                <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
-                  {voteStatusQuery.isLoading
-                    ? 'Fetching your voting power…'
-                    : voteStatusQuery.isError
-                      ? 'Could not load vote status. Check your connection and reload.'
-                      : userSupport !== null
-                        ? `You voted ${supportLabel(userSupport)}.`
-                        : state !== 'Active'
-                          ? 'Voting is not currently active for this proposal.'
-                          : voteStatusQuery.data &&
-                              voteStatusQuery.data.votingPower === 0n
-                            ? 'You had no voting power at the proposal snapshot.'
-                            : 'Choose For, Against, or Abstain and optionally include a reason.'}
-                </p>
-              </div>
-
-              <div className="mt-5">
-                <TextBox
-                  description="Optional reason submitted on-chain with your vote."
-                  disabled={!canVote || voteMutation.isPending}
-                  label="Vote reason"
-                  onChange={(event) => setReason(event.target.value)}
-                  placeholder="Share your rationale"
-                  rows={4}
-                  value={reason}
+            <>
+              {/* No voting power — either no tokens at all, or tokens not delegated. */}
+              {!voteStatusQuery.isLoading &&
+              !voteStatusQuery.isError &&
+              userSupport === null &&
+              voteStatusQuery.data?.votingPower === 0n ? (
+                <WalletStateCard
+                  title="No voting power"
+                  description={
+                    voteStatusQuery.data.tokenBalance > 0n
+                      ? `You held ${formatTokenAmount(voteStatusQuery.data.tokenBalance)} ${tokenSymbol} but had not delegated at the proposal snapshot. Delegate your tokens before the next proposal to participate.`
+                      : `You held no ${tokenSymbol} at the proposal snapshot block.`
+                  }
+                  action={
+                    voteStatusQuery.data.tokenBalance > 0n ? (
+                      <Button
+                        as="a"
+                        href="/delegates"
+                        size="small"
+                        variant="outlined-primary"
+                      >
+                        Delegate tokens
+                      </Button>
+                    ) : undefined
+                  }
                 />
-              </div>
+              ) : (
+                <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">
+                  <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-ui-primary/55">
+                    Cast vote
+                  </h3>
+                  <div className="mt-4 rounded-3xl bg-ui-secondary-200 p-5">
+                    <div className="text-sm text-brand-ui-primary/65">
+                      Voting power at snapshot
+                    </div>
+                    <div className="mt-2 text-2xl font-semibold text-brand-ui-primary">
+                      {voteStatusQuery.isLoading
+                        ? 'Loading…'
+                        : voteStatusQuery.isError
+                          ? 'Unavailable'
+                          : `${formatTokenAmount(voteStatusQuery.data?.votingPower ?? 0n)} ${tokenSymbol}`}
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-brand-ui-primary/70">
+                      {voteStatusQuery.isLoading
+                        ? 'Fetching your voting power…'
+                        : voteStatusQuery.isError
+                          ? 'Could not load vote status. Check your connection and reload.'
+                          : userSupport !== null
+                            ? `You voted ${supportLabel(userSupport)}.`
+                            : 'Choose For, Against, or Abstain and optionally include a reason.'}
+                    </p>
+                  </div>
 
-              <div className="mt-5 grid grid-cols-3 gap-2">
-                <Button
-                  disabled={!canVote || voteMutation.isPending}
-                  loading={pendingSupport === 1 && voteMutation.isPending}
-                  onClick={() => voteMutation.mutate(1)}
-                  size="small"
-                >
-                  Vote For
-                </Button>
-                <Button
-                  disabled={!canVote || voteMutation.isPending}
-                  loading={pendingSupport === 0 && voteMutation.isPending}
-                  onClick={() => voteMutation.mutate(0)}
-                  size="small"
-                  variant="outlined-primary"
-                >
-                  Vote Against
-                </Button>
-                <Button
-                  disabled={!canVote || voteMutation.isPending}
-                  loading={pendingSupport === 2 && voteMutation.isPending}
-                  onClick={() => voteMutation.mutate(2)}
-                  size="small"
-                  variant="secondary"
-                >
-                  Abstain
-                </Button>
-              </div>
-            </section>
+                  <div className="mt-5">
+                    <TextBox
+                      description="Optional reason submitted on-chain with your vote."
+                      disabled={!canVote || voteMutation.isPending}
+                      label="Vote reason"
+                      onChange={(event) => setReason(event.target.value)}
+                      placeholder="Share your rationale"
+                      rows={4}
+                      value={reason}
+                    />
+                  </div>
+
+                  <div className="mt-5 grid grid-cols-3 gap-2">
+                    <Button
+                      disabled={!canVote || voteMutation.isPending}
+                      loading={pendingSupport === 1 && voteMutation.isPending}
+                      onClick={() => voteMutation.mutate(1)}
+                      size="small"
+                    >
+                      Vote For
+                    </Button>
+                    <Button
+                      disabled={!canVote || voteMutation.isPending}
+                      loading={pendingSupport === 0 && voteMutation.isPending}
+                      onClick={() => voteMutation.mutate(0)}
+                      size="small"
+                      variant="outlined-primary"
+                    >
+                      Vote Against
+                    </Button>
+                    <Button
+                      disabled={!canVote || voteMutation.isPending}
+                      loading={pendingSupport === 2 && voteMutation.isPending}
+                      onClick={() => voteMutation.mutate(2)}
+                      size="small"
+                      variant="secondary"
+                    >
+                      Abstain
+                    </Button>
+                  </div>
+                </section>
+              )}
+            </>
           ) : null}
 
           <section className="rounded-[2rem] border border-brand-ui-primary/10 bg-white p-6 shadow-sm">

--- a/governance-app/src/config/governance.ts
+++ b/governance-app/src/config/governance.ts
@@ -22,6 +22,7 @@ export const governanceConfig = {
     'https://subgraph.unlock-protocol.com/8453',
   timelockAddress: '0xB34567C4cA697b39F72e1a8478f285329A98ed1b',
   tokenAddress: '0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187',
+  explorerUrl: 'https://basescan.org',
   knownContracts: [
     { label: 'UPGovernor', abi: UPGovernor, kind: 'governor' },
     { label: 'UPToken', abi: UPToken, kind: 'token' },
@@ -30,6 +31,10 @@ export const governanceConfig = {
     { label: 'PublicLock', abi: PublicLock, kind: 'publicLock' },
   ],
 } as const
+
+export function txExplorerUrl(hash: string) {
+  return `${governanceConfig.explorerUrl}/tx/${hash}`
+}
 
 export const governanceRoutes = [
   { href: '/', label: 'Home' },

--- a/governance-app/src/config/governance.ts
+++ b/governance-app/src/config/governance.ts
@@ -36,6 +36,10 @@ export function txExplorerUrl(hash: string) {
   return `${governanceConfig.explorerUrl}/tx/${hash}`
 }
 
+export function addressExplorerUrl(address: string) {
+  return `${governanceConfig.explorerUrl}/address/${address}`
+}
+
 export const governanceRoutes = [
   { href: '/', label: 'Home' },
   { href: '/proposals', label: 'Proposals' },

--- a/governance-app/src/config/governance.ts
+++ b/governance-app/src/config/governance.ts
@@ -33,10 +33,12 @@ export const governanceConfig = {
 } as const
 
 export function txExplorerUrl(hash: string) {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(hash)) return null
   return `${governanceConfig.explorerUrl}/tx/${hash}`
 }
 
 export function addressExplorerUrl(address: string) {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(address)) return null
   return `${governanceConfig.explorerUrl}/address/${address}`
 }
 

--- a/governance-app/src/lib/governance/format.ts
+++ b/governance-app/src/lib/governance/format.ts
@@ -71,9 +71,9 @@ export function formatDuration(seconds: bigint | number) {
   if (days) parts.push(`${days}d`)
   if (hours) parts.push(`${hours}h`)
   if (minutes) parts.push(`${minutes}m`)
-  // Seconds are intentionally omitted for multi-day durations — the precision
-  // is not useful when displaying governance delay/period values to users.
-  if (secs && !days) parts.push(`${secs}s`)
+  // Seconds are shown only for sub-hour durations — once hours or days are
+  // present the precision is not useful for governance delay/period display.
+  if (secs && !days && !hours) parts.push(`${secs}s`)
 
   return parts.join(' ')
 }

--- a/governance-app/src/lib/governance/format.ts
+++ b/governance-app/src/lib/governance/format.ts
@@ -71,6 +71,8 @@ export function formatDuration(seconds: bigint | number) {
   if (days) parts.push(`${days}d`)
   if (hours) parts.push(`${hours}h`)
   if (minutes) parts.push(`${minutes}m`)
+  // Seconds are intentionally omitted for multi-day durations — the precision
+  // is not useful when displaying governance delay/period values to users.
   if (secs && !days) parts.push(`${secs}s`)
 
   return parts.join(' ')

--- a/governance-app/src/lib/governance/format.ts
+++ b/governance-app/src/lib/governance/format.ts
@@ -58,6 +58,24 @@ export function formatRelativeTime(timestamp: bigint, now: bigint) {
   return 'just now'
 }
 
+export function formatDuration(seconds: bigint | number) {
+  const s = Number(seconds)
+  if (s <= 0) return '0 seconds'
+
+  const days = Math.floor(s / 86400)
+  const hours = Math.floor((s % 86400) / 3600)
+  const minutes = Math.floor((s % 3600) / 60)
+  const secs = s % 60
+
+  const parts: string[] = []
+  if (days) parts.push(`${days}d`)
+  if (hours) parts.push(`${hours}h`)
+  if (minutes) parts.push(`${minutes}m`)
+  if (secs && !days) parts.push(`${secs}s`)
+
+  return parts.join(' ')
+}
+
 export function truncateAddress(address: string, size = 4) {
   if (address.length <= size * 2 + 2) {
     return address

--- a/governance-app/src/lib/governance/proposals.ts
+++ b/governance-app/src/lib/governance/proposals.ts
@@ -14,7 +14,7 @@ import type {
 } from './types'
 
 // Maps the numeric IProposalState enum returned by governor.state() to our type.
-const ON_CHAIN_STATE: Record<number, ProposalState> = {
+export const ON_CHAIN_STATE: Record<number, ProposalState> = {
   0: 'Pending',
   1: 'Active',
   2: 'Canceled',

--- a/governance-app/src/lib/governance/proposals.ts
+++ b/governance-app/src/lib/governance/proposals.ts
@@ -10,7 +10,20 @@ import type {
   DecodedCalldata,
   GovernanceOverview,
   ProposalRecord,
+  ProposalState,
 } from './types'
+
+// Maps the numeric IProposalState enum returned by governor.state() to our type.
+const ON_CHAIN_STATE: Record<number, ProposalState> = {
+  0: 'Pending',
+  1: 'Active',
+  2: 'Canceled',
+  3: 'Defeated',
+  4: 'Succeeded',
+  5: 'Queued',
+  6: 'Expired',
+  7: 'Executed',
+}
 
 export const getGovernanceOverview = cache(
   async (): Promise<GovernanceOverview> => {
@@ -31,10 +44,33 @@ export const getGovernanceOverview = cache(
 
     const rawProposals = await getProposalsFromSubgraph(proposalThreshold)
 
-    const proposals: ProposalRecord[] = rawProposals.map((proposal) => ({
+    const derived = rawProposals.map((proposal) => ({
       ...proposal,
       state: deriveProposalState(proposal, latestTimestamp),
     }))
+
+    // Verify actionable states (Succeeded / Queued) against on-chain reality.
+    // The subgraph quorum/vote data can diverge from the governor's own state()
+    // (e.g. proposal is Defeated on-chain but appears Succeeded via vote math).
+    const actionable = derived.filter(
+      (p) => p.state === 'Succeeded' || p.state === 'Queued'
+    )
+    const onChainStates = await Promise.all(
+      actionable.map((p) =>
+        (governor.state(BigInt(p.id)) as Promise<bigint>).catch(() => null)
+      )
+    )
+    const overrides = new Map<string, ProposalState>()
+    actionable.forEach((p, i) => {
+      const raw = onChainStates[i]
+      if (raw === null) return
+      const mapped = ON_CHAIN_STATE[Number(raw)]
+      if (mapped && mapped !== p.state) overrides.set(p.id, mapped)
+    })
+
+    const proposals: ProposalRecord[] = derived.map((p) =>
+      overrides.has(p.id) ? { ...p, state: overrides.get(p.id)! } : p
+    )
 
     return {
       latestTimestamp,

--- a/governance-app/src/lib/governance/subgraph.ts
+++ b/governance-app/src/lib/governance/subgraph.ts
@@ -73,7 +73,9 @@ async function fetchSubgraph<T>(query: string): Promise<T> {
 }
 
 function getTitle(description: string) {
-  return description.split('\n')[0]?.trim() || 'Untitled proposal'
+  const firstLine = description.split('\n')[0]?.trim() || 'Untitled proposal'
+  // Strip leading markdown heading markers (e.g. "## Title" → "Title")
+  return firstLine.replace(/^#+\s*/, '') || 'Untitled proposal'
 }
 
 export const getProposalsFromSubgraph = cache(

--- a/governance-app/src/lib/governance/types.ts
+++ b/governance-app/src/lib/governance/types.ts
@@ -6,6 +6,7 @@ export type ProposalState =
   | 'Queued'
   | 'Executed'
   | 'Canceled'
+  | 'Expired'
 
 export type DecodedCalldata =
   | {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22502,6 +22502,7 @@ __metadata:
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-markdown: "npm:10.1.0"
+    remark-gfm: "npm:4.0.1"
     tailwindcss: "npm:3.4.18"
     typescript: "npm:5.8.3"
   peerDependencies:
@@ -50115,7 +50116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-gfm@npm:^4.0.0":
+"remark-gfm@npm:4.0.1, remark-gfm@npm:^4.0.0":
   version: 4.0.1
   resolution: "remark-gfm@npm:4.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -22501,6 +22501,7 @@ __metadata:
     postcss: "npm:8.4.49"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
+    react-markdown: "npm:10.1.0"
     tailwindcss: "npm:3.4.18"
     typescript: "npm:5.8.3"
   peerDependencies:


### PR DESCRIPTION
## Summary
- add connected-wallet voting on proposal detail pages with snapshot voting power
- wire queue and execute actions to the governor using the proposal payload already loaded on the page
- gate write actions behind Privy configuration and Base network wallet switching

## Testing
- yarn workspace @unlock-protocol/governance-app lint .
- yarn workspace @unlock-protocol/governance-app build