### PR TITLE
Add membership renewal status filter

### DIFF
--- a/locksmith/__tests__/operations/keysOperations.test.ts
+++ b/locksmith/__tests__/operations/keysOperations.test.ts
@@ -9,6 +9,17 @@ import { Rsvp } from '../../src/models'
 const network = 4
 const lockAddress = '0x62CcB13A72E6F991dE53b9B7AC42885151588Cd2'
 const wrongLockAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const mockGetMembershipState = vi.hoisted(() =>
+  vi.fn(async ({ tokenId }: { tokenId: string }) => {
+    return {
+      currency: 'USDC',
+      isRenewable: true,
+      isAutoRenewable: tokenId === '1',
+      isRenewableIfReApproved: tokenId === '2',
+      isRenewableIfRePurchased: tokenId === '3',
+    }
+  })
+)
 
 const lock = {
   address: '0xxee',
@@ -125,6 +136,13 @@ vi.mock('../../src/operations/metadataOperations', () => {
     },
   }
 })
+
+vi.mock('../../src/operations/membershipOperations', () => {
+  return {
+    getMembershipState: mockGetMembershipState,
+  }
+})
+
 describe('keysOperations operations', () => {
   describe('buildKeysWithMetadata', () => {
     it('should merge keys items with the corresponding metadata', () => {
@@ -426,6 +444,32 @@ describe('keysOperations operations', () => {
           transactionsHash: ['0x'],
         },
       ])
+    })
+
+    it('should filter keys by renewal status', async () => {
+      expect.assertions(3)
+
+      const { address } = await loginRandomUser(app)
+      const { keys, total } = await getKeysWithMetadata({
+        network,
+        lockAddress,
+        filters: {
+          filterKey: 'owner',
+          approval: 'minted',
+          renewal: 'needs approval',
+          max: 10,
+          page: 0,
+        },
+        loggedInUserAddress: address,
+      })
+
+      expect(total).toBe(1)
+      expect(keys.length).toBe(1)
+      expect(keys[0]).toMatchObject({
+        token: '2',
+        renewalStatus: 'needs approval',
+        renewalCurrency: 'USDC',
+      })
     })
 
     describe('pending keys', () => {

--- a/locksmith/src/controllers/v2/keyController.ts
+++ b/locksmith/src/controllers/v2/keyController.ts
@@ -26,6 +26,7 @@ export default class KeyController {
         filterKey,
         expiration = 'active',
         approval = 'minted',
+        renewal = 'all',
       } = request.query ?? {}
 
       if (!filterKey) {
@@ -41,6 +42,7 @@ export default class KeyController {
         filterKey,
         expiration,
         approval,
+        renewal,
         max: Math.min(PAGE_SIZE, Number(max)),
       }
 
@@ -150,6 +152,7 @@ export default class KeyController {
         filterKey,
         expiration = 'active',
         approval = 'minted',
+        renewal = 'all',
       } = request.query ?? {}
 
       if (!filterKey) {
@@ -165,6 +168,7 @@ export default class KeyController {
         filterKey,
         expiration,
         approval,
+        renewal,
         max: Math.min(PAGE_SIZE, Number(max)),
       }
 

--- a/locksmith/src/operations/keysOperations.ts
+++ b/locksmith/src/operations/keysOperations.ts
@@ -7,6 +7,8 @@ import { getUserAddressesMatchingData } from './userMetadataOperations'
 import { Rsvp } from '../models'
 import { PAGE_SIZE } from '@unlock-protocol/core'
 import { getWeb3Service } from '../initializers'
+import * as membershipOperations from './membershipOperations'
+import pLimit from 'p-limit'
 
 const KEY_FILTER_MAPPING: { [key: string]: string } = {
   owner: 'keyholderAddress',
@@ -14,6 +16,17 @@ const KEY_FILTER_MAPPING: { [key: string]: string } = {
   email: 'email',
   transactionHash: 'transactionsHash',
 }
+
+const RENEWAL_FILTER_FETCH_LIMIT = 5000
+
+type RenewalStatus =
+  | 'all'
+  | 'will renew'
+  | 'needs approval'
+  | 'balance low'
+  | 'needs purchase'
+  | 'not renewable'
+
 /**
  * Filters keys base on query
  * @param {Array} keys - list of keys
@@ -39,6 +52,86 @@ async function filterKeys(keys: any[], filters: any) {
   return fuse.remove((item: any) => {
     return item?.checkedInAt
   })
+}
+
+const getRenewalStatus = (membershipState: {
+  isRenewable: boolean
+  isAutoRenewable: boolean
+  isRenewableIfReApproved: boolean
+  isRenewableIfRePurchased: boolean
+}): RenewalStatus => {
+  if (!membershipState.isRenewable) {
+    return 'not renewable'
+  }
+
+  if (membershipState.isAutoRenewable) {
+    return 'will renew'
+  }
+
+  if (membershipState.isRenewableIfReApproved) {
+    return 'needs approval'
+  }
+
+  if (membershipState.isRenewableIfRePurchased) {
+    return 'needs purchase'
+  }
+
+  return 'balance low'
+}
+
+async function addRenewalStatusToKeys({
+  keys,
+  lock,
+  lockAddress,
+  network,
+}: {
+  keys: any[]
+  lock: Partial<SubgraphLock>
+  lockAddress: string
+  network: number
+}) {
+  const renewalStatusLimit = pLimit(5)
+
+  return Promise.all(
+    keys.map((key) =>
+      renewalStatusLimit(async () => {
+        if (!key?.token) {
+          return {
+            ...key,
+            renewalStatus: 'not renewable',
+          }
+        }
+
+        try {
+          const membershipState = await membershipOperations.getMembershipState(
+            {
+              key: {
+                expiration: key.expiration,
+                lock: {
+                  version: lock?.version,
+                },
+              },
+              tokenAddress: lock?.tokenAddress || '',
+              network,
+              lockAddress,
+              tokenId: `${key.token}`,
+            },
+          )
+
+          return {
+            ...key,
+            renewalStatus: getRenewalStatus(membershipState),
+            renewalCurrency: membershipState.currency,
+          }
+        } catch {
+          return {
+            ...key,
+            renewalStatus: 'not renewable',
+          }
+        }
+      })
+    )
+  )
 }
 
 type Lock = Omit<Partial<SubgraphLock>, 'keys'> & {
@@ -119,6 +212,10 @@ export async function getKeysWithMetadata({
   let metadataItems: any[] = []
 
   let keysFilter = filters
+  const renewalFilter = filters.renewal || 'all'
+  const shouldFilterByRenewal =
+    renewalFilter !== 'all' &&
+    ['pending', 'denied'].indexOf(filters.approval) === -1
 
   // Ok so if the filters is not an _onchain_ thing we need to first get the addresses that would match it!
   if (filters.filterKey === 'email' && filters.query) {
@@ -140,6 +237,15 @@ export async function getKeysWithMetadata({
   let lock: any
   const limit = filters.max || PAGE_SIZE
   const page = filters.page || 0
+
+  if (shouldFilterByRenewal) {
+    keysFilter = {
+      ...keysFilter,
+      page: 0,
+      max: RENEWAL_FILTER_FETCH_LIMIT,
+    }
+  }
+
   if (['pending', 'denied'].indexOf(filters.approval) > -1) {
     const rsvps = await Rsvp.findAll({
       where: {
@@ -191,7 +297,24 @@ export async function getKeysWithMetadata({
   }
 
   const keys = buildKeysWithMetadata(lock as Lock, metadataItems)
-  const filteredKeys = await filterKeys(keys, filters)
+  let filteredKeys = await filterKeys(keys, filters)
+
+  if (shouldFilterByRenewal) {
+    filteredKeys = (
+      await addRenewalStatusToKeys({
+        keys: filteredKeys,
+        lock,
+        lockAddress,
+        network,
+      })
+    ).filter((key) => key.renewalStatus === renewalFilter)
+
+    return {
+      keys: filteredKeys.slice(page * limit, page * limit + limit),
+      total: filteredKeys.length,
+    }
+  }
+
   return {
     keys: filteredKeys,
     total: lock.totalKeys,

--- a/unlock-app/src/components/interface/keychain/KeyInfoDrawer.tsx
+++ b/unlock-app/src/components/interface/keychain/KeyInfoDrawer.tsx
@@ -61,27 +61,31 @@ const KeyRenewal = ({
   const possible = BigInt(possibleRenewals)
   const approved = BigInt(approvedRenewals)
 
-  if (possible >= 0) {
+  if (approved >= UNLIMITED_RENEWAL_LIMIT) {
     return (
       <KeyItem label="Renewals">
-        Your balance of {balance.amount} {balance.symbol} is too low to renew
+        Renews unlimited times
       </KeyItem>
     )
   }
 
-  if (approved >= 0) {
-    return <KeyItem label="Renewals">No renewals approved</KeyItem>
-  }
-
-  if (approved > 0 && approved >= UNLIMITED_RENEWAL_LIMIT) {
+  if (approved > 0) {
     return <KeyItem label="Renewals">{approved.toString()} times</KeyItem>
   }
 
-  if (approved > UNLIMITED_RENEWAL_LIMIT) {
-    return <KeyItem label="Renewals">Renews unlimited times</KeyItem>
+  if (possible > 0) {
+    return (
+      <KeyItem label="Renewals">
+        You have enough balance but need to approve future renewals
+      </KeyItem>
+    )
   }
 
-  return <KeyItem label="Renewals">-</KeyItem>
+  return (
+    <KeyItem label="Renewals">
+      Your balance of {balance.amount} {balance.symbol} is too low to renew
+    </KeyItem>
+  )
 }
 
 interface KeyInfoProps {

--- a/unlock-app/src/components/interface/locks/Manage/elements/FilterBar.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/FilterBar.tsx
@@ -15,6 +15,7 @@ interface FilterBarProps {
   lockAddress?: string
   hideExpirationFilter?: boolean
   hideApprovalFilter?: boolean
+  showRenewalFilter?: boolean
   setLockAddress?: (address: string) => void
   setFilters: (filters: FilterProps) => void
   setLoading?: (loading: boolean) => void
@@ -80,6 +81,15 @@ export enum ApprovalStatus {
   DENIED = 'denied',
 }
 
+export enum RenewalStatus {
+  ALL = 'all',
+  WILL_RENEW = 'will renew',
+  NEEDS_APPROVAL = 'needs approval',
+  BALANCE_LOW = 'balance low',
+  NEEDS_PURCHASE = 'needs purchase',
+  NOT_RENEWABLE = 'not renewable',
+}
+
 interface AttributeFilterProps {
   values: any
   currentValue: string
@@ -118,6 +128,7 @@ export const FilterBar = ({
   lockAddress,
   hideExpirationFilter = false,
   hideApprovalFilter = true,
+  showRenewalFilter = false,
   setLockAddress,
   setFilters,
   setLoading,
@@ -156,10 +167,25 @@ export const FilterBar = ({
     }
   }, [setLoading, isTyping])
 
+  useEffect(() => {
+    if (showRenewalFilter || filters.renewal === RenewalStatus.ALL) {
+      return
+    }
+
+    setFilters({
+      ...filters,
+      renewal: RenewalStatus.ALL,
+    })
+    setPage(1)
+  }, [filters, setFilters, setPage, showRenewalFilter])
+
   const [openSearch, setOpenSearch] = useState(false)
   const [expandExpirationFilter, setExpandExpirationFilter] = useState(false)
   const [expandApprovalFilter, setExpandApprovalFilter] = useState(
     filters.approval !== ApprovalStatus.MINTED
+  )
+  const [expandRenewalFilter, setExpandRenewalFilter] = useState(
+    filters.renewal !== RenewalStatus.ALL
   )
 
   const filterOptions = FILTER_ITEMS.filter((filter: Filter) => {
@@ -252,6 +278,32 @@ export const FilterBar = ({
               onChange={(approval: string) => {
                 setFiltersAndResetPage({
                   approval: approval as ApprovalStatus,
+                })
+              }}
+            />
+          )}
+        </div>
+      )}
+      {showRenewalFilter && (
+        <div className="flex flex-row gap-2 items-start md:items-center md:h-6">
+          <Button
+            className="justify-start"
+            variant="borderless"
+            size="small"
+            onClick={() => setExpandRenewalFilter(!expandRenewalFilter)}
+          >
+            <div className="w-24 md:w-fit  flex items-center gap-1">
+              <FilterIcon size={18} />
+              <span>Renewal {expandRenewalFilter ? ':' : ''}</span>
+            </div>
+          </Button>
+          {expandRenewalFilter && (
+            <AttributeFilter
+              values={RenewalStatus}
+              currentValue={filters.renewal}
+              onChange={(renewal: string) => {
+                setFiltersAndResetPage({
+                  renewal: renewal as RenewalStatus,
                 })
               }}
             />

--- a/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/Members.tsx
@@ -4,13 +4,14 @@ import { ImageBar } from './ImageBar'
 import { MemberCard as DefaultMemberCard, MemberCardProps } from './MemberCard'
 import { paginate } from '~/utils/pagination'
 import { PaginationBar } from './PaginationBar'
-import { ApprovalStatus, ExpirationStatus } from './FilterBar'
+import { ApprovalStatus, ExpirationStatus, RenewalStatus } from './FilterBar'
 import { graphService } from '~/config/subgraph'
-import { locksmith } from '~/config/locksmith'
+import { locksmith, locksmithClient } from '~/config/locksmith'
 import { Placeholder } from '@unlock-protocol/ui'
 import { PAGE_SIZE } from '@unlock-protocol/core'
 import { useBatchNameResolver } from '~/hooks/useNameResolver'
 import { useLockManager } from '~/hooks/useLockManager'
+import { config } from '~/config/app'
 
 /**
  * Default placeholder component when there are no members and no filters applied
@@ -43,6 +44,7 @@ export interface FilterProps {
   filterKey: string
   expiration: ExpirationStatus
   approval: ApprovalStatus
+  renewal: RenewalStatus
 }
 
 export interface MembersProps {
@@ -84,16 +86,23 @@ const getMembers = async (
   filters: FilterProps,
   page: number
 ) => {
-  const { query, filterKey, expiration, approval } = filters
-  const response = await locksmith.keysByPage(
-    network,
-    lockAddress,
-    query,
-    filterKey,
-    expiration,
-    approval,
-    page - 1, // API starts at 0
-    PAGE_SIZE
+  const { query, filterKey, expiration, approval, renewal } = filters
+  const response = await locksmithClient.get(
+    new URL(
+      `/v2/api/${network}/locks/${lockAddress}/keys-by-page`,
+      config.locksmithHost
+    ).toString(),
+    {
+      params: {
+        query,
+        filterKey,
+        expiration,
+        approval,
+        renewal,
+        page: page - 1, // API starts at 0
+        max: PAGE_SIZE,
+      },
+    }
   )
   return response.data
 }
@@ -122,6 +131,7 @@ export const Members = ({
     filterKey: 'owner',
     expiration: ExpirationStatus.ALL,
     approval: ApprovalStatus.MINTED,
+    renewal: RenewalStatus.ALL,
   },
   MemberCard = DefaultMemberCard,
   NoMemberWithFilter = DefaultNoMemberWithFilter,
@@ -175,6 +185,7 @@ export const Members = ({
       filters.filterKey,
       filters.expiration,
       filters.approval,
+      filters.renewal,
     ],
     queryFn: async () => {
       const membersResponse = await getMembers(
@@ -237,6 +248,7 @@ export const Members = ({
   const hasActiveFilter =
     filters?.approval !== 'minted' ||
     filters?.expiration !== 'all' ||
+    filters?.renewal !== RenewalStatus.ALL ||
     filters?.filterKey !== 'owner' ||
     filters?.query?.length > 0
 

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -50,6 +50,8 @@ const keysToIgnore = [
   'data',
   'transactionsHash',
   'createdAt',
+  'renewalStatus',
+  'renewalCurrency',
 ]
 
 interface KeyRenewalProps {
@@ -66,31 +68,7 @@ const MembershipRenewal = ({
   const possible = BigInt(possibleRenewals)
   const approved = BigInt(approvedRenewals)
 
-  if (possible >= 0) {
-    return (
-      <Detail className="py-2" label="Renewals:" inline justify={false}>
-        User balance of {balance.amount} {balance.symbol} is too low to renew
-      </Detail>
-    )
-  }
-
-  if (approved >= 0) {
-    return (
-      <Detail className="py-2" label="Renewals" inline justify={false}>
-        No renewals approved
-      </Detail>
-    )
-  }
-
-  if (approved > 0 && approved >= UNLIMITED_RENEWAL_LIMIT) {
-    return (
-      <Detail className="py-2" label="Renewals" inline justify={false}>
-        {approved.toString()} times
-      </Detail>
-    )
-  }
-
-  if (approved > UNLIMITED_RENEWAL_LIMIT) {
+  if (approved >= UNLIMITED_RENEWAL_LIMIT) {
     return (
       <Detail className="py-2" label="Renewals" inline justify={false}>
         Renews unlimited times
@@ -98,9 +76,25 @@ const MembershipRenewal = ({
     )
   }
 
+  if (approved > 0) {
+    return (
+      <Detail className="py-2" label="Renewals" inline justify={false}>
+        {approved.toString()} times
+      </Detail>
+    )
+  }
+
+  if (possible > 0) {
+    return (
+      <Detail className="py-2" label="Renewals" inline justify={false}>
+        User has enough balance but needs to approve future renewals
+      </Detail>
+    )
+  }
+
   return (
     <Detail className="py-2" label="Renewals" inline justify={false}>
-      -
+      User balance of {balance.amount} {balance.symbol} is too low to renew
     </Detail>
   )
 }

--- a/unlock-app/src/components/interface/locks/Manage/index.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/index.tsx
@@ -13,6 +13,7 @@ import {
   ApprovalStatus,
   ExpirationStatus,
   FilterBar,
+  RenewalStatus,
 } from './elements/FilterBar'
 import { useLockManager } from '~/hooks/useLockManager'
 import Link from 'next/link'
@@ -20,6 +21,7 @@ import { Picker } from '../../Picker'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
 import { useCentralizedLockData } from '~/hooks/useCentralizedLockData'
 import { ActionBar } from '../elements/ActionBar'
+import { ADDRESS_ZERO, MAX_UINT } from '~/constants'
 
 import { NotManagerBanner } from '../Settings'
 import { TopActionBar } from '../elements/TopActionBar'
@@ -64,8 +66,17 @@ export const ManageLockContent = ({
     filterKey: 'owner',
     expiration: ExpirationStatus.ALL,
     approval: ApprovalStatus.MINTED,
+    renewal: RenewalStatus.ALL,
   })
   const [page, setPage] = useState(1)
+
+  const selectedLock = centralizedLockData?.lock
+  const showRenewalFilter = Boolean(
+    Number(selectedLock?.version || 0) >= 11 &&
+      selectedLock?.expirationDuration !== MAX_UINT &&
+      selectedLock?.tokenAddress &&
+      selectedLock.tokenAddress !== ADDRESS_ZERO
+  )
 
   // Handler for toggling airdrop modal
   const toggleAirdropKeys = useCallback(() => {
@@ -186,6 +197,7 @@ export const ManageLockContent = ({
                   setLoading={setLoading}
                   setPage={setPage}
                   page={page}
+                  showRenewalFilter={showRenewalFilter}
                 />
 
                 {/* Members list component with centralized data */}


### PR DESCRIPTION
Closes #16190.

## Summary
- Add a renewal-status query filter to the lock members endpoint and members dashboard filters.
- Show renewal filter controls only for recurring ERC20 locks.
- Correct renewal status copy so approval-needed cases are not reported as low balance.
- Add coverage for renewal status filtering in keysOperations.

## Testing
- `git diff --check`
- Targeted test: `yarn test locksmith/__tests__/operations/keysOperations.test.ts --runInBand -t "renewal status"` passed 1 test, 6 skipped.
- Full `keysOperations.test.ts` was not completed locally because the DB-backed cases require a running local Postgres test database.
