### PR TITLE
fix: use vercel@53.1.1 with --archive=tgz to fix unlock-app deploy

### DIFF
--- a/paywall-app/scripts/deploy-vercel.sh
+++ b/paywall-app/scripts/deploy-vercel.sh
@@ -32,10 +32,9 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
-  # Binary search: trying v48.0.0.
-  npx -y vercel@48.0.0 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@48.0.0 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD
+  # Use --archive=tgz to upload as a single tarball (avoids per-file digest errors).
+  npx -y vercel@53.1.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@53.1.1 deploy --cwd . --prebuilt --archive=tgz --token $VERCEL_TOKEN $PROD
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1

--- a/unlock-app/scripts/deploy-vercel.sh
+++ b/unlock-app/scripts/deploy-vercel.sh
@@ -32,10 +32,10 @@ if [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID
   export NEXT_PUBLIC_UNLOCK_ENV="$DEPLOY_ENV"
   # move to root directory
   cd ..
-  # Pinned: "File digest missing" upload bug affects large SSR Next.js apps on recent CLI versions.
-  # v44.4.1 API-rejected, v48-52+ broken. Trying v48.0.0 — absolute minimum satisfying API.
-  npx -y vercel@48.0.0 build -y --cwd . --token $VERCEL_TOKEN $PROD
-  npx -y vercel@48.0.0 deploy --cwd . --prebuilt --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
+  # Use --archive=tgz to upload as a single tarball, bypassing the per-file "File digest missing"
+  # error that affects large SSR Next.js apps on all CLI versions without this flag.
+  npx -y vercel@53.1.1 build -y --cwd . --token $VERCEL_TOKEN $PROD
+  npx -y vercel@53.1.1 deploy --cwd . --prebuilt --archive=tgz --token $VERCEL_TOKEN $PROD --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 else
   echo "Failed to deploy to Vercel because we're missing VERCEL_TOKEN, VERCEL_PROJECT_ID and/or VERCEL_ORG_ID"
   exit 1


### PR DESCRIPTION
The 'File digest missing' error is **server-side** — Vercel rejects per-file uploads for large SSR apps across all CLI versions. The `--archive=tgz` flag (available in v53+) bundles the prebuilt output into a single tarball, bypassing per-file digest validation entirely. 🤖 Generated with Claude Code