### PR TITLE
fix: prevent transient Docker Hub push failures from breaking master build

### DIFF
--- a/.github/workflows/_docker-cache.yml
+++ b/.github/workflows/_docker-cache.yml
@@ -29,9 +29,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        # Use the action from the master, as we've seen some inconsistencies with @v1
-        # Issue: https://github.com/docker/build-push-action/issues/286
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image
         uses: docker/build-push-action@v6

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -169,6 +169,7 @@ jobs:
 
   cache_deps:
     needs: run-all-tests
+    continue-on-error: true
     uses: ./.github/workflows/_docker-cache.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary

The `cache_deps` job in the master workflow was failing intermittently with a **400 Bad Request** from Docker Hub's CDN when pushing a ~3 GB deps image layer (failed 2 out of 3 recent runs). This was marking the entire master build as failed even though all real deployments (locksmith, paywall, unlock-app, docs, wedlocks) had already succeeded.

**Root cause**: Two issues:
1. `docker/setup-buildx-action@master` was unpinned — the original comment referenced a known v1 bug (#286), which was fixed long ago. Using `@master` risks pulling in pre-release behavior.
2. `cache_deps` had no fault tolerance despite being a non-critical cache-warming step. The GHA cache is already written during the test phase (`export_cache: true`), so the Docker Hub push is just a fallback for cold-cache scenarios (cache eviction after 7 days of inactivity).

## Changes

- **`_docker-cache.yml`**: pin `docker/setup-buildx-action` from `@master` → `@v3`
- **`master.yml`**: add `continue-on-error: true` to `cache_deps` — it is not a deployment gate

## Test plan

- [ ] Verify next master push completes successfully even if Docker Hub push fails
- [ ] Confirm `cache_deps` failure shows as a warning (yellow) not a blocker (red) in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)