### PR TITLE
Add custom fields to manual airdrops

### DIFF
--- a/unlock-app/src/__tests__/utils/airdropMetadata.test.ts
+++ b/unlock-app/src/__tests__/utils/airdropMetadata.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { airdropMemberToMetadata } from '../../utils/airdropMetadata'
+
+describe('airdropMemberToMetadata', () => {
+  it('maps email and custom manual airdrop fields to protected metadata', () => {
+    expect(
+      airdropMemberToMetadata({
+        wallet: '0xabc',
+        count: 1,
+        email: 'member@example.com',
+        Role: 'Speaker',
+      })
+    ).toEqual({
+      protected: {
+        email: 'member@example.com',
+        Role: 'Speaker',
+      },
+      public: {},
+    })
+  })
+
+  it('maps fields suffixed with public to public metadata', () => {
+    expect(
+      airdropMemberToMetadata({
+        wallet: '0xabc',
+        count: 1,
+        'Company.public': 'Unlock',
+        'Ticket Type.protected': 'VIP',
+      })
+    ).toEqual({
+      protected: {
+        'Ticket Type': 'VIP',
+      },
+      public: {
+        Company: 'Unlock',
+      },
+    })
+  })
+})

--- a/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropDrawer.tsx
@@ -12,16 +12,14 @@ import { ToastHelper } from '@unlock-protocol/ui'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import dayjs from 'dayjs'
 import { formatDate } from '~/utils/lock'
-import { omit } from 'lodash'
 import { useMultipleLockData } from '~/hooks/useLockData'
 import { useState } from 'react'
 import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
 import { useProvider } from '~/hooks/useProvider'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { airdropMemberToMetadata } from '~/utils/airdropMetadata'
 
 dayjs.extend(customParseFormat)
-
-type Metadata = Record<'public' | 'protected', Record<string, string>>
 
 export const AirdropForm = ({ locks }: { locks: PaywallLocksConfigType }) => {
   const results = useMultipleLockData(locks) as {
@@ -88,35 +86,9 @@ export const AirdropFormForLock = ({ lock }: { lock: Lock }) => {
 
     async function sendTransaction(newItems: AirdropMember[]): Promise<void> {
       // Create metadata
-      const users = newItems.map(({ wallet: userAddress, ...rest }) => {
-        const data = omit(rest, [
-          'manager',
-          'neverExpire',
-          'count',
-          'expiration',
-          'balance',
-          'line',
-        ])
-        const metadata = Object.entries(data).reduce<Metadata>(
-          (result, [key, value]) => {
-            const [name, designation] = key.split('.')
-
-            if (designation !== 'public') {
-              // @ts-expect-error
-              result.protected[name] = value
-            } else {
-              // @ts-expect-error
-              result.public[name] = value
-            }
-
-            return result
-          },
-          {
-            protected: {},
-            public: {},
-          }
-        )
-
+      const users = newItems.map((member) => {
+        const { wallet: userAddress } = member
+        const metadata = airdropMemberToMetadata(member)
         const user = {
           userAddress,
           lockAddress: lock.address,
@@ -187,7 +159,7 @@ export const AirdropFormForLock = ({ lock }: { lock: Lock }) => {
             `Successfully granted ${options.recipients.length} keys to ${newItems.length} recipients`
           )
         })
-        .catch((error: any) => {
+        .catch((error: unknown) => {
           console.error(error)
           throw new Error('We were unable to airdrop these memberships.')
         })
@@ -205,7 +177,7 @@ export const AirdropFormForLock = ({ lock }: { lock: Lock }) => {
       promises.push(promise)
     }
 
-    Promise.allSettled(promises).catch((error: any) => {
+    Promise.allSettled(promises).catch((error: unknown) => {
       console.error(error)
       ToastHelper.error('We were unable to airdrop some memberships.')
     })

--- a/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropElements.tsx
@@ -27,22 +27,47 @@ interface AirdropListItemProps {
   onRemove: MouseEventHandler<HTMLButtonElement>
 }
 
-export function AirdropListItem({
-  value: { wallet, count, email, expiration, neverExpire },
-  onRemove,
-}: AirdropListItemProps) {
+const memberFields = new Set([
+  'balance',
+  'count',
+  'email',
+  'expiration',
+  'line',
+  'manager',
+  'neverExpire',
+  'wallet',
+])
+
+const formatMetadataField = (key: string) => {
+  const [name, designation] = key.split('.')
+  return designation === 'public' ? `${name} (public)` : name
+}
+
+export function AirdropListItem({ value, onRemove }: AirdropListItemProps) {
+  const { wallet, count, email, expiration, neverExpire } = value
+  const metadataItems = Object.entries(value).filter(([key, item]) => {
+    return !memberFields.has(key) && item !== undefined && item !== ''
+  })
+
   return (
     <div className="flex items-center justify-between w-full px-2 py-1 text-sm bg-white rounded-lg shadow">
-      <div className="space-x-2">
+      <div className="space-y-1">
         <span>
           {addressMinify(wallet)} {email ? `(${email})` : ''}{' '}
         </span>
-        <span className="text-gray-500">
+        <span className="block text-gray-500">
           {count} {count > 1 ? 'keys' : 'key'}{' '}
           {expiration &&
             `valid until ${new Date(expiration).toLocaleDateString()}`}
           {neverExpire && 'never expires'}
         </span>
+        {metadataItems.length > 0 && (
+          <span className="block text-gray-500">
+            {metadataItems
+              .map(([key, item]) => `${formatMetadataField(key)}: ${item}`)
+              .join(', ')}
+          </span>
+        )}
       </div>
       <IconButton
         onClick={onRemove}

--- a/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
+++ b/unlock-app/src/components/interface/members/airdrop/AirdropManualForm.tsx
@@ -11,7 +11,7 @@ import { useList } from 'react-use'
 import { AirdropListItem } from './AirdropElements'
 import { Lock } from '~/unlockTypes'
 import { formatDate } from '~/utils/lock'
-import { ChangeEvent, useCallback, useState } from 'react'
+import { ChangeEvent, MouseEvent, useCallback, useState } from 'react'
 import { ToastHelper } from '@unlock-protocol/ui'
 import { KeyManager } from '@unlock-protocol/unlock-js'
 import { useConfig } from '~/utils/withConfig'
@@ -28,6 +28,23 @@ export interface Props {
   emailRequired?: boolean
 }
 
+type CustomMetadataField = {
+  key: string
+  name: string
+  designation: 'public' | 'protected'
+}
+
+const reservedMetadataFields = new Set([
+  'balance',
+  'count',
+  'email',
+  'expiration',
+  'line',
+  'manager',
+  'neverexpire',
+  'wallet',
+])
+
 export function AirdropInternalForm({
   add,
   defaultValues,
@@ -36,6 +53,9 @@ export function AirdropInternalForm({
 }: Props) {
   const config = useConfig()
   const [useEmail, setUseEmail] = useState(false)
+  const [customFieldName, setCustomFieldName] = useState('')
+  const [customFieldIsPublic, setCustomFieldIsPublic] = useState(false)
+  const [customFields, setCustomFields] = useState<CustomMetadataField[]>([])
   const {
     handleSubmit,
     register,
@@ -65,6 +85,45 @@ export function AirdropInternalForm({
         })
       }
     }
+  }
+
+  const addCustomField = () => {
+    const name = customFieldName.trim()
+    const lowerName = name.toLowerCase()
+
+    if (!name) {
+      ToastHelper.error('Enter a field name first.')
+      return
+    }
+
+    if (name.includes('.')) {
+      ToastHelper.error('Field names cannot include periods.')
+      return
+    }
+
+    if (reservedMetadataFields.has(lowerName)) {
+      ToastHelper.error('That field is already handled by the airdrop form.')
+      return
+    }
+
+    const designation = customFieldIsPublic ? 'public' : 'protected'
+    const key = `${name}.${designation}`
+    const fieldExists = customFields.some(
+      (field) => field.key.toLowerCase() === key.toLowerCase()
+    )
+
+    if (fieldExists) {
+      ToastHelper.error('That field has already been added.')
+      return
+    }
+
+    setCustomFields((fields) => [...fields, { key, name, designation }])
+    setCustomFieldName('')
+  }
+
+  const removeCustomField = (key: string) => {
+    resetField(key as keyof AirdropMember)
+    setCustomFields((fields) => fields.filter((field) => field.key !== key))
   }
 
   const required = useEmail ? 'Email is required' : 'Wallet address is required'
@@ -197,7 +256,7 @@ export function AirdropInternalForm({
                       <AddressInput
                         withIcon
                         value={wallet}
-                        onChange={(value: any) => {
+                        onChange={(value: string) => {
                           setValue('wallet', value)
                         }}
                         required
@@ -229,6 +288,62 @@ export function AirdropInternalForm({
           error={errors.email?.message}
         />
       )}
+
+      <div className="grid gap-3 p-4 border border-gray-300 rounded-lg">
+        <span className="text-base font-medium">Custom attributes</span>
+        <div className="grid gap-3 md:grid-cols-[1fr_auto_auto] md:items-end">
+          <Input
+            label="Attribute name"
+            placeholder="Company"
+            value={customFieldName}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setCustomFieldName(event.target.value)
+            }
+          />
+          <div className="flex items-center gap-2 pb-2">
+            <span className="text-sm">
+              {customFieldIsPublic ? 'Public' : 'Protected'}
+            </span>
+            <Toggle
+              size="small"
+              value={customFieldIsPublic}
+              onChange={(value: boolean) => setCustomFieldIsPublic(value)}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outlined-primary"
+            onClick={addCustomField}
+          >
+            Add field
+          </Button>
+        </div>
+
+        {customFields.length > 0 && (
+          <div className="grid gap-3">
+            {customFields.map((field) => (
+              <div
+                key={field.key}
+                className="grid gap-2 md:grid-cols-[1fr_auto] md:items-end"
+              >
+                <Input
+                  label={`${field.name} (${field.designation})`}
+                  {...register(field.key as keyof AirdropMember)}
+                />
+                <Button
+                  type="button"
+                  size="small"
+                  variant="outlined-primary"
+                  onClick={() => removeCustomField(field.key)}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
       <div className="flex flex-row gap-4 w-full">
         <Input
           pattern="\d+"
@@ -352,7 +467,7 @@ export function AirdropManualForm({
           <Button
             loading={isConfirming}
             disabled={isConfirming}
-            onClick={async (event: any) => {
+            onClick={async (event: MouseEvent<HTMLButtonElement>) => {
               event.preventDefault()
               setIsConfirming(true)
               try {

--- a/unlock-app/src/utils/airdropMetadata.ts
+++ b/unlock-app/src/utils/airdropMetadata.ts
@@ -1,0 +1,48 @@
+export type AirdropMetadata = Record<
+  'public' | 'protected',
+  Record<string, string>
+>
+
+const nonMetadataFields = new Set([
+  'manager',
+  'neverExpire',
+  'count',
+  'expiration',
+  'balance',
+  'line',
+  'wallet',
+])
+
+export const airdropMemberToMetadata = (
+  member: Record<string, unknown>
+): AirdropMetadata => {
+  return Object.entries(member).reduce<AirdropMetadata>(
+    (result, [key, value]) => {
+      if (nonMetadataFields.has(key) || value === undefined || value === null) {
+        return result
+      }
+
+      const stringValue = String(value)
+      if (!stringValue.trim()) {
+        return result
+      }
+
+      const [name, designation] = key.split('.')
+      if (!name) {
+        return result
+      }
+
+      if (designation === 'public') {
+        result.public[name] = stringValue
+      } else {
+        result.protected[name] = stringValue
+      }
+
+      return result
+    },
+    {
+      protected: {},
+      public: {},
+    }
+  )
+}


### PR DESCRIPTION
Summary:
- add dynamic custom attribute fields to the manual airdrop form
- preserve public/protected metadata mapping when creating airdrop recipients
- show custom attributes in the pending airdrop recipient list before confirmation

Fixes #10614.

Testing:
- yarn workspace @unlock-protocol/unlock-app vitest run src/__tests__/utils/airdropMetadata.test.ts --environment=jsdom --coverage.enabled=false
- yarn workspace @unlock-protocol/unlock-app eslint src/components/interface/members/airdrop/AirdropDrawer.tsx src/components/interface/members/airdrop/AirdropElements.tsx src/components/interface/members/airdrop/AirdropManualForm.tsx src/utils/airdropMetadata.ts src/__tests__/utils/airdropMetadata.test.ts