### PR TITLE
fix: try vercel@47.2.2 for unlock-app deploy (binary search for clean version)

### DIFF
--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -32,10 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
-  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
+  # Binary-searching for last clean version above the API minimum (>=47.2.2).
+  npx -y vercel@47.2.2 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@47.2.2 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -32,10 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: v53+ introduced a "File digest missing" upload bug for large SSR Next.js apps.
-  # v52.2.1 is the last known-working version before the regression. Verify before upgrading past v52.
-  npx -y vercel@52.2.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@52.2.1 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
+  # v44.4.1 worked but is now rejected by API (requires >=47.2.2). Binary-searching for last clean version.
+  npx -y vercel@47.2.2 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@47.2.2 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1


### PR DESCRIPTION
v52.2.1 also has 'File digest missing' bug. Testing v47.2.2 (API minimum) to narrow down where the regression started. 🤖 Generated with Claude Code