### PR TITLE
feat: add event clone prefill

### DIFF
--- a/unlock-app/src/components/content/event/EventDetails.tsx
+++ b/unlock-app/src/components/content/event/EventDetails.tsx
@@ -17,7 +17,7 @@ import { Event, PaywallConfigType } from '@unlock-protocol/core'
 import { useEvent } from '~/hooks/useEvent'
 import { SettingEmail } from '~/components/interface/locks/Settings/elements/SettingEmail'
 import { FaUsers } from 'react-icons/fa'
-import { TbSettings } from 'react-icons/tb'
+import { TbCopy, TbSettings } from 'react-icons/tb'
 import { useEventVerifiers } from '~/hooks/useEventVerifiers'
 import { EventDefaultLayout } from './Layout/EventDefaultLayout'
 import { EventBannerlessLayout } from './Layout/EventBannerlessLayout'
@@ -141,6 +141,18 @@ export const EventDetails = ({
                 <div className="flex items-center gap-2">
                   <Icon icon={FaUsers} size={20} />
                   <span>Attendees</span>
+                </div>
+              </Button>
+              <Button
+                onClick={() => {
+                  router.push(
+                    `/event/new?clone=${encodeURIComponent(event.slug)}`
+                  )
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <Icon icon={TbCopy} size={20} />
+                  <span>Clone event</span>
                 </div>
               </Button>
             </>

--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -1,7 +1,7 @@
 import { FaRegLightbulb } from 'react-icons/fa'
 import { usePlacesWidget } from 'react-google-autocomplete'
 import { config } from '~/config/app'
-import { useEffect, useState } from 'react'
+import { FormEvent, RefObject, useEffect, useMemo, useState } from 'react'
 import { Lock, Token } from '@unlock-protocol/types'
 import { BsArrowLeft as ArrowBackIcon } from 'react-icons/bs'
 import { BiLogoZoom as ZoomIcon } from 'react-icons/bi'
@@ -44,32 +44,54 @@ export interface NewEventForm {
   metadata: Partial<MetadataFormData>
 }
 
+export type NewEventFormDefaults = Partial<
+  Omit<NewEventForm, 'lock' | 'metadata'>
+> & {
+  lock?: Partial<NewEventForm['lock']>
+  metadata?: Partial<NewEventForm['metadata']>
+}
+
 interface GoogleMapsAutoCompleteProps {
   onChange: (address: string, location: string, timezone: string) => void
   defaultValue?: string
+}
+
+interface GooglePlaceResult {
+  formatted_address?: string
+  geometry?: {
+    location?: {
+      lat?: () => number
+      lng?: () => number
+    }
+  }
 }
 
 export const GoogleMapsAutoComplete = ({
   onChange,
   defaultValue,
 }: GoogleMapsAutoCompleteProps) => {
-  const onPlaceSelected = async (place: any, inputRef: any) => {
-    const lat = place.geometry?.location?.lat()
-    const lng = place.geometry?.location?.lng()
+  const onPlaceSelected = async (
+    place: unknown,
+    inputRef: RefObject<HTMLInputElement>
+  ) => {
+    const selectedPlace = place as GooglePlaceResult
+    const inputValue = inputRef.current?.value || ''
+    const lat = selectedPlace.geometry?.location?.lat?.()
+    const lng = selectedPlace.geometry?.location?.lng?.()
 
     //  We use a dedicated API key because this Timezone API  does not support restricting by referrers as of Sept 2024
     const timezoneInfo = await fetch(
       `https://maps.googleapis.com/maps/api/timezone/json?location=${lat}%2C${lng}&timestamp=${Math.floor(new Date().getTime() / 1000)}&key=AIzaSyB7AMd20omjPeJRS2rDBbq8HKZIoRZQD_o`
     ).then((response) => response.json())
 
-    if (place.formatted_address) {
+    if (selectedPlace.formatted_address) {
       return onChange(
-        inputRef.value,
-        place.formatted_address,
+        inputValue,
+        selectedPlace.formatted_address,
         timezoneInfo.timeZoneId
       )
     }
-    return onChange(inputRef.value, inputRef.value, timezoneInfo.timeZoneId)
+    return onChange(inputValue, inputValue, timezoneInfo.timeZoneId)
   }
 
   const { ref } = usePlacesWidget({
@@ -77,7 +99,7 @@ export const GoogleMapsAutoComplete = ({
       types: [],
     },
     apiKey: config.googleMapsApiKey,
-    onPlaceSelected: (place: any, inputRef: any) => {
+    onPlaceSelected: (place, inputRef) => {
       onPlaceSelected(place, inputRef)
     },
   })
@@ -96,17 +118,33 @@ export const GoogleMapsAutoComplete = ({
 interface FormProps {
   onSubmit: (data: NewEventForm) => void
   compact?: boolean
+  defaultValues?: NewEventFormDefaults
 }
 
-export const Form = ({ onSubmit, compact = false }: FormProps) => {
+const getBooleanDefault = (value: unknown, fallback: boolean) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  return fallback
+}
+
+export const Form = ({
+  onSubmit,
+  compact = false,
+  defaultValues,
+}: FormProps) => {
   const [oldMaxNumberOfKeys, setOldMaxNumberOfKeys] = useState<number>(0)
   const { networks } = useConfig()
   const { account } = useAuthenticate()
-  const [isInPerson, setIsInPerson] = useState(true)
-  const [screeningEnabled, enableScreening] = useState(false)
-  const [isUnlimitedCapacity, setIsUnlimitedCapacity] = useState(false)
-  const [attendeeRefund, setAttendeeRefund] = useState(false)
-  const [isFree, setIsFree] = useState(true)
   const [isCurrencyModalOpen, setCurrencyModalOpen] = useState(false)
   const { mutateAsync: uploadImage, isPending: isUploading } = useImageUpload()
 
@@ -117,10 +155,8 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
   const moreNetworkOptions = useAvailableNetworks(true)
   const network = networkOptions[0]?.value
 
-  const methods = useForm<NewEventForm>({
-    mode: 'onChange',
-    shouldUnregister: false,
-    defaultValues: {
+  const baseDefaultValues = useMemo<NewEventForm>(
+    () => ({
       network,
       lock: {
         name: '',
@@ -146,7 +182,53 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
         requiresApproval: false,
         emailSender: '',
       },
-    },
+    }),
+    [network, networks, today]
+  )
+
+  const formDefaultValues = useMemo<NewEventForm>(
+    () => ({
+      ...baseDefaultValues,
+      ...defaultValues,
+      lock: {
+        ...baseDefaultValues.lock,
+        ...defaultValues?.lock,
+      },
+      metadata: {
+        ...baseDefaultValues.metadata,
+        ...defaultValues?.metadata,
+        ticket: {
+          ...baseDefaultValues.metadata.ticket,
+          ...defaultValues?.metadata?.ticket,
+        },
+      },
+    }),
+    [baseDefaultValues, defaultValues]
+  )
+
+  const [isInPerson, setIsInPerson] = useState(
+    getBooleanDefault(
+      formDefaultValues.metadata.ticket?.event_is_in_person,
+      true
+    )
+  )
+  const [screeningEnabled, enableScreening] = useState(
+    getBooleanDefault(formDefaultValues.metadata.requiresApproval, false)
+  )
+  const [isUnlimitedCapacity, setIsUnlimitedCapacity] = useState(
+    formDefaultValues.lock.maxNumberOfKeys === undefined
+  )
+  const [attendeeRefund, setAttendeeRefund] = useState(
+    !!formDefaultValues.metadata.attendeeRefund
+  )
+  const [isFree, setIsFree] = useState(
+    Number(formDefaultValues.lock.keyPrice || 0) === 0
+  )
+
+  const methods = useForm<NewEventForm>({
+    mode: 'onChange',
+    shouldUnregister: false,
+    defaultValues: formDefaultValues,
   })
 
   const {
@@ -210,13 +292,15 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
     },
   })
 
-  const processAndSubmit = (values: any) => {
+  const processAndSubmit = (values: NewEventForm) => {
     if (attendeeRefund) {
       values.metadata.attendeeRefund = {
         amount: values.lock!.keyPrice,
         currency: values.lock!.currencyContractAddress,
         network: values.network,
       }
+    } else {
+      delete values.metadata.attendeeRefund
     }
     onSubmit(values)
   }
@@ -265,16 +349,20 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
                   description="This illustration will be used for your event page, as well as the NFT tickets by default. Use 512 by 512 pixels for best results."
                   isUploading={isUploading}
                   preview={metadataImage!}
-                  onChange={async (fileOrFileUrl: any) => {
+                  onChange={async (
+                    fileOrFileUrl: string | File[] | FormEvent<HTMLDivElement>
+                  ) => {
                     if (typeof fileOrFileUrl === 'string') {
                       setValue('metadata.image', fileOrFileUrl)
-                    } else {
+                    } else if (Array.isArray(fileOrFileUrl)) {
                       const items = await uploadImage(fileOrFileUrl[0])
                       const image = items?.[0]?.publicUrl
                       if (!image) {
                         return
                       }
                       setValue('metadata.image', image)
+                    } else {
+                      return
                     }
                     trigger('metadata.image')
                   }}

--- a/unlock-app/src/components/content/event/NewEvent.tsx
+++ b/unlock-app/src/components/content/event/NewEvent.tsx
@@ -1,16 +1,24 @@
 'use client'
 
 import { useState } from 'react'
-import { Form, NewEventForm } from './Form'
+import { Form, NewEventForm, NewEventFormDefaults } from './Form'
 import { ToastHelper } from '@unlock-protocol/ui'
 import { LockDeploying } from './LockDeploying'
 import { locksmith } from '~/config/locksmith'
 import { networks } from '@unlock-protocol/networks'
-import { formDataToMetadata } from '~/components/interface/locks/metadata/utils'
+import {
+  formDataToMetadata,
+  toFormData,
+} from '~/components/interface/locks/metadata/utils'
 import { useProvider } from '~/hooks/useProvider'
 import { EventStatus } from '@unlock-protocol/types'
-import { PaywallConfigType } from '@unlock-protocol/core'
+import { Event, PaywallConfigType } from '@unlock-protocol/core'
 import { EventsLayout } from './Layout/constants'
+import { useSearchParams } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+import { useWeb3Service } from '~/utils/withWeb3Service'
+import LoadingIcon from '~/components/interface/Loading'
+import { useAuthenticate } from '~/hooks/useAuthenticate'
 
 export interface TransactionDetails {
   hash: string
@@ -58,10 +66,186 @@ export const defaultEventCheckoutConfigForLockOnNetwork = (
   } as PaywallConfigType
 }
 
+const checkoutConfigForClonedLock = (
+  checkoutConfig: PaywallConfigType,
+  lockAddress: string,
+  network: number
+) => {
+  const defaultConfig = defaultEventCheckoutConfigForLockOnNetwork(
+    lockAddress,
+    network
+  )
+  const sourceLockConfig = Object.values(checkoutConfig.locks || {})[0] || {}
+  const metadataInputs =
+    sourceLockConfig.metadataInputs || checkoutConfig.metadataInputs
+
+  return {
+    ...defaultConfig,
+    title: checkoutConfig.title || defaultConfig.title,
+    emailRequired: checkoutConfig.emailRequired,
+    network,
+    locks: {
+      [lockAddress]: {
+        ...defaultConfig.locks[lockAddress],
+        ...(metadataInputs ? { metadataInputs } : {}),
+        ...(typeof sourceLockConfig.emailRequired === 'boolean'
+          ? { emailRequired: sourceLockConfig.emailRequired }
+          : {}),
+        network,
+      },
+    },
+  } as PaywallConfigType
+}
+
+const getBooleanValue = (value: unknown, fallback: boolean) => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  return fallback
+}
+
+const eventToFormDefaults = ({
+  event,
+  lock,
+  network,
+}: {
+  event: Event
+  lock?: Partial<NewEventForm['lock']> & {
+    currencySymbol?: string | null
+  }
+  network?: number
+}): NewEventFormDefaults => {
+  const sourceTicket = event.ticket || {}
+  const lockDefaults: NewEventFormDefaults['lock'] = {
+    name: event.name,
+  }
+
+  if (lock) {
+    lockDefaults.expirationDuration = lock.expirationDuration
+    lockDefaults.maxNumberOfKeys = lock.maxNumberOfKeys
+    lockDefaults.currencyContractAddress = lock.currencyContractAddress ?? null
+    lockDefaults.keyPrice = lock.keyPrice ? `${lock.keyPrice}` : '0'
+  }
+
+  const defaultValues: NewEventFormDefaults = {
+    lock: lockDefaults,
+    currencySymbol:
+      lock?.currencySymbol ||
+      (network ? networks[network].nativeCurrency.symbol : undefined),
+    metadata: {
+      description: event.description,
+      image: event.image,
+      ticket: {
+        event_cover_image: sourceTicket.event_cover_image,
+        event_start_date: sourceTicket.event_start_date,
+        event_start_time: sourceTicket.event_start_time,
+        event_end_date: sourceTicket.event_end_date,
+        event_end_time: sourceTicket.event_end_time,
+        event_timezone: sourceTicket.event_timezone,
+        event_address: sourceTicket.event_address,
+        event_location: sourceTicket.event_location,
+        event_url: sourceTicket.event_url,
+        event_is_in_person: getBooleanValue(
+          sourceTicket.event_is_in_person,
+          true
+        ),
+      },
+      requiresApproval: getBooleanValue(event.requiresApproval, false),
+      attendeeRefund: event.attendeeRefund,
+      emailSender: event.emailSender,
+      replyTo: event.replyTo,
+      layout: event.layout,
+    },
+  }
+
+  if (network) {
+    defaultValues.network = network
+  }
+
+  if (!defaultValues.currencySymbol) {
+    delete defaultValues.currencySymbol
+  }
+
+  return defaultValues
+}
+
 export const NewEvent = () => {
+  const searchParams = useSearchParams()
+  const cloneSlug = searchParams.get('clone')
   const [transactionDetails, setTransactionDetails] =
     useState<TransactionDetails>()
   const { getWalletService } = useProvider()
+  const web3Service = useWeb3Service()
+  const { account } = useAuthenticate()
+
+  const {
+    data: clonedEvent,
+    isLoading: isClonedEventLoading,
+    isError: isClonedEventError,
+    error: clonedEventError,
+  } = useQuery({
+    queryKey: ['clonedEvent', cloneSlug, account],
+    enabled: !!cloneSlug && !!account,
+    queryFn: async () => {
+      const { data: eventMetadata } = await locksmith.getEvent(cloneSlug!)
+      const event = toFormData({
+        ...eventMetadata.data!,
+        slug: eventMetadata.slug,
+      }) as Event
+      const checkoutConfig = eventMetadata.checkoutConfig as
+        | { id?: string; config: PaywallConfigType }
+        | undefined
+      const sourceLocks = checkoutConfig?.config?.locks || {}
+      const sourceLockAddresses = Object.keys(sourceLocks)
+      const sourceLockAddress = sourceLockAddresses[0]
+      const sourceNetwork = sourceLockAddress
+        ? sourceLocks[sourceLockAddress]?.network ||
+          checkoutConfig?.config?.network
+        : checkoutConfig?.config?.network
+
+      const isOrganizer = await Promise.all(
+        sourceLockAddresses.map((lockAddress) => {
+          const network =
+            sourceLocks[lockAddress].network || checkoutConfig?.config.network
+
+          if (!network) {
+            return false
+          }
+
+          return web3Service.isLockManager(lockAddress, account!, network)
+        })
+      )
+
+      if (!isOrganizer.some(Boolean)) {
+        throw new Error('Only event organizers can clone this event.')
+      }
+
+      const lock =
+        sourceLockAddress && sourceNetwork
+          ? await web3Service.getLock(sourceLockAddress, sourceNetwork)
+          : undefined
+
+      return {
+        checkoutConfig,
+        defaultValues: eventToFormDefaults({
+          event,
+          lock,
+          network: sourceNetwork,
+        }),
+      }
+    },
+  })
+
+  const isCloneLoading = !!cloneSlug && (!account || isClonedEventLoading)
 
   const onSubmit = async (formData: NewEventForm) => {
     try {
@@ -75,7 +259,7 @@ export const NewEvent = () => {
             ...formData.metadata,
           }),
           ...formData.metadata,
-          layout: EventsLayout.Bannerless,
+          layout: formData.metadata.layout || EventsLayout.Bannerless,
         },
         status: EventStatus.PENDING,
       }
@@ -118,14 +302,22 @@ export const NewEvent = () => {
         })
 
         // Update existing event with checkout config and deployed status
+        const checkoutConfig = clonedEvent?.checkoutConfig?.config
+          ? checkoutConfigForClonedLock(
+              clonedEvent.checkoutConfig.config,
+              lockAddress,
+              formData.network
+            )
+          : defaultEventCheckoutConfigForLockOnNetwork(
+              lockAddress,
+              formData.network
+            )
+
         await locksmith.updateEventData(pendingEvent.slug, {
           status: EventStatus.DEPLOYED,
           checkoutConfig: {
             name: `Checkout config for ${formData.lock.name}`,
-            config: defaultEventCheckoutConfigForLockOnNetwork(
-              lockAddress,
-              formData.network
-            ),
+            config: checkoutConfig,
           },
         })
       }
@@ -141,7 +333,17 @@ export const NewEvent = () => {
       {transactionDetails && (
         <LockDeploying transactionDetails={transactionDetails} />
       )}
-      {!transactionDetails && <Form onSubmit={onSubmit} />}
+      {!transactionDetails && isCloneLoading && <LoadingIcon />}
+      {!transactionDetails && !isCloneLoading && isClonedEventError && (
+        <div className="px-4 py-3 text-sm text-red-600 border border-red-200 rounded-lg bg-red-50">
+          {clonedEventError instanceof Error
+            ? clonedEventError.message
+            : 'We could not load the event you want to clone. Please try again from the event page.'}
+        </div>
+      )}
+      {!transactionDetails && !isCloneLoading && !isClonedEventError && (
+        <Form onSubmit={onSubmit} defaultValues={clonedEvent?.defaultValues} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add a Clone event action for event organizers that opens event creation with the existing event details pre-filled.
- Reuse the source lock's public ticket settings while deploying a fresh lock and event.
- Keep clone prefill gated to organizers and avoid copying the full source checkout config.

## Security
- Clone defaults only load for accounts that are lock managers on the source event.
- The cloned checkout config starts from a new-event default and only carries over attendee metadata inputs/title/email-required settings, not the full source checkout behavior.
- Attendee refund metadata is removed on submit if the organizer disables refunding in the form.

## Tests
- corepack yarn prettier --check "unlock-app/src/components/content/event/EventDetails.tsx" "unlock-app/src/components/content/event/NewEvent.tsx" "unlock-app/src/components/content/event/Form.tsx"
- corepack yarn workspace @unlock-protocol/unlock-app lint "src/components/content/event/EventDetails.tsx" "src/components/content/event/NewEvent.tsx" "src/components/content/event/Form.tsx"
- corepack yarn workspace @unlock-protocol/unlock-app tsc --noEmit --project tsconfig.json

Fixes #16196