### PR TITLE
fix: add governance-app to yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "workspaces": [
     "packages/**",
     "governance",
+    "governance-app",
     "smart-contracts",
     "subgraph",
     "tests",


### PR DESCRIPTION
## Summary
- `governance-app` was added to the production branch via #16354 but was never registered in the root `package.json` workspaces
- The `deploy-governance-app-vercel` CI job runs `yarn workspace @unlock-protocol/governance-app deploy-vercel` inside Docker, which fails with "Workspace not found"
- This adds `governance-app` to the workspaces list alongside `governance` so yarn can resolve it

## Test plan
- [ ] CI deploys governance-app to production successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)