### PR TITLE
Add referrer to key token attributes

### DIFF
--- a/locksmith/__tests__/utils/keyData.test.ts
+++ b/locksmith/__tests__/utils/keyData.test.ts
@@ -27,5 +27,22 @@ describe('KeyData', () => {
         })
       })
     })
+
+    describe('when the data has a referrer', () => {
+      it('adds the refer attribute', () => {
+        const referrer = '0x0000000000000000000000000000000000000abc'
+
+        expect.assertions(1)
+        expect(keyData.openSeaPresentation({ referrer })).toEqual({
+          attributes: [
+            {
+              display_type: 'string',
+              trait_type: 'refer',
+              value: referrer,
+            },
+          ],
+        })
+      })
+    })
   })
 })

--- a/locksmith/src/utils/keyData.ts
+++ b/locksmith/src/utils/keyData.ts
@@ -8,6 +8,7 @@ import { TIMEOUT_ON_SUBGRAPH } from './constants'
 interface Key {
   expiration?: number
   minted?: number
+  referrer?: string
   tokenId: string
   owner: string
 }
@@ -49,6 +50,7 @@ export default class KeyData {
         tokenId: key?.tokenId,
         owner: key?.owner,
         minted: key?.createdAt ? parseInt(key.createdAt) : undefined,
+        referrer: key?.referrer,
       }
 
       return data
@@ -75,6 +77,13 @@ export default class KeyData {
         trait_type: 'Minted',
         display_type: 'date',
         value: data.minted,
+      })
+    }
+    if (data.referrer) {
+      attributes.push({
+        trait_type: 'refer',
+        display_type: 'string',
+        value: data.referrer,
       })
     }
     return {

--- a/packages/unlock-js/src/subgraph/schema.graphql
+++ b/packages/unlock-js/src/subgraph/schema.graphql
@@ -72,6 +72,7 @@ query AllKeys(
     manager
     expiration
     tokenURI
+    referrer
     createdAt
     createdAtBlock
     cancelled
@@ -137,6 +138,7 @@ query allLocksWithKeys(
       manager
       expiration
       tokenURI
+      referrer
       createdAt
       createdAtBlock
       cancelled

--- a/subgraph/introspection.json
+++ b/subgraph/introspection.json
@@ -395,6 +395,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Address of the referrer used when the key was purchased",
+              "isDeprecated": false,
+              "name": "referrer",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Block key was created",
               "isDeprecated": false,
               "name": "createdAtBlock",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -64,6 +64,8 @@ type Key @entity {
   expiration: BigInt!
   "The tokenURI on an NFT is a unique identifier"
   tokenURI: String
+  "Address of the referrer used when the key was purchased"
+  referrer: Bytes
   "Block key was created"
   createdAtBlock: BigInt!
   "Timestamp of the block in which the key was created"

--- a/subgraph/src/public-lock.ts
+++ b/subgraph/src/public-lock.ts
@@ -1,4 +1,11 @@
-import { Address, BigInt, log, Bytes, store } from '@graphprotocol/graph-ts'
+import {
+  Address,
+  BigInt,
+  log,
+  Bytes,
+  store,
+  ethereum,
+} from '@graphprotocol/graph-ts'
 import {
   CancelKey as CancelKeyEvent,
   ExpirationChanged as ExpirationChangedUntilV11Event,
@@ -39,6 +46,158 @@ import {
   KEY_GRANTER,
 } from './helpers'
 import { tryCreateCancelReceipt, createReceipt } from './receipt'
+import { ERC20_TRANSFER_TOPIC0, nullAddress } from '../tests/constants'
+
+const PURCHASE_ARRAY_SELECTOR = '0x33818997'
+const PURCHASE_STRUCT_ARRAY_SELECTOR = '0x4609b39b'
+const PURCHASE_SINGLE_SELECTOR = '0x8be4b870'
+
+function selectorFor(input: Bytes): string {
+  if (input.length < 4) {
+    return ''
+  }
+  return Bytes.fromUint8Array(input.subarray(0, 4)).toHexString()
+}
+
+function callData(input: Bytes): Bytes {
+  if (input.length <= 4) {
+    return Bytes.fromHexString('0x')
+  }
+  return Bytes.fromUint8Array(input.subarray(4))
+}
+
+function purchaseIndexFor(event: TransferEvent, recipients: Address[]): i32 {
+  const eventIndex = mintTransferIndex(event)
+  if (eventIndex >= 0) {
+    return eventIndex
+  }
+
+  for (let i = 0; i < recipients.length; i++) {
+    if (recipients[i] == event.params.to) {
+      return i
+    }
+  }
+
+  return recipients.length == 1 ? 0 : -1
+}
+
+function mintTransferIndex(event: TransferEvent): i32 {
+  if (event.receipt == null) {
+    return -1
+  }
+
+  const receipt = event.receipt!
+  const logs: ethereum.Log[] = receipt.logs
+  let index: i32 = -1
+
+  for (let i = 0; i < logs.length; i++) {
+    const txLog = logs[i]
+    if (
+      txLog.address == event.address &&
+      txLog.topics.length >= 4 &&
+      txLog.topics[0].toHexString() == ERC20_TRANSFER_TOPIC0
+    ) {
+      const from = ethereum.decode('address', txLog.topics[1])!.toAddress()
+      if (from.toHexString() == nullAddress) {
+        index = index + 1
+        if (txLog.transactionLogIndex == event.transactionLogIndex) {
+          return index
+        }
+      }
+    }
+  }
+
+  return -1
+}
+
+function referrerFromArrayPurchase(event: TransferEvent, data: Bytes): Address {
+  const decoded = ethereum.decode(
+    '(uint256[],address[],address[],address[],bytes[])',
+    data
+  )
+  if (decoded == null) {
+    return Address.fromString(nullAddress)
+  }
+
+  const values = decoded!.toTuple()
+  const recipients = values[1].toAddressArray()
+  const referrers = values[2].toAddressArray()
+  const index = purchaseIndexFor(event, recipients)
+
+  if (index >= 0 && index < referrers.length) {
+    return referrers[index]
+  }
+
+  return Address.fromString(nullAddress)
+}
+
+function referrerFromStructArrayPurchase(
+  event: TransferEvent,
+  data: Bytes
+): Address {
+  const decoded = ethereum.decode(
+    '(uint256,address,address,address,address,bytes,uint256)[]',
+    data
+  )
+  if (decoded == null) {
+    return Address.fromString(nullAddress)
+  }
+
+  const purchaseArgs = decoded!.toArray()
+  const recipients = new Array<Address>(purchaseArgs.length)
+
+  for (let i = 0; i < purchaseArgs.length; i++) {
+    recipients[i] = purchaseArgs[i].toTuple()[1].toAddress()
+  }
+
+  const index = purchaseIndexFor(event, recipients)
+  if (index >= 0 && index < purchaseArgs.length) {
+    return purchaseArgs[index].toTuple()[2].toAddress()
+  }
+
+  return Address.fromString(nullAddress)
+}
+
+function referrerFromSinglePurchase(
+  event: TransferEvent,
+  data: Bytes
+): Address {
+  const decoded = ethereum.decode(
+    '(uint256,address,address,address,bytes)',
+    data
+  )
+  if (decoded == null) {
+    return Address.fromString(nullAddress)
+  }
+
+  const values = decoded!.toTuple()
+  const recipient = values[1].toAddress()
+  if (recipient != event.params.to) {
+    return Address.fromString(nullAddress)
+  }
+
+  return values[2].toAddress()
+}
+
+function referrerFromPurchase(event: TransferEvent): Address {
+  const input = event.transaction.input
+  const selector = selectorFor(input)
+  const data = callData(input)
+
+  if (selector == PURCHASE_ARRAY_SELECTOR) {
+    return referrerFromArrayPurchase(event, data)
+  }
+
+  if (selector == PURCHASE_STRUCT_ARRAY_SELECTOR) {
+    return referrerFromStructArrayPurchase(event, data)
+  }
+
+  if (selector == PURCHASE_SINGLE_SELECTOR) {
+    return referrerFromSinglePurchase(event, data)
+  }
+
+  return Address.fromString(nullAddress)
+}
 
 function newKey(event: TransferEvent): void {
   const keyID = genKeyID(event.address, event.params.tokenId.toString())
@@ -66,6 +225,10 @@ function newKey(event: TransferEvent): void {
     event.params.tokenId,
     event.params.to
   )
+  const referrer = referrerFromPurchase(event)
+  if (referrer.toHexString() != nullAddress) {
+    key.referrer = referrer
+  }
 
   addTransactionHashToKey(key, event.transaction.hash.toHexString())
   key.save()

--- a/subgraph/tests/keys-v11.test.ts
+++ b/subgraph/tests/keys-v11.test.ts
@@ -7,7 +7,7 @@ import {
   describe,
   test,
 } from 'matchstick-as/assembly/index'
-import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
 import {
   handleTransfer,
   handleCancelKey,
@@ -39,12 +39,49 @@ import {
   expiration,
   lockAddress,
   lockManagers,
+  keyPrice,
 } from './constants'
+import {
+  createKeyTransferEventLog,
+  newTransactionReceipt,
+} from './mockTxReceipt'
 
 // mock contract functions
 import './mocks'
 
 const keyID = `${lockAddress}-${tokenId}`
+const purchaseArraySelector = '0x33818997'
+const purchaseStructInput =
+  '0x4609b39b0000000000000000000000000000000000000000000000000000000000000020' +
+  '0000000000000000000000000000000000000000000000000000000000000001' +
+  '0000000000000000000000000000000000000000000000000000000000000020' +
+  '00000000000000000000000000000000000000000000000000000000000003e8' +
+  '0000000000000000000000000000000000000000000000000000000000000002' +
+  '0000000000000000000000000000000000000000000000000000000000000999' +
+  '0000000000000000000000000000000000000000000000000000000000000999' +
+  '0000000000000000000000000000000000000000000000000000000000000123' +
+  '00000000000000000000000000000000000000000000000000000000000000e0' +
+  '0000000000000000000000000000000000000000000000000000000000000000' +
+  '0000000000000000000000000000000000000000000000000000000000000000'
+
+function createPurchaseInput(
+  recipient: Address,
+  referrer: Address,
+  keyManager: Address
+): Bytes {
+  const values: Array<ethereum.Value> = [
+    ethereum.Value.fromUnsignedBigIntArray([BigInt.fromU32(keyPrice)]),
+    ethereum.Value.fromAddressArray([recipient]),
+    ethereum.Value.fromAddressArray([referrer]),
+    ethereum.Value.fromAddressArray([keyManager]),
+    ethereum.Value.fromBytesArray([Bytes.fromHexString('0x')]),
+  ]
+  const tuple = changetype<ethereum.Tuple>(values)
+
+  return Bytes.fromHexString(purchaseArraySelector).concat(
+    ethereum.encode(ethereum.Value.fromTuple(tuple))!
+  )
+}
 
 describe('Burn a key', () => {
   beforeAll(() => {
@@ -97,6 +134,63 @@ describe('Key transfers', () => {
     assert.fieldEquals('Key', keyID, 'createdAtBlock', '1')
     const hash = newTransferEvent.transaction.hash.toHexString()
     assert.fieldEquals('Key', keyID, 'transactionsHash', `[${hash}]`)
+  })
+
+  test('Creation of a new key stores the purchase referrer', () => {
+    const referrer = Address.fromString(
+      '0x0000000000000000000000000000000000000999'
+    )
+    const newTransferEvent = createTransferEvent(
+      Address.fromString(nullAddress),
+      Address.fromString(keyOwnerAddress),
+      BigInt.fromU32(tokenId)
+    )
+    const transactionLogIndex = BigInt.fromU32(4)
+
+    newTransferEvent.transaction.input = createPurchaseInput(
+      Address.fromString(keyOwnerAddress),
+      referrer,
+      Address.fromString(lockManagers[0])
+    )
+    newTransferEvent.transactionLogIndex = transactionLogIndex
+    newTransferEvent.receipt = newTransactionReceipt([
+      createKeyTransferEventLog(
+        Address.fromString(nullAddress),
+        Address.fromString(keyOwnerAddress),
+        BigInt.fromU32(tokenId),
+        transactionLogIndex
+      ),
+    ])
+
+    handleTransfer(newTransferEvent)
+    assert.fieldEquals('Key', keyID, 'referrer', referrer.toHexString())
+  })
+
+  test('Creation of a new key stores the v15 purchase referrer', () => {
+    const referrer = Address.fromString(
+      '0x0000000000000000000000000000000000000999'
+    )
+    const newTransferEvent = createTransferEvent(
+      Address.fromString(nullAddress),
+      Address.fromString(keyOwnerAddress),
+      BigInt.fromU32(tokenId)
+    )
+    const transactionLogIndex = BigInt.fromU32(4)
+
+    newTransferEvent.transaction.input =
+      Bytes.fromHexString(purchaseStructInput)
+    newTransferEvent.transactionLogIndex = transactionLogIndex
+    newTransferEvent.receipt = newTransactionReceipt([
+      createKeyTransferEventLog(
+        Address.fromString(nullAddress),
+        Address.fromString(keyOwnerAddress),
+        BigInt.fromU32(tokenId),
+        transactionLogIndex
+      ),
+    ])
+
+    handleTransfer(newTransferEvent)
+    assert.fieldEquals('Key', keyID, 'referrer', referrer.toHexString())
   })
 
   test('Transfer of an existing key', () => {

--- a/subgraph/tests/mockTxReceipt.ts
+++ b/subgraph/tests/mockTxReceipt.ts
@@ -16,6 +16,7 @@ import {
   nullAddress,
   tokenId,
   GNP_CHANGED_TOPIC0,
+  ERC20_TRANSFER_TOPIC0,
 } from './constants'
 
 const defaultAddress = Address.fromString(defaultMockAddress)
@@ -101,6 +102,34 @@ function createTransferEventLog(
     defaultBigInt,
     defaultBigInt,
     defaultBigInt,
+    'Transfer',
+    new Wrapped(false)
+  )
+}
+
+export function createKeyTransferEventLog(
+  from: Address,
+  to: Address,
+  tokenId: BigInt,
+  transactionLogIndex: BigInt
+): ethereum.Log {
+  const eventSignature = Bytes.fromHexString(ERC20_TRANSFER_TOPIC0)
+  const topics = [
+    eventSignature,
+    addressToTopic(from),
+    addressToTopic(to),
+    bigIntToTopic(tokenId),
+  ]
+  return new ethereum.Log(
+    Address.fromString(lockAddress),
+    topics,
+    Bytes.fromHexString('0x'),
+    defaultAddressBytes,
+    defaultIntBytes,
+    defaultAddressBytes,
+    defaultBigInt,
+    transactionLogIndex,
+    transactionLogIndex,
     'Transfer',
     new Wrapped(false)
   )


### PR DESCRIPTION
Closes #12212.

## Summary
- store each key purchase referrer on the subgraph Key entity by decoding purchase calldata for mint transfers
- expose the referrer field through unlock-js key queries
- add the `refer` OpenSea attribute in locksmith metadata when subgraph key data includes a referrer
- cover legacy purchase array calldata and v15 PurchaseArgs calldata in key subgraph tests

## Validation
- `yarn workspace @unlock-protocol/unlock-js generate:subgraph`
- `yarn workspace @unlock-protocol/subgraph test -v 0.5.2 keys-v11`
- direct locksmith smoke for `openSeaPresentation({ referrer })`
