### PR TITLE
fix: prefill checkout user metadata

### DIFF
--- a/unlock-app/src/__tests__/utils/userMetadata.test.ts
+++ b/unlock-app/src/__tests__/utils/userMetadata.test.ts
@@ -1,5 +1,9 @@
 import type { MetadataInputType } from '@unlock-protocol/core'
-import { getPublicInputs, formResultToMetadata } from '../../utils/userMetadata'
+import {
+  getPublicInputs,
+  formResultToMetadata,
+  userMetadataToFormResult,
+} from '../../utils/userMetadata'
 import { expect, it, describe } from 'vitest'
 const inputs: MetadataInputType[] = [
   {
@@ -54,6 +58,28 @@ describe('userMetadata utils', () => {
           'First Name': 'Saxton',
         },
       })
+    })
+  })
+
+  describe('userMetadataToFormResult', () => {
+    it('processes saved user metadata into checkout form values', () => {
+      expect.assertions(1)
+
+      expect(
+        userMetadataToFormResult(
+          {
+            public: {
+              'first name': 'Saxton',
+            },
+            protected: {
+              'last name': 'Hale',
+              'email address': 'ceo@mann.co',
+              ignored: 'value',
+            },
+          },
+          inputs
+        )
+      ).toEqual(formResult)
     })
   })
 })

--- a/unlock-app/src/components/interface/checkout/main/Metadata.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Metadata.tsx
@@ -23,7 +23,10 @@ import {
   Toggle,
 } from '@unlock-protocol/ui'
 import { twMerge } from 'tailwind-merge'
-import { formResultToMetadata } from '~/utils/userMetadata'
+import {
+  formResultToMetadata,
+  userMetadataToFormResult,
+} from '~/utils/userMetadata'
 import { ToastHelper } from '@unlock-protocol/ui'
 import { useSelector } from '@xstate/react'
 import { PoweredByUnlock } from '../PoweredByUnlock'
@@ -37,7 +40,10 @@ import {
   MetadataInputType as MetadataInput,
   PaywallConfigType,
 } from '@unlock-protocol/core'
-import { useUpdateUsersMetadata } from '~/hooks/useUserMetadata'
+import {
+  useUpdateUsersMetadata,
+  useUserMetadata,
+} from '~/hooks/useUserMetadata'
 import Disconnect from './Disconnect'
 import { shouldSkip } from './utils'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
@@ -389,6 +395,7 @@ export function Metadata({ checkoutService }: Props) {
     control,
     handleSubmit,
     formState: { isSubmitting, errors },
+    setValue,
     watch,
   } = methods
 
@@ -398,6 +405,30 @@ export function Metadata({ checkoutService }: Props) {
   })
 
   const recipient = recipientFromConfig(paywallConfig, lock) || account || ''
+  const canLoadUserMetadata =
+    !!account &&
+    !!isAccount(recipient) &&
+    recipient.toLowerCase() === account.toLowerCase()
+
+  const { data: savedUserMetadata, isLoading: isUserMetadataLoading } =
+    useUserMetadata({
+      network: lock!.network,
+      lockAddress: lock!.address,
+      userAddress: canLoadUserMetadata ? recipient : '',
+      viewerAddress: account,
+      enabled: canLoadUserMetadata,
+    })
+
+  const savedFormMetadata = useMemo(() => {
+    if (!canLoadUserMetadata) {
+      return {}
+    }
+
+    return userMetadataToFormResult(
+      savedUserMetadata?.metadata,
+      metadataInputs || []
+    )
+  }, [canLoadUserMetadata, metadataInputs, savedUserMetadata?.metadata])
 
   const { isLoading: isMemberLoading, data: isMember } = useQuery({
     queryKey: ['isMember', recipient, lock?.address],
@@ -427,7 +458,7 @@ export function Metadata({ checkoutService }: Props) {
 
   useEffect(() => {
     // Don't do anything if we're loading member status or if quantity is invalid
-    if (isMemberLoading || quantity <= 0) {
+    if (isMemberLoading || isUserMetadataLoading || quantity <= 0) {
       return
     }
 
@@ -440,7 +471,8 @@ export function Metadata({ checkoutService }: Props) {
     if (quantity > fields.length) {
       const fieldsRequired = quantity - fields.length
       for (let i = 0; i < fieldsRequired; i++) {
-        const addAccountAddress = fields.length === 0 && !isMember && !!account
+        const fieldIndex = fields.length + i
+        const addAccountAddress = fieldIndex === 0 && !isMember && !!account
         const isValidAddress = isAddressOrEns(recipient) || isAccount(recipient)
         const recipientValue = addAccountAddress
           ? isValidAddress
@@ -448,7 +480,10 @@ export function Metadata({ checkoutService }: Props) {
             : account
           : ''
         append(
-          { recipient: recipientValue },
+          {
+            recipient: recipientValue,
+            ...(fieldIndex === 0 ? savedFormMetadata : {}),
+          },
           {
             shouldFocus: false,
           }
@@ -461,7 +496,28 @@ export function Metadata({ checkoutService }: Props) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [quantity, recipient, isMember, isMemberLoading, account])
+  }, [
+    quantity,
+    recipient,
+    isMember,
+    isMemberLoading,
+    isUserMetadataLoading,
+    account,
+    savedFormMetadata,
+  ])
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      return
+    }
+
+    Object.entries(savedFormMetadata).forEach(([name, value]) => {
+      setValue(`metadata.0.${name}`, value, {
+        shouldDirty: false,
+        shouldTouch: false,
+      })
+    })
+  }, [fields.length, savedFormMetadata, setValue])
 
   const termsAccepted = watch('termsAccepted')
 
@@ -518,7 +574,7 @@ export function Metadata({ checkoutService }: Props) {
     <Fragment>
       <Stepper service={checkoutService} />
       <main className="h-full px-6 overflow-auto">
-        {isMemberLoading ? (
+        {isMemberLoading || isUserMetadataLoading ? (
           <Placeholder.Root className="py-6">
             <Placeholder.Line />
             <Placeholder.Line />
@@ -599,7 +655,12 @@ export function Metadata({ checkoutService }: Props) {
       <footer className="grid items-center px-6 pt-6 border-t">
         <Button
           loading={isLoading}
-          disabled={isLoading || isMemberLoading || !termsAccepted}
+          disabled={
+            isLoading ||
+            isMemberLoading ||
+            isUserMetadataLoading ||
+            !termsAccepted
+          }
           className="w-full"
           form="metadata"
         >

--- a/unlock-app/src/hooks/useUserMetadata.ts
+++ b/unlock-app/src/hooks/useUserMetadata.ts
@@ -1,11 +1,45 @@
-import { useMutation } from '@tanstack/react-query'
-import { locksmith } from '~/config/locksmith'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { config } from '~/config/app'
+import { locksmith, locksmithClient } from '~/config/locksmith'
 
 interface User {
   userAddress: string
   network: number
   lockAddress: string
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
+}
+
+interface UserMetadataQuery extends Omit<User, 'metadata'> {
+  enabled?: boolean
+  viewerAddress?: string
+}
+
+export const useUserMetadata = ({
+  network,
+  lockAddress,
+  userAddress,
+  enabled = true,
+  viewerAddress,
+}: UserMetadataQuery) => {
+  return useQuery({
+    queryKey: [
+      'userMetadata',
+      network,
+      lockAddress,
+      userAddress,
+      viewerAddress,
+    ],
+    queryFn: async () => {
+      const url = new URL(
+        `/v2/api/metadata/${network}/locks/${lockAddress}/users/${userAddress}`,
+        config.locksmithHost
+      )
+      const response = await locksmithClient.get(url.toString())
+      return response.data
+    },
+    enabled: enabled && !!network && !!lockAddress && !!userAddress,
+    retry: false,
+  })
 }
 
 export const useUpdateUsersMetadata = () => {
@@ -27,7 +61,7 @@ export const useUpdateUserMetadata = ({
 }: Omit<User, 'metadata'>) => {
   return useMutation({
     mutationKey: ['updateUserMetadata', network, lockAddress, userAddress],
-    mutationFn: async (metadata: Record<string, any>) => {
+    mutationFn: async (metadata: Record<string, unknown>) => {
       const response = await locksmith.updateUserMetadata(
         network,
         lockAddress,

--- a/unlock-app/src/utils/userMetadata.ts
+++ b/unlock-app/src/utils/userMetadata.ts
@@ -29,3 +29,29 @@ export function formResultToMetadata(
 
   return result
 }
+
+export function userMetadataToFormResult(
+  metadata:
+    | {
+        public?: Record<string, unknown>
+        protected?: Record<string, unknown>
+      }
+    | undefined,
+  inputs: MetadataInputType[]
+): Record<string, string> {
+  const storedMetadata = {
+    ...(metadata?.public || {}),
+    ...(metadata?.protected || {}),
+  }
+
+  return inputs.reduce<Record<string, string>>((result, input) => {
+    const value =
+      storedMetadata[input.name] ?? storedMetadata[input.name.toLowerCase()]
+
+    if (value !== undefined && value !== null) {
+      result[input.name] = `${value}`
+    }
+
+    return result
+  }, {})
+}


### PR DESCRIPTION
## Summary
- Load saved checkout user metadata when the recipient is the connected account.
- Prefill the first checkout metadata form from saved public/protected metadata without exposing other users' protected metadata.
- Add unit coverage for converting saved user metadata into checkout form values.

## Tests
- corepack yarn prettier --check "unlock-app/src/hooks/useUserMetadata.ts" "unlock-app/src/utils/userMetadata.ts" "unlock-app/src/__tests__/utils/userMetadata.test.ts" "unlock-app/src/components/interface/checkout/main/Metadata.tsx"
- corepack yarn workspace @unlock-protocol/unlock-app lint "src/hooks/useUserMetadata.ts" "src/utils/userMetadata.ts" "src/__tests__/utils/userMetadata.test.ts" "src/components/interface/checkout/main/Metadata.tsx"
- corepack yarn vitest run "unlock-app/src/__tests__/utils/userMetadata.test.ts"
- corepack yarn workspace @unlock-protocol/unlock-app tsc --noEmit --project tsconfig.json

Fixes #12481