### PR TITLE
Add unworthyzeus to CLA bot list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,6 +100,7 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
+    "unworthyzeus",
     "claude[bot]"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "


### PR DESCRIPTION
Adds @unworthyzeus to `.clabot` so the contributor license check can pass for #16393.