### PR TITLE
fix: switch Railway builder to DOCKERFILE using root Dockerfile

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "RAILPACK",
-    "dockerfilePath": "/locksmith/Dockerfile"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
     "startCommand": "yarn start",

--- a/railway.toml
+++ b/railway.toml
@@ -1,2 +1,0 @@
-[build]
-dockerfilePath = "locksmith/Dockerfile"


### PR DESCRIPTION
## What broke

Railway's build server changed to reject Dockerfiles in subdirectories (`acceptChildOfRepoRoot:false`). The existing `railway.json` specified:
```json
"builder": "RAILPACK",
"dockerfilePath": "/locksmith/Dockerfile"
```
Railway can no longer resolve the subdirectory path → build fails immediately after scheduling.

## What this fixes

- `builder: "DOCKERFILE"` — explicit Docker builder instead of RAILPACK
- `dockerfilePath: "Dockerfile"` — uses the root-level `Dockerfile` which already exists, builds the full monorepo, and sets `WORKDIR` to `/home/unlock/locksmith`
- Removes the `railway.toml` added in #16351 which was redundant (conflicted with `railway.json`)

Deploy commands (`startCommand`, `preDeployCommand`) are unchanged.

## Test plan

- [ ] Merge and verify `deploy-locksmith-web-production` and `deploy-locksmith-worker-production` both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)