### PR TITLE
fix: pin @railway/cli to 4.5.4 to restore production deploys

### DIFF
--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Install Railway CLI
       shell: bash
-      run: npm i -g @railway/cli
+      run: npm i -g @railway/cli@4.5.4
 
     - name: Deploy to Railway
       shell: bash


### PR DESCRIPTION
## Summary

- Pins \`@railway/cli\` to \`4.5.4\` in \`.github/actions/railway/action.yml\`
- The action was installing the latest CLI on every run (\`npm i -g @railway/cli\`)
- CLI v4.45.0 changed Dockerfile detection: it now rejects Dockerfiles in subdirectories (\`acceptChildOfRepoRoot:false\`), so \`locksmith/Dockerfile\` is silently skipped and the Railway build fails with no Dockerfile to use
- v4.5.4 was the version in use when production deploys last succeeded (2025-07-15)

**Root cause log from failing deploy:**
\`\`\`
skipping 'Dockerfile' at 'locksmith/Dockerfile' as it is not rooted at a valid path (root_dir=, fileOpts={acceptChildOfRepoRoot:false})
\`\`\`

## Test plan

- [ ] Merge this and cherry-pick to \`production\` branch to verify locksmith deploys succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)