### PR TITLE
fix: bump Vercel CLI to v53.1.1 with --archive=tgz on master

### DIFF
--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -33,9 +33,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   # move to root directory
   cd ..
   # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v44.4.1 was the last known-working version (July 2025). Verify before upgrading.
-  npx -y vercel@44.4.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@44.4.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
+  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -32,10 +32,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
-  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # Use --archive=tgz to upload as a single tarball (avoids per-file digest errors).
+  npx -y vercel@53.1.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@53.1.1 deploy --cwd . --prebuilt --archive=tgz --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -33,9 +33,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   # move to root directory
   cd ..
   # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v44.4.1 was the last known-working version (July 2025). Verify before upgrading.
-  npx -y vercel@44.4.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@44.4.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
+  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -32,10 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
-  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # Use --archive=tgz to upload as a single tarball, bypassing the per-file "File digest missing"
+  # error that affects large SSR Next.js apps on all CLI versions without this flag.
+  npx -y vercel@53.1.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@53.1.1 deploy --cwd . --prebuilt --archive=tgz --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1


### PR DESCRIPTION
## Problem

Vercel API now rejects CLI versions older than v47.2.2. The previously pinned v44.4.1 caused all preview deploys on master to fail with "Your Vercel CLI version is outdated."

Additionally, v53+ introduced a per-file "File digest missing" server error for large SSR apps (unlock-app). The `--archive=tgz` flag bundles the deployment as a single tarball, bypassing that error.

## Changes

- `unlock-app/scripts/deploy-vercel.sh`: pins `vercel@53.1.1`, adds `--archive=tgz` to the deploy step
- `paywall-app/scripts/deploy-vercel.sh`: same

## Verification

This exact combination (v53.1.1 + --archive=tgz) was already validated on the `production` branch CI run [#25390683558](https://github.com/unlock-protocol/unlock/actions/runs/25390683558) where all 7 jobs passed.