### PR TITLE
fix: remove railway.toml conflicting with railway.json on master

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,2 +1,0 @@
-[build]
-dockerfilePath = "locksmith/Dockerfile"


### PR DESCRIPTION
## Summary

- `railway.toml` was added to master (via the revert commit in #16351) but never removed
- `railway.toml` and `railway.json` conflict — Railway cannot use both simultaneously
- Production already had this fixed in #16353; applying the same cleanup to master

## No other changes needed

Master is already in sync with all production deploy fixes:
- ✅ Vercel CLI pinned to v44.4.1 (via #16356)
- ✅ `resolutions: { next: "14.2.35" }` in package.json
- ✅ yarn.lock has no `next@15.x` vulnerability (lockfile was already regenerated correctly on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)