### PR TITLE
fix: try vercel@50.0.0 — binary search for last clean upload version

### DIFF
--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -33,9 +33,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   # move to root directory
   cd ..
   # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
-  # Binary-searching for last clean version above the API minimum (>=47.2.2).
-  npx -y vercel@47.2.2 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@47.2.2 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # Binary search: trying v50.0.0 (midpoint 48-52).
+  npx -y vercel@50.0.0 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@50.0.0 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -33,9 +33,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   # move to root directory
   cd ..
   # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
-  # v44.4.1 worked but is now rejected by API (requires >=47.2.2). Binary-searching for last clean version.
-  npx -y vercel@47.2.2 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@47.2.2 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # v52.2.1 broken, v44.4.1 API-rejected. Binary search: trying v50.0.0 (midpoint 48-52).
+  npx -y vercel@50.0.0 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@50.0.0 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1


### PR DESCRIPTION
v47.2.2 doesn't exist on npm. v52.2.1 broken. Trying v50.0.0 as midpoint. If broken → try v48.x. If works → try v51.x. 🤖 Generated with Claude Code