### PR TITLE
Show cross-chain purchase total estimate

### DIFF
--- a/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCrossChainPurchase.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Confirm/ConfirmCrossChainPurchase.tsx
@@ -80,6 +80,11 @@ export function ConfirmCrossChainPurchase({
   const symbol = route.tokenPayment.isNative
     ? route.currency
     : route.tokenPayment.symbol
+  const estimatedTotal = `${formatNumber(
+    Number(
+      ethers.formatUnits(route.tokenPayment.amount, route.tokenPayment.decimals)
+    )
+  )} ${symbol}`
 
   const isLoading = isPricingDataLoading || isInitialDataLoading
 
@@ -180,17 +185,13 @@ export function ConfirmCrossChainPurchase({
         )}
 
         {pricingData && (
-          <Pricing
-            isCardEnabled={false}
-            keyPrice={`${formatNumber(
-              Number(
-                ethers.formatUnits(
-                  route.tokenPayment.amount,
-                  route.tokenPayment.decimals
-                )
-              )
-            )} ${symbol}`}
-          />
+          <div className="grid gap-2">
+            <Pricing isCardEnabled={false} keyPrice={estimatedTotal} />
+            <p className="text-sm text-gray-500">
+              Estimated cross-chain total quoted by {route.provider.name}.
+              Wallet gas may vary before confirmation.
+            </p>
+          </div>
         )}
       </main>
       <footer className="grid items-center px-6 pt-6 border-t">

--- a/unlock-app/src/components/interface/checkout/main/Payment.tsx
+++ b/unlock-app/src/components/interface/checkout/main/Payment.tsx
@@ -353,6 +353,14 @@ export function Payment({ checkoutService }: Props) {
                 paymentMethods['crosschain'] &&
                 crosschainRoutes?.map((route, index) => {
                   const symbol = route.tokenPayment?.symbol || route.symbol
+                  const estimatedTotal = formatNumber(
+                    Number(
+                      ethers.formatUnits(
+                        route.tokenPayment.amount,
+                        route.tokenPayment.decimals
+                      )
+                    )
+                  )
 
                   if (!symbol) {
                     // Some routes are returned with Decent without a token
@@ -379,14 +387,7 @@ export function Payment({ checkoutService }: Props) {
                           Pay with {symbol} on {route.networkName}
                         </h3>
                         <AmountBadge
-                          amount={formatNumber(
-                            Number(
-                              ethers.formatUnits(
-                                route.tokenPayment.amount,
-                                route.tokenPayment.decimals
-                              )
-                            )
-                          )}
+                          amount={estimatedTotal}
                           symbol={symbol}
                         />
                       </div>
@@ -404,6 +405,9 @@ export function Payment({ checkoutService }: Props) {
                             {route.provider.name}
                           </Link>
                           .
+                          <br />
+                          Estimated cross-chain total: ~{estimatedTotal}{' '}
+                          {symbol.toUpperCase()}. Wallet gas may vary.
                         </div>
                         <RightArrowIcon
                           className="transition-transform duration-300 ease-out group-hover:fill-brand-ui-primary group-hover:translate-x-1 group-disabled:translate-x-0 group-disabled:transition-none group-disabled:group-hover:fill-black"


### PR DESCRIPTION
## Summary

This makes the cross-chain route quote explicit in checkout:

- labels the Relay route input amount as the estimated cross-chain total in the payment option
- repeats the same estimated total on the confirmation screen
- notes that wallet gas can still vary before confirmation

Fixes #14066

## Validation

- Reviewed the cross-chain checkout flow in `Payment.tsx`, `ConfirmCrossChainPurchase.tsx`, `useCrossChainRoutes.ts`, and `relayLink.ts`.
- Ran `git diff --check`.

I did not run the full Unlock app test suite locally because this fresh checkout does not have workspace dependencies installed.
