### PR TITLE
fix: pin Vercel CLI to v44.4.1 to fix upload regression

### DIFF
--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -32,8 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  npx -y vercel build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
+  # v44.4.1 was the last known-working version (July 2025). Verify before upgrading.
+  npx -y vercel@44.4.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@44.4.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -32,8 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  npx -y vercel build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
+  # v44.4.1 was the last known-working version (July 2025). Verify before upgrading.
+  npx -y vercel@44.4.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@44.4.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1


### PR DESCRIPTION
Vercel CLI v53+ introduced a regression where uploading large SSR Next.js apps fails with 'File digest missing'. Pins both unlock-app and paywall-app deploy scripts to v44.4.1 (last known-working version, July 2025).