### PR TITLE
fix: create EVM wallet for Solana-only Privy users, fix blank checkout Connect step

### DIFF
--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getAccessToken, saveAccessToken } from '~/utils/session'
+import { getAccessToken, saveAccessToken, removeAccessToken, removeCurrentAccount } from '~/utils/session'
 import {
   getAccessToken as privyGetAccessToken,
   PrivyProvider,
@@ -9,6 +9,7 @@ import {
   User,
   usePrivy,
   LinkedAccountWithMetadata,
+  WalletWithMetadata,
 } from '@privy-io/react-auth'
 import { ReactNode, useContext, useEffect, useState } from 'react'
 import { config } from './app'
@@ -55,9 +56,13 @@ export const onSignedInWithPrivy = async (
       console.error('No access token found in Privy')
       return null
     }
-    // Prefer the live wallet address from the user object; fall back to the
-    // override only when Privy has not yet reflected the newly created wallet.
-    const walletAddress = user.wallet?.address || walletAddressOverride
+    // Find the first EVM wallet across all linked accounts. user.wallet is just
+    // the first linked wallet and may be Solana; linkedAccounts has chainType.
+    const evmAccount = user.linkedAccounts.find(
+      (a): a is WalletWithMetadata =>
+        a.type === 'wallet' && a.chainType === 'ethereum'
+    )
+    const walletAddress = evmAccount?.address ?? walletAddressOverride
     if (walletAddress) {
       const response = await locksmith.loginWithPrivy({
         accessToken,
@@ -74,14 +79,22 @@ export const onSignedInWithPrivy = async (
         )
         return walletAddress
       }
+      // Locksmith responded but issued no token — clear stale cache so the
+      // user can reconnect with a different wallet.
+      removeAccessToken(walletAddress)
+      removeCurrentAccount()
       return null
     } else {
       console.error(
-        'No wallet linked on Privy account, cannot authenticate with Locksmith'
+        'No EVM wallet linked on Privy account, cannot authenticate with Locksmith'
       )
       return null
     }
   } catch (error) {
+    // 401 or network error — clear stale cache so the getAccessToken() guard in
+    // PrivyMigration does not silently block retry, and the user can reconnect.
+    if (walletAddress) removeAccessToken(walletAddress)
+    removeCurrentAccount()
     console.error(error)
     return null
   }
@@ -176,8 +189,12 @@ export const PrivyMigration = () => {
       }
     }
 
-    // Only create wallet if user doesn't have one AND doesn't have a legacy account
-    if (!user.wallet?.address && !hasLegacyAccount) {
+    // Create EVM wallet if the user has no EVM wallet (may have only Solana).
+    const hasEvmWallet = user.linkedAccounts.some(
+      (a): a is WalletWithMetadata =>
+        a.type === 'wallet' && a.chainType === 'ethereum'
+    )
+    if (!hasEvmWallet && !hasLegacyAccount) {
       const walletAddress = await createWalletForUser()
       if (!walletAddress) return
       // Pass the new wallet address explicitly: the user object captured in this

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -11,6 +11,7 @@ import {
   LinkedAccountWithMetadata,
   WalletWithMetadata,
 } from '@privy-io/react-auth'
+import { isAxiosError } from 'axios'
 import { ReactNode, useContext, useEffect, useState } from 'react'
 import { config } from './app'
 import { ToastHelper } from '@unlock-protocol/ui'
@@ -98,8 +99,7 @@ export const onSignedInWithPrivy = async (
   } catch (error) {
     // Only clear stale cache on auth failures (4xx) — transient 5xx/network
     // errors should not wipe a valid session.
-    const status = (error as any)?.response?.status
-    if (status && status >= 400 && status < 500) {
+    if (isAxiosError(error) && error.response?.status && error.response.status >= 400 && error.response.status < 500) {
       if (walletAddress) removeAccessToken(walletAddress)
       removeCurrentAccount()
     }

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -20,6 +20,12 @@ import { MigrationModal } from '~/components/legacy-auth/MigrationNotificationMo
 import { isInIframe } from '~/utils/iframe'
 import { setLocalStorageItem } from '~/hooks/useAppStorage'
 
+const findEvmWallet = (user: User): WalletWithMetadata | undefined =>
+  user.linkedAccounts.find(
+    (a): a is WalletWithMetadata =>
+      a.type === 'wallet' && a.chainType === 'ethereum'
+  )
+
 // check for legacy account
 export const checkLegacyAccount = async (
   emailAddress: string
@@ -58,13 +64,9 @@ export const onSignedInWithPrivy = async (
       console.error('No access token found in Privy')
       return null
     }
-    // Find the first EVM wallet across all linked accounts. user.wallet is just
-    // the first linked wallet and may be Solana; linkedAccounts has chainType.
-    const evmAccount = user.linkedAccounts.find(
-      (a): a is WalletWithMetadata =>
-        a.type === 'wallet' && a.chainType === 'ethereum'
-    )
-    walletAddress = evmAccount?.address ?? walletAddressOverride
+    // user.wallet is just the first linked wallet and may be Solana;
+    // findEvmWallet checks chainType to find a real EVM wallet.
+    walletAddress = findEvmWallet(user)?.address ?? walletAddressOverride
     if (walletAddress) {
       const response = await locksmith.loginWithPrivy({
         accessToken,
@@ -94,10 +96,13 @@ export const onSignedInWithPrivy = async (
       return null
     }
   } catch (error) {
-    // 401 or network error — clear stale cache so the getAccessToken() guard in
-    // PrivyMigration does not silently block retry, and the user can reconnect.
-    if (walletAddress) removeAccessToken(walletAddress)
-    removeCurrentAccount()
+    // Only clear stale cache on auth failures (4xx) — transient 5xx/network
+    // errors should not wipe a valid session.
+    const status = (error as any)?.response?.status
+    if (status && status >= 400 && status < 500) {
+      if (walletAddress) removeAccessToken(walletAddress)
+      removeCurrentAccount()
+    }
     console.error(error)
     return null
   }
@@ -179,10 +184,7 @@ export const PrivyMigration = () => {
   const handleMigrationIfNeeded = async (user: User) => {
     let hasLegacyAccount = false
 
-    const hasEvmWallet = user.linkedAccounts.some(
-      (a): a is WalletWithMetadata =>
-        a.type === 'wallet' && a.chainType === 'ethereum'
-    )
+    const hasEvmWallet = !!findEvmWallet(user)
 
     // Check for legacy account if user logged in with email
     if (user.email?.address) {

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -100,8 +100,10 @@ export const onSignedInWithPrivy = async (
     // Only clear stale cache on auth failures (4xx) — transient 5xx/network
     // errors should not wipe a valid session.
     if (isAxiosError(error) && error.response?.status && error.response.status >= 400 && error.response.status < 500) {
-      if (walletAddress) removeAccessToken(walletAddress)
-      removeCurrentAccount()
+      if (walletAddress) {
+        removeAccessToken(walletAddress)
+        removeCurrentAccount()
+      }
     }
     console.error(error)
     return null

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -50,6 +50,8 @@ export const onSignedInWithPrivy = async (
   user: User,
   walletAddressOverride?: string
 ) => {
+  // Hoist so the catch block can clear stale cache for the same address.
+  let walletAddress: string | undefined
   try {
     const accessToken = await privyGetAccessToken()
     if (!accessToken) {
@@ -62,7 +64,7 @@ export const onSignedInWithPrivy = async (
       (a): a is WalletWithMetadata =>
         a.type === 'wallet' && a.chainType === 'ethereum'
     )
-    const walletAddress = evmAccount?.address ?? walletAddressOverride
+    walletAddress = evmAccount?.address ?? walletAddressOverride
     if (walletAddress) {
       const response = await locksmith.loginWithPrivy({
         accessToken,
@@ -85,8 +87,9 @@ export const onSignedInWithPrivy = async (
       removeCurrentAccount()
       return null
     } else {
-      console.error(
-        'No EVM wallet linked on Privy account, cannot authenticate with Locksmith'
+      // No EVM wallet yet — PrivyMigration will create one and retry.
+      console.info(
+        'No EVM wallet linked on Privy account; wallet creation pending'
       )
       return null
     }
@@ -176,12 +179,17 @@ export const PrivyMigration = () => {
   const handleMigrationIfNeeded = async (user: User) => {
     let hasLegacyAccount = false
 
+    const hasEvmWallet = user.linkedAccounts.some(
+      (a): a is WalletWithMetadata =>
+        a.type === 'wallet' && a.chainType === 'ethereum'
+    )
+
     // Check for legacy account if user logged in with email
     if (user.email?.address) {
       hasLegacyAccount = await checkLegacyAccount(user.email.address)
 
-      // Only show migration modal if user has legacy account but no Privy wallet
-      if (hasLegacyAccount && !user.wallet?.address) {
+      // Only show migration modal if user has legacy account but no EVM wallet
+      if (hasLegacyAccount && !hasEvmWallet) {
         setShowMigrationModal(true)
         // close connect modal
         window.dispatchEvent(new CustomEvent('legacy.account.detected'))
@@ -190,10 +198,6 @@ export const PrivyMigration = () => {
     }
 
     // Create EVM wallet if the user has no EVM wallet (may have only Solana).
-    const hasEvmWallet = user.linkedAccounts.some(
-      (a): a is WalletWithMetadata =>
-        a.type === 'wallet' && a.chainType === 'ethereum'
-    )
     if (!hasEvmWallet && !hasLegacyAccount) {
       const walletAddress = await createWalletForUser()
       if (!walletAddress) return

--- a/unlock-app/src/utils/session.ts
+++ b/unlock-app/src/utils/session.ts
@@ -46,6 +46,10 @@ export const removeAccessToken = (
   deleteLocalStorageItem(getSessionKey(address))
 }
 
+export const removeCurrentAccount = () => {
+  deleteLocalStorageItem(CURRENT_ACCOUNT_KEY)
+}
+
 export const saveAccessToken = ({
   walletAddress,
   accessToken,


### PR DESCRIPTION
## Problem

When a Privy user's primary wallet is a Solana address, `user.wallet?.address` returns a base58-encoded key (no `0x` prefix). The previous code passed that address to Locksmith's `/v2/auth/privy` endpoint, which returned 401 and left the checkout's Connect step blank.

## Fix

**`PrivyProvider.tsx`**

- Adds a `findEvmWallet(user)` helper that scans `user.linkedAccounts` for `chainType === 'ethereum'` — the correct Privy API for finding an EVM wallet, regardless of which wallet Privy designates as "primary"
- `onSignedInWithPrivy` uses `findEvmWallet` instead of `user.wallet`; falls back to `walletAddressOverride` (used when a wallet was just created and Privy's user object has not yet updated)
- `PrivyMigration.handleMigrationIfNeeded` detects Solana-only users via `findEvmWallet` and creates an embedded EVM wallet via `useCreateWallet`, then calls `onSignedInWithPrivy` with the new address — no error shown to the user
- Cache-clearing on errors scoped to 4xx HTTP responses only (via `isAxiosError`), so transient 5xx/network errors do not wipe a valid session
- Legacy account + Solana wallet edge case fixed: migration modal guard uses `!hasEvmWallet` instead of `!user.wallet?.address`

**`session.ts`**

- Exports `removeCurrentAccount()` helper used by the error-recovery paths

## Edge cases

- **Solana-only user on first login**: EVM wallet created transparently; no error shown
- **Legacy account + Solana wallet**: migration modal appears correctly
- **Returning Solana user with existing EVM wallet**: `getAccessToken()` guard prevents duplicate Locksmith auth calls
- **Transient network/server errors**: 5xx errors do not clear a valid cached session