### PR TITLE
Load saved checkout metadata into recipient form

### DIFF
--- a/unlock-app/src/__tests__/utils/userMetadata.test.ts
+++ b/unlock-app/src/__tests__/utils/userMetadata.test.ts
@@ -1,5 +1,9 @@
 import type { MetadataInputType } from '@unlock-protocol/core'
-import { getPublicInputs, formResultToMetadata } from '../../utils/userMetadata'
+import {
+  getPublicInputs,
+  formResultToMetadata,
+  userMetadataToFormValues,
+} from '../../utils/userMetadata'
 import { expect, it, describe } from 'vitest'
 const inputs: MetadataInputType[] = [
   {
@@ -53,6 +57,28 @@ describe('userMetadata utils', () => {
         publicData: {
           'First Name': 'Saxton',
         },
+      })
+    })
+  })
+
+  describe('userMetadataToFormValues', () => {
+    it('merges public and protected saved metadata into form values', () => {
+      expect.assertions(1)
+
+      expect(
+        userMetadataToFormValues({
+          public: {
+            'First Name': 'Saxton',
+          },
+          protected: {
+            'Last Name': 'Hale',
+            Subscribed: true,
+          },
+        })
+      ).toEqual({
+        'First Name': 'Saxton',
+        'Last Name': 'Hale',
+        Subscribed: 'true',
       })
     })
   })

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -5,6 +5,7 @@ import {
   useFieldArray,
   useForm,
   useFormContext,
+  useWatch,
 } from 'react-hook-form'
 import {
   ChangeEvent,
@@ -12,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import {
@@ -23,7 +25,10 @@ import {
   Toggle,
 } from '@unlock-protocol/ui'
 import { twMerge } from 'tailwind-merge'
-import { formResultToMetadata } from '~/utils/userMetadata'
+import {
+  formResultToMetadata,
+  userMetadataToFormValues,
+} from '~/utils/userMetadata'
 import { ToastHelper } from '@unlock-protocol/ui'
 import { useSelector } from '@xstate/react'
 import { PoweredByUnlock } from '../PoweredByUnlock'
@@ -37,7 +42,10 @@ import {
   MetadataInputType as MetadataInput,
   PaywallConfigType,
 } from '@unlock-protocol/core'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
+import {
+  useReadUserMetadata,
+  useUpdateUsersMetadata,
+} from '~/hooks/useUserMetadata'
 import Disconnect from './Disconnect'
 import { shouldSkip } from './utils'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
@@ -85,6 +93,7 @@ export const MetadataInputs = ({
   const web3Service = useWeb3Service()
   const {
     register,
+    getValues,
     setValue,
     control,
     formState: { errors },
@@ -128,11 +137,66 @@ export const MetadataInputs = ({
   )
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account
+  const selectedRecipient =
+    useWatch({
+      control,
+      name: `metadata.${id}.recipient`,
+    }) || recipient
   const hideRecipient = shouldSkip({ paywallConfig, lock }).skipRecipient
+  const hydratedMetadataKey = useRef('')
+
+  const { data: savedMetadata } = useReadUserMetadata({
+    network: lock.network,
+    lockAddress: lock.address,
+    userAddress: selectedRecipient,
+    enabled:
+      !!metadataInputs?.length &&
+      !!selectedRecipient &&
+      !!isAccount(selectedRecipient),
+  })
 
   const [hideEmailInput, setHideEmailInput] = useState<boolean>(
     !!email && id === 0
   )
+
+  useEffect(() => {
+    if (!metadataInputs?.length || !savedMetadata?.metadata) {
+      return
+    }
+
+    const metadataKey = `${lock.network}:${lock.address}:${selectedRecipient}`
+    if (hydratedMetadataKey.current === metadataKey) {
+      return
+    }
+
+    const savedValues = userMetadataToFormValues(savedMetadata.metadata)
+    metadataInputs.forEach((input) => {
+      const savedValue = savedValues[input.name]
+      const field = `metadata.${id}.${input.name}` as const
+      const currentValue = getValues(field)
+
+      if (
+        savedValue !== undefined &&
+        (currentValue === undefined || currentValue === '')
+      ) {
+        setValue(field, savedValue, {
+          shouldDirty: false,
+          shouldValidate: false,
+        })
+      }
+    })
+
+    hydratedMetadataKey.current = metadataKey
+  }, [
+    getValues,
+    id,
+    lock.address,
+    lock.network,
+    metadataInputs,
+    savedMetadata?.metadata,
+    selectedRecipient,
+    setValue,
+  ])
 
   // register email value from user's account - to only apply to first recipient
   useEffect(() => {

--- a/unlock-app/src/hooks/useUserMetadata.ts
+++ b/unlock-app/src/hooks/useUserMetadata.ts
@@ -1,11 +1,11 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { locksmith } from '~/config/locksmith'
 
 interface User {
   userAddress: string
   network: number
   lockAddress: string
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
 }
 
 export const useUpdateUsersMetadata = () => {
@@ -20,6 +20,26 @@ export const useUpdateUsersMetadata = () => {
   })
 }
 
+export const useReadUserMetadata = ({
+  network,
+  lockAddress,
+  userAddress,
+  enabled = true,
+}: Omit<User, 'metadata'> & { enabled?: boolean }) => {
+  return useQuery({
+    queryKey: ['readUserMetadata', network, lockAddress, userAddress],
+    queryFn: async () => {
+      const response = await locksmith.getUserMetadata(
+        network,
+        lockAddress,
+        userAddress
+      )
+      return response.data
+    },
+    enabled: enabled && !!network && !!lockAddress && !!userAddress,
+  })
+}
+
 export const useUpdateUserMetadata = ({
   network,
   lockAddress,
@@ -27,7 +47,7 @@ export const useUpdateUserMetadata = ({
 }: Omit<User, 'metadata'>) => {
   return useMutation({
     mutationKey: ['updateUserMetadata', network, lockAddress, userAddress],
-    mutationFn: async (metadata: Record<string, any>) => {
+    mutationFn: async (metadata: Record<string, unknown>) => {
       const response = await locksmith.updateUserMetadata(
         network,
         lockAddress,

--- a/unlock-app/src/utils/userMetadata.ts
+++ b/unlock-app/src/utils/userMetadata.ts
@@ -29,3 +29,18 @@ export function formResultToMetadata(
 
   return result
 }
+
+export function userMetadataToFormValues(metadata?: {
+  public?: Record<string, unknown>
+  protected?: Record<string, unknown>
+}): Record<string, string> {
+  return Object.entries({
+    ...(metadata?.public || {}),
+    ...(metadata?.protected || {}),
+  }).reduce<Record<string, string>>((values, [key, value]) => {
+    if (value !== undefined && value !== null) {
+      values[key] = String(value)
+    }
+    return values
+  }, {})
+}


### PR DESCRIPTION
# Description

When a checkout visitor saves recipient metadata and returns to the same checkout before completing the purchase, the metadata step now loads their saved metadata and fills empty metadata fields for that recipient.

The change adds a small read hook for the existing Locksmith user metadata endpoint, hydrates checkout metadata inputs without overwriting already edited values, and keeps the metadata shape conversion covered by a unit test.

# Issues

Fixes #12481

# Checklist:

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the docs to reflect my changes if applicable
- [x] I have added tests (and stories for frontend components) that prove my fix is effective or that my feature works
- [x] I have performed a self-review of my own code
- [ ] If my code involves visual changes, I am adding applicable screenshots to this thread

## Testing

- `yarn workspace @unlock-protocol/unlock-app vitest run src/__tests__/utils/userMetadata.test.ts --environment=jsdom`
- `yarn workspace @unlock-protocol/unlock-app eslint src/components/interface/checkout/main/Metadata.tsx src/hooks/useUserMetadata.ts src/utils/userMetadata.ts src/__tests__/utils/userMetadata.test.ts`

## Release Note Draft Snippet

Checkout now restores saved recipient metadata when users return to an incomplete checkout.