### PR TITLE
revert: undo railway CLI version pin (4.5.4 token format incompatible)

### DIFF
--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -22,7 +22,10 @@ runs:
   steps:
     - name: Install Railway CLI
       shell: bash
-      run: npm i -g @railway/cli
+      # Pinned: v4.45.0 is the minimum that accepts the current RAILWAY_TOKEN format.
+      # Dockerfile path is set via railway.toml — verify new versions still support
+      # subdirectory dockerfilePath before upgrading.
+      run: npm i -g @railway/cli@4.45.0
 
     - name: Deploy to Railway
       shell: bash

--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Install Railway CLI
       shell: bash
-      run: npm i -g @railway/cli
+      run: npm i -g @railway/cli@4.5.4
 
     - name: Deploy to Railway
       shell: bash

--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Install Railway CLI
       shell: bash
-      run: npm i -g @railway/cli@4.5.4
+      run: npm i -g @railway/cli
 
     - name: Deploy to Railway
       shell: bash

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,2 @@
+[build]
+dockerfilePath = "locksmith/Dockerfile"


### PR DESCRIPTION
Reverts #16350.

v4.5.4 fails with `Unauthorized` — the Railway token in 1Password was rotated to a newer format that only v4.45+ recognizes. The pin made things worse.

The actual build failure is happening on Railway's side (after successful upload with v4.45.0). Need to investigate Railway build logs directly.