### PR TITLE
fix: keep email login in iframes, only disable Google OAuth and Farcaster

### DIFF
--- a/unlock-app/src/__tests__/config/PrivyProvider.test.ts
+++ b/unlock-app/src/__tests__/config/PrivyProvider.test.ts
@@ -23,6 +23,12 @@ vi.mock('~/config/locksmith', () => ({
 vi.mock('~/utils/session', () => ({
   saveAccessToken: vi.fn(),
   getAccessToken: vi.fn(),
+  removeAccessToken: vi.fn(),
+  removeCurrentAccount: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  isAxiosError: vi.fn().mockReturnValue(false),
 }))
 
 import { getAccessToken as privyGetAccessToken } from '@privy-io/react-auth'
@@ -37,10 +43,18 @@ const mockSaveAccessToken = vi.mocked(saveAccessToken)
 const PRIVY_TOKEN = 'privy-access-token'
 const LOCKSMITH_TOKEN = 'locksmith-access-token'
 const WALLET_ADDRESS = '0x1234567890AbcdEF1234567890aBcdef12345678'
+const SOLANA_ADDRESS = 'BgNcYPxA8GAdbUhS9ErgoTdLcHmsX2yz1mMqikNoYmnu'
 
-function makeUser(walletAddress?: string) {
+function makeUser(
+  walletAddress?: string,
+  chainType: 'ethereum' | 'solana' = 'ethereum'
+) {
+  const linkedAccounts = walletAddress
+    ? [{ type: 'wallet', address: walletAddress, chainType }]
+    : []
   return {
     wallet: walletAddress ? { address: walletAddress } : undefined,
+    linkedAccounts,
     email: undefined,
   } as any
 }
@@ -54,7 +68,7 @@ describe('onSignedInWithPrivy', () => {
     } as any)
   })
 
-  it('authenticates with Locksmith using user.wallet.address', async () => {
+  it('authenticates with Locksmith using EVM wallet from linkedAccounts', async () => {
     const user = makeUser(WALLET_ADDRESS)
     const result = await onSignedInWithPrivy(user)
 
@@ -69,7 +83,7 @@ describe('onSignedInWithPrivy', () => {
     expect(result).toBe(WALLET_ADDRESS)
   })
 
-  it('returns null when user has no wallet and no override is provided', async () => {
+  it('returns null when user has no EVM wallet and no override is provided', async () => {
     const user = makeUser() // no wallet
     const result = await onSignedInWithPrivy(user)
 
@@ -77,9 +91,9 @@ describe('onSignedInWithPrivy', () => {
     expect(result).toBeNull()
   })
 
-  it('uses walletAddressOverride when user object is stale (no wallet after creation)', async () => {
-    // This is the bug scenario: wallet was just created but user object is stale
-    const staleUser = makeUser() // user object captured before wallet was created
+  it('uses walletAddressOverride when user has no EVM wallet in linkedAccounts', async () => {
+    // Stale user object captured before EVM wallet was created
+    const staleUser = makeUser()
     const result = await onSignedInWithPrivy(staleUser, WALLET_ADDRESS)
 
     expect(mockLoginWithPrivy).toHaveBeenCalledWith({
@@ -93,14 +107,25 @@ describe('onSignedInWithPrivy', () => {
     expect(result).toBe(WALLET_ADDRESS)
   })
 
-  it('prefers user.wallet.address over walletAddressOverride when both are present', async () => {
+  it('uses EVM wallet from linkedAccounts, ignores walletAddressOverride', async () => {
     const overrideAddress = '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF'
-    const user = makeUser(WALLET_ADDRESS)
+    const user = makeUser(WALLET_ADDRESS) // has EVM wallet in linkedAccounts
     const result = await onSignedInWithPrivy(user, overrideAddress)
 
     expect(mockLoginWithPrivy).toHaveBeenCalledWith({
       accessToken: PRIVY_TOKEN,
-      walletAddress: WALLET_ADDRESS,
+      walletAddress: WALLET_ADDRESS, // linkedAccounts EVM wallet wins
+    })
+    expect(result).toBe(WALLET_ADDRESS)
+  })
+
+  it('skips Solana wallet and uses override instead', async () => {
+    const user = makeUser(SOLANA_ADDRESS, 'solana') // only Solana in linkedAccounts
+    const result = await onSignedInWithPrivy(user, WALLET_ADDRESS)
+
+    expect(mockLoginWithPrivy).toHaveBeenCalledWith({
+      accessToken: PRIVY_TOKEN,
+      walletAddress: WALLET_ADDRESS, // override used since no EVM in linkedAccounts
     })
     expect(result).toBe(WALLET_ADDRESS)
   })

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -255,21 +255,18 @@ export const Privy = ({ children }: { children: ReactNode }) => {
     typeof window !== 'undefined' &&
     window.location.pathname.includes('migrate-user')
 
-  // Any iframe context is an embedded paywall — Google OAuth fails on third-party
-  // domains and wallet-only login is the right restriction regardless of URL.
+  // Any iframe context is an embedded paywall — Google OAuth and Farcaster fail on
+  // third-party domains, but wallet and email login still work fine.
   const isInPaywall = isInIframe()
 
   return (
     <AuthenticationContext.Provider value={{ account, setAccount }}>
       <PrivyProvider
         config={{
-          /* For the meantime, when users are authenticating via paywall on an external website (embedded paywall),
-           * we can only allow the wallet method to login.
-           */
           loginMethods: isMigratePage
             ? ['email']
             : isInPaywall
-              ? ['wallet']
+              ? ['wallet', 'email']
               : ['wallet', 'email', 'google', 'farcaster'],
           embeddedWallets: {
             createOnLogin: 'off',

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { getAccessToken, saveAccessToken, removeAccessToken, removeCurrentAccount } from '~/utils/session'
+import {
+  getAccessToken,
+  saveAccessToken,
+  removeAccessToken,
+  removeCurrentAccount,
+} from '~/utils/session'
 import {
   getAccessToken as privyGetAccessToken,
   PrivyProvider,
@@ -99,7 +104,12 @@ export const onSignedInWithPrivy = async (
   } catch (error) {
     // Only clear stale cache on auth failures (4xx) — transient 5xx/network
     // errors should not wipe a valid session.
-    if (isAxiosError(error) && error.response?.status && error.response.status >= 400 && error.response.status < 500) {
+    if (
+      isAxiosError(error) &&
+      error.response?.status &&
+      error.response.status >= 400 &&
+      error.response.status < 500
+    ) {
       if (walletAddress) {
         removeAccessToken(walletAddress)
         removeCurrentAccount()

--- a/unlock-app/src/config/PrivyProvider.tsx
+++ b/unlock-app/src/config/PrivyProvider.tsx
@@ -165,8 +165,8 @@ export const PrivyMigration = () => {
 
   const { createWallet } = useCreateWallet({
     onError: (error) => {
-      console.error('Error creating wallet:', error)
-      ToastHelper.error('Failed to create wallet. Please try again.')
+      // Suppress — createWalletForUser's catch block handles user-facing errors.
+      console.info('useCreateWallet onError (handled by caller):', error)
     },
   })
 
@@ -175,7 +175,12 @@ export const PrivyMigration = () => {
     try {
       const newWallet = await createWallet()
       return newWallet.address
-    } catch (error) {
+    } catch (error: any) {
+      // "embedded_wallet_already_exists" means a concurrent call already created
+      // the wallet; find it in linkedAccounts and proceed normally.
+      if (error?.code === 'embedded_wallet_already_exists' && user) {
+        return findEvmWallet(user)?.address ?? null
+      }
       console.error('Error creating wallet:', error)
       ToastHelper.error('Failed to create wallet. Please try again.')
       return null
@@ -240,9 +245,9 @@ export const Privy = ({ children }: { children: ReactNode }) => {
     typeof window !== 'undefined' &&
     window.location.pathname.includes('migrate-user')
 
-  // Check if we're in an iframe && not in the Unlock dashboard
-  const isInPaywall =
-    isInIframe() && !window.location.href.includes(config.unlockApp)
+  // Any iframe context is an embedded paywall — Google OAuth fails on third-party
+  // domains and wallet-only login is the right restriction regardless of URL.
+  const isInPaywall = isInIframe()
 
   return (
     <AuthenticationContext.Provider value={{ account, setAccount }}>


### PR DESCRIPTION
## Summary
- The previous fix (#16366) restricted login to `['wallet']` only in iframes
- Email login works fine in iframes; only Google OAuth and Farcaster fail on third-party domains
- Changed to `['wallet', 'email']` when in an iframe

## Test plan
- [ ] Embedded checkout on dappcon.io shows wallet + email login but not Google/Farcaster

🤖 Generated with [Claude Code](https://claude.com/claude-code)