### PR TITLE
Add guide links to lock creation flows

### DIFF
--- a/unlock-app/src/components/content/certification/CertificationForm.tsx
+++ b/unlock-app/src/components/content/certification/CertificationForm.tsx
@@ -27,6 +27,7 @@ import { BalanceWarning } from '~/components/interface/locks/Create/elements/Bal
 import { ProtocolFee } from '~/components/interface/locks/Create/elements/ProtocolFee'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
 import { useWeb3Service } from '~/utils/withWeb3Service'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 // TODO replace with zod, but only once we have replaced Lock and MetadataFormData as well
 export interface NewCertificationForm {
@@ -142,6 +143,11 @@ export const CertificationForm = ({ onSubmit }: FormProps) => {
       </div>
       <form className="mb-6" onSubmit={methods.handleSubmit(onSubmit)}>
         <div className="grid gap-6">
+          <GuideCallout
+            description="Plan the credential details, issuer information, expiration, and airdrop workflow before deploying your certification."
+            href="https://unlock-protocol.com/guides/certifications/"
+            linkLabel="Read the certification guide"
+          />
           <Disclosure label="Basic Information" defaultOpen>
             <p className="mb-5">
               All of these fields can also be adjusted later.

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -35,6 +35,7 @@ import Link from 'next/link'
 import { regexUrlPattern } from '~/utils/regexUrlPattern'
 import { ProtocolFee } from '~/components/interface/locks/Create/elements/ProtocolFee'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 // TODO replace with zod, but only once we have replaced Lock and MetadataFormData as well
 export interface NewEventForm {
@@ -252,6 +253,11 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
 
       <form className="mb-6" onSubmit={methods.handleSubmit(processAndSubmit)}>
         <div className="grid gap-6">
+          <GuideCallout
+            description="Use the ticketing guide to plan capacity, pricing, attendee screening, ticket distribution, and check-in before publishing your event."
+            href="https://unlock-protocol.com/guides/how-to-sell-nft-tickets-for-an-event/"
+            linkLabel="Read the event guide"
+          />
           <Disclosure label="Basic Information" defaultOpen>
             <p className="mb-5">
               All of these fields can also be adjusted later.

--- a/unlock-app/src/components/content/subscription/NewSubscription.tsx
+++ b/unlock-app/src/components/content/subscription/NewSubscription.tsx
@@ -114,6 +114,12 @@ export const Deploy: React.FC = () => {
               <CreateLockForm
                 onSubmit={onSubmitMutation.mutate}
                 hideFields={['quantity']}
+                guide={{
+                  description:
+                    'Subscriptions need a renewal period and ERC-20 pricing so renewals can be approved automatically.',
+                  href: 'https://unlock-protocol.com/guides/onchain-subscriptions/',
+                  linkLabel: 'Read the subscription guide',
+                }}
                 defaultOptions={{
                   expirationDuration: {
                     label: 'Renew every',

--- a/unlock-app/src/components/interface/GuideCallout.tsx
+++ b/unlock-app/src/components/interface/GuideCallout.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { FiExternalLink as ExternalLinkIcon } from 'react-icons/fi'
+
+interface GuideCalloutProps {
+  title?: string
+  description: string
+  href: string
+  linkLabel: string
+}
+
+export const GuideCallout = ({
+  title = 'Need help?',
+  description,
+  href,
+  linkLabel,
+}: GuideCalloutProps) => {
+  return (
+    <div className="rounded-lg border border-brand-ui-primary bg-[#FFF7E8] p-4 text-sm text-brand-dark">
+      <p className="font-semibold">{title}</p>
+      <p className="mt-1">
+        {description}{' '}
+        <Link
+          className="inline-flex items-center font-semibold text-brand-ui-primary hover:underline"
+          href={href}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {linkLabel}
+          <ExternalLinkIcon className="ml-1" />
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/unlock-app/src/components/interface/Launcher.tsx
+++ b/unlock-app/src/components/interface/Launcher.tsx
@@ -43,6 +43,26 @@ const options = [
     cta: 'Deploy a custom membership',
     href: '/locks/create',
   },
+  {
+    image: {
+      src: '/images/illustrations/deploy-lock/custom-membership.png',
+      width: 250,
+      height: 250,
+      alt: 'create an art collection',
+    },
+    cta: 'Launch an art collection',
+    href: '/locks/create',
+  },
+  {
+    image: {
+      src: '/images/illustrations/deploy-lock/custom-membership.png',
+      width: 250,
+      height: 250,
+      alt: 'sell products or merchandise',
+    },
+    cta: 'Sell products or merchandise',
+    href: '/locks/create',
+  },
 ]
 
 export const Launcher = () => {

--- a/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
+++ b/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
@@ -211,7 +211,16 @@ const CreateLock = ({ onSubmit, defaultValues }: CreateLockProps) => {
           />
         </div>
         <div className="md:max-w-lg">
-          <CreateLockForm onSubmit={onSubmit} defaultValues={defaultValues} />
+          <CreateLockForm
+            onSubmit={onSubmit}
+            defaultValues={defaultValues}
+            guide={{
+              description:
+                'Designing a membership program before you deploy helps you choose the right benefits, pricing, and supply.',
+              href: 'https://unlock-protocol.com/guides/how-to-create-a-membership-program/',
+              linkLabel: 'Read the membership guide',
+            }}
+          />
         </div>
       </div>
     </div>

--- a/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
+++ b/unlock-app/src/components/interface/locks/Create/elements/CreateLockForm.tsx
@@ -20,6 +20,7 @@ import { useAvailableNetworks } from '~/utils/networks'
 import { SelectToken } from './SelectToken'
 import { ProtocolFee } from './ProtocolFee'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 export interface LockFormProps {
   name: string
@@ -40,6 +41,11 @@ interface CreateLockFormProps {
   hideFields?: string[]
   isLoading?: boolean
   defaultOptions?: any
+  guide?: {
+    description: string
+    href: string
+    linkLabel: string
+  }
 }
 
 export const NetworkDescription = ({ network }: { network: number }) => {
@@ -90,6 +96,7 @@ export const CreateLockForm = ({
   hideFields = [],
   isLoading = false,
   defaultOptions = {},
+  guide,
 }: CreateLockFormProps) => {
   const { networks } = useConfig()
   const web3Service = useWeb3Service()
@@ -176,6 +183,7 @@ export const CreateLockForm = ({
             className="flex flex-col w-full gap-6"
             onSubmit={handleSubmit(onHandleSubmit)}
           >
+            {guide && <GuideCallout {...guide} />}
             {!hideFields.includes('network') && (
               <Combobox
                 label="Network:"


### PR DESCRIPTION
## Summary
- add a reusable guide callout and show it at the top of membership, subscription, event, and certification creation forms
- link each flow to the relevant Unlock guide so creators get context while configuring the lock
- add Art Collection and Product/Merchandise launcher starting points that route to the custom membership flow

Fixes #16186

## Testing
- git diff --check

Note: I could not run the unlock-app lint command locally because yarn is not installed in this environment and the available corepack shim points to a missing Windows Node.js path.