### PR TITLE
Add Email Membership Details action for members

### DIFF
--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -19,6 +19,9 @@ vi.mock('@unlock-protocol/unlock-js', async () => {
   const actual: any = await vi.importActual('@unlock-protocol/unlock-js')
   return {
     ...actual,
+    SubgraphService: vi.fn().mockImplementation(() => ({
+      lock: async () => null,
+    })),
     Web3Service: vi.fn().mockImplementation(() => {
       return {
         isLockManager: (lock: string) => lockAddressMock === lock,
@@ -78,6 +81,7 @@ describe('Wedlocks operations', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
     fetchMock.enableMocks()
+    fetchMock.mockResponse(JSON.stringify({ data: { locks: [] } }))
   })
 
   describe('notifyNewKeyToWedlocks', () => {
@@ -162,7 +166,10 @@ describe('Wedlocks operations', () => {
         }
       )
 
-      const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]!.body as string)
+      const wedlocksCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([url]) => url === config.services.wedlocks)
+      const body = JSON.parse(wedlocksCall![1]!.body as string)
 
       expect(body).toMatchObject({
         params: {

--- a/locksmith/__tests__/operations/wedlocksOperations.test.ts
+++ b/locksmith/__tests__/operations/wedlocksOperations.test.ts
@@ -124,6 +124,59 @@ describe('Wedlocks operations', () => {
       })
     })
 
+    it('should include custom content and extra attachments', async () => {
+      expect.assertions(1)
+
+      const lockAddress = '0x95de5F777A3e283bFf0c47374998E10D8A2183C7'
+      const ownerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+      const lockName = 'Alice in Wonderland'
+
+      await addMetadata({
+        chain: network,
+        tokenAddress: lockAddress,
+        userAddress: ownerAddress,
+        data: {
+          protected: {
+            email: 'julien@unlock-protocol.com',
+          },
+        },
+      })
+      await notifyNewKeyToWedlocks(
+        {
+          lock: {
+            address: lockAddress,
+            name: lockName,
+          },
+          owner: ownerAddress,
+          manager: ownerAddress,
+        },
+        network,
+        {
+          customContent: 'Membership details',
+          attachments: [
+            {
+              path: 'data:application/pdf;base64,abc123',
+              filename: 'receipt_1.pdf',
+            },
+          ],
+        }
+      )
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]!.body as string)
+
+      expect(body).toMatchObject({
+        params: {
+          customContent: '<p>Membership details</p>\n',
+        },
+        attachments: [
+          {
+            path: 'data:application/pdf;base64,abc123',
+            filename: 'receipt_1.pdf',
+          },
+        ],
+      })
+    })
+
     it('should not notify wedlocks if there is no metadata', async () => {
       expect.assertions(1)
 

--- a/locksmith/src/controllers/v2/ticketsController.tsx
+++ b/locksmith/src/controllers/v2/ticketsController.tsx
@@ -1,6 +1,9 @@
 import { Request, RequestHandler, Response } from 'express'
 import Dispatcher from '../../fulfillment/dispatcher'
-import { notifyNewKeyToWedlocks } from '../../operations/wedlocksOperations'
+import {
+  notifyNewKeyToWedlocks,
+  type Attachment,
+} from '../../operations/wedlocksOperations'
 import Normalizer from '../../utils/normalizer'
 import { SubgraphService } from '@unlock-protocol/unlock-js'
 import logger from '../../logger'
@@ -17,8 +20,67 @@ import { Verifier } from '../../models/verifier'
 import { getEventForLock } from '../../operations/eventOperations'
 import { notify } from '../../worker/helpers'
 import { getWeb3Service } from '../../initializers'
+import { getReceiptDetails } from '../../operations/receiptOperations'
+import { createReceiptPDFBuffer } from '../../utils/receipts'
 
 export class TicketsController {
+  async getReceiptAttachments({
+    lockAddress,
+    network,
+    hashes,
+  }: {
+    lockAddress: string
+    network: number
+    hashes: string[]
+  }): Promise<Attachment[]> {
+    if (!hashes.length) {
+      return []
+    }
+
+    const web3Service = getWeb3Service()
+    const lock = await web3Service.getLock(lockAddress, network)
+    const attachments: Attachment[] = []
+
+    for (const hash of hashes) {
+      const receiptDetails = await getReceiptDetails({
+        lockAddress,
+        network,
+        hash,
+      })
+      if (!receiptDetails.receipt) {
+        continue
+      }
+
+      const supplier = receiptDetails.supplier
+      const receipt = {
+        ...receiptDetails.receipt,
+        vat: supplier?.vat,
+        service: supplier?.servicePerformed,
+        supplierName: supplier?.supplierName,
+        supplierAddress:
+          supplier?.addressLine1 && supplier?.addressLine2
+            ? `${supplier.addressLine1}\n${supplier.addressLine2}`
+            : supplier?.addressLine1 || supplier?.addressLine2 || '',
+        city: supplier?.city,
+        state: supplier?.state,
+        zip: supplier?.zip,
+        country: supplier?.country,
+      }
+      const pdfBuffer = await createReceiptPDFBuffer(receipt, lock)
+      const receiptNumber = String(receipt.receiptNumber || hash).replace(
+        /[^a-z0-9_-]/gi,
+        '-'
+      )
+
+      attachments.push({
+        path: `data:application/pdf;base64,${pdfBuffer.toString('base64')}`,
+        filename: `receipt_${receiptNumber}.pdf`,
+      })
+    }
+
+    return attachments
+  }
+
   /**
    * API to generate signatures that prove validity of a token
    * @param request
@@ -203,9 +265,76 @@ export class TicketsController {
           },
           manager: key.manager,
           owner: key.owner,
+          transactionsHash: key.transactionsHash,
         },
         network
       )
+      response.status(200).send({
+        sent,
+      })
+      return
+    } catch (err) {
+      logger.error(err.message)
+      response.sendStatus(500)
+      return
+    }
+  }
+
+  /**
+   * API call to email membership details and receipt PDFs to a member.
+   * This can only be called by a lock manager.
+   */
+  async sendMembershipDetailsEmail(request: Request, response: Response) {
+    try {
+      const lockAddress = Normalizer.ethereumAddress(request.params.lockAddress)
+      const network = Number(request.params.network)
+      const keyId = request.params.keyId.toLowerCase()
+      const content =
+        typeof request.body?.content === 'string' ? request.body.content : ''
+      const subgraph = new SubgraphService()
+      const key = await subgraph.key(
+        {
+          where: {
+            lock: lockAddress.toLowerCase(),
+            tokenId: keyId,
+          },
+        },
+        {
+          network,
+        }
+      )
+
+      if (!key) {
+        response.status(404).send({
+          message: 'No key found for this lock and keyId',
+        })
+        return
+      }
+
+      const attachments = await this.getReceiptAttachments({
+        lockAddress,
+        network,
+        hashes: key.transactionsHash ?? [],
+      })
+
+      const sent = await notifyNewKeyToWedlocks(
+        {
+          tokenId: keyId,
+          lock: {
+            address: lockAddress,
+            name: key.lock.name || 'Unlock Lock',
+          },
+          manager: key.manager,
+          owner: key.owner,
+          transactionsHash: key.transactionsHash,
+        },
+        network,
+        {
+          customContent: content,
+          attachments,
+        }
+      )
+
       response.status(200).send({
         sent,
       })

--- a/locksmith/src/operations/wedlocksOperations.ts
+++ b/locksmith/src/operations/wedlocksOperations.ts
@@ -34,7 +34,7 @@ type Params = {
   openSeaUrl?: string
 }
 
-type Attachment = {
+export type Attachment = {
   path: string
   filename: string
 }
@@ -371,7 +371,16 @@ export interface CertificationProps {
   certificationUrl: string
 }
 
-export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
+interface NotifyNewKeyOptions {
+  customContent?: string
+  attachments?: Attachment[]
+}
+
+export const notifyNewKeyToWedlocks = async (
+  key: Key,
+  network: number,
+  options: NotifyNewKeyOptions = {}
+) => {
   try {
     const keyManager = new KeyManager()
     const lockAddress = Normalizer.ethereumAddress(key.lock.address)
@@ -463,6 +472,7 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
       event: eventDetail,
       types,
     })
+    attachments.push(...(options.attachments ?? []))
 
     // email templates
     const templates = getTemplates({
@@ -477,11 +487,15 @@ export const notifyNewKeyToWedlocks = async (key: Key, network: number) => {
       isAirdropped: isAirdroppedRecipient,
     })
 
-    const customContent = await getCustomContent(
-      lockAddress,
-      network!,
-      template
-    )
+    const customContent =
+      options.customContent !== undefined
+        ? String(
+            await unified()
+              .use(remarkParse)
+              .use(remarkHtml)
+              .process(options.customContent)
+          )
+        : await getCustomContent(lockAddress, network!, template)
     const withLockImage = (customContent || '')?.length > 0
     const lockImage = `${config.services.locksmith}/lock/${lockAddress}/icon`
 

--- a/locksmith/src/routes/v2/ticket.ts
+++ b/locksmith/src/routes/v2/ticket.ts
@@ -55,6 +55,15 @@ router.post(
   }
 )
 
+router.post(
+  '/:network/:lockAddress/:keyId/membership-email',
+  authenticatedMiddleware,
+  lockManagerMiddleware,
+  (req, res) => {
+    ticketsController.sendMembershipDetailsEmail(req, res)
+  }
+)
+
 router.get(
   '/:network/:lockAddress/:keyId/qr',
   authenticatedMiddleware,

--- a/locksmith/src/utils/receipts.ts
+++ b/locksmith/src/utils/receipts.ts
@@ -107,6 +107,88 @@ export const getReceiptsZipName = (lockAddress: string, network: number) => {
   return `receipts-${network}-${lockAddress}.zip`
 }
 
+export const createReceiptPDFBuffer = async (data: any, lock: any) => {
+  const amount = `${Number(data.amountTransferred) / Math.pow(10, lock.currencyDecimals)} ${lock.currencySymbol}`
+  const dynamicFields = [
+    'supplierName',
+    'supplierAddress',
+    'city',
+    'state',
+    'zip',
+    'country',
+  ]
+  const svgContent = `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 256">
+      <path d="M449.93988,230.05371h53.04V0h-53.04ZM215.102,15.97607H159.5058V71.58386H70.67963V15.97607H15.083V71.58386H0V98.00415H15.083v41.62573c0,52.08155,45.05224,94.57764,100.3291,94.57764,54.957,0,99.68994-42.49609,99.68994-94.57764V98.00415h14.964V71.58386H215.102ZM159.5058,139.62988c0,24.603-19.49072,44.73242-44.09375,44.73242a44.86367,44.86367,0,0,1-44.73242-44.73242V98.00415H159.5058ZM348.65668,67.09912c-19.17139,0-37.70362,8.627-48.24756,24.2832H299.77l-3.19483-19.81005h-46.6499V230.05371h53.04v-82.436c0-18.21241,14.05908-32.91016,30.99365-32.91016,17.57325,0,31.3125,14.69775,31.3125,32.27148v83.07471h53.04v-88.187C418.31146,99.68994,391.47211,67.09912,348.65668,67.09912Zm680.87695,77.32324,65.18164-72.85009h-65.501l-51.123,59.43066h-.959V0h-53.04V230.05371h53.04V157.84229h.959l52.7207,72.21142h66.7793ZM613.20844,67.09912c-49.5254,0-90.42383,37.70313-90.42383,83.71387s40.89843,83.39453,90.42383,83.39453,90.42382-37.38379,90.42382-83.39453S662.73383,67.09912,613.20844,67.09912Zm0,120.77832c-20.12989,0-37.06446-16.93457-37.06446-37.06445s16.93457-37.06445,37.06446-37.06445,37.38378,16.93457,37.38378,37.06445S633.33832,187.87744,613.20844,187.87744ZM814.81879,113.4292c15.65625,0,28.4375,8.94678,33.23047,21.40771h53.998c-5.43164-37.064-41.53711-67.73779-86.26953-67.73779-49.8457,0-91.0635,37.70313-91.0635,83.71387s41.2178,83.39453,91.0635,83.39453c43.77344,0,81.15723-29.396,86.26953-68.05762h-53.998c-5.752,13.1001-17.57422,21.40772-33.23047,21.40772A36.9551,36.9551,0,0,1,778.07465,150.813C778.07465,130.68311,794.36957,113.4292,814.81879,113.4292Z" />
+    </svg>`
+
+  const dynamicContent = dynamicFields.reduce((acc: any[], key: string) => {
+    const value = data[key]
+    if (value) {
+      acc.push({
+        text: value,
+        bold: key === 'supplierName',
+        margin: [0, 0, 0, 8],
+      })
+    }
+    return acc
+  }, [])
+
+  const docDefinition = {
+    content: [
+      { text: 'Receipt Number:', color: 'black', margin: [0, 0, 0, 8] },
+      { text: `#${data.receiptNumber}`, bold: true, margin: [0, 0, 0, 16] },
+      { text: 'Transaction Date:', margin: [0, 0, 0, 8] },
+      {
+        text: new Date(data.timestamp * 1000).toDateString(),
+        bold: true,
+        margin: [0, 0, 0, 16],
+      },
+      { text: 'Transaction Hash:', margin: [0, 0, 0, 8] },
+      { text: data.id, bold: true, margin: [0, 0, 0, 16] },
+      ...dynamicContent,
+      {
+        text: 'Service Performed:',
+        color: '#603DEB',
+        bold: true,
+        margin: [0, 0, 0, 8],
+      },
+      { text: data.service || 'NFT membership', margin: [0, 0, 0, 16] },
+      { text: 'Amount:', color: '#603DEB', bold: true, margin: [0, 0, 0, 8] },
+      {
+        columns: [
+          { text: 'TOTAL', margin: [0, 0, 0, 16] },
+          {
+            text: amount,
+            bold: true,
+            margin: [0, 0, 0, 16],
+            alignment: 'right',
+          },
+        ],
+      },
+      {
+        columns: [
+          {
+            text: 'Powered by ',
+            fontSize: 10,
+            width: 'auto',
+            margin: [220, 0, 0, 0],
+          },
+          { svg: svgContent, width: 50, height: 12, margin: [5, 0, 0, 0] },
+        ],
+      },
+    ],
+  }
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const pdfDoc = pdfmake.createPdf(docDefinition as TDocumentDefinitions)
+    pdfDoc.getBuffer((buffer) => {
+      if (buffer) resolve(Buffer.from(buffer))
+      else reject(new Error('Failed to create PDF buffer'))
+    })
+  })
+}
+
 export const zipReceiptsAndSendtos3 = async (
   lockAddress: string,
   network: number
@@ -119,88 +201,6 @@ export const zipReceiptsAndSendtos3 = async (
 
   const web3Service = getWeb3Service()
   const lock = await web3Service.getLock(lockAddress, network)
-
-  const createPDFBuffer = async (data: any) => {
-    const amount = `${Number(data.amountTransferred) / Math.pow(10, lock.currencyDecimals)} ${lock.currencySymbol}`
-    const dynamicFields = [
-      'supplierName',
-      'supplierAddress',
-      'city',
-      'state',
-      'zip',
-      'country',
-    ]
-    const svgContent = `
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 256">
-      <path d="M449.93988,230.05371h53.04V0h-53.04ZM215.102,15.97607H159.5058V71.58386H70.67963V15.97607H15.083V71.58386H0V98.00415H15.083v41.62573c0,52.08155,45.05224,94.57764,100.3291,94.57764,54.957,0,99.68994-42.49609,99.68994-94.57764V98.00415h14.964V71.58386H215.102ZM159.5058,139.62988c0,24.603-19.49072,44.73242-44.09375,44.73242a44.86367,44.86367,0,0,1-44.73242-44.73242V98.00415H159.5058ZM348.65668,67.09912c-19.17139,0-37.70362,8.627-48.24756,24.2832H299.77l-3.19483-19.81005h-46.6499V230.05371h53.04v-82.436c0-18.21241,14.05908-32.91016,30.99365-32.91016,17.57325,0,31.3125,14.69775,31.3125,32.27148v83.07471h53.04v-88.187C418.31146,99.68994,391.47211,67.09912,348.65668,67.09912Zm680.87695,77.32324,65.18164-72.85009h-65.501l-51.123,59.43066h-.959V0h-53.04V230.05371h53.04V157.84229h.959l52.7207,72.21142h66.7793ZM613.20844,67.09912c-49.5254,0-90.42383,37.70313-90.42383,83.71387s40.89843,83.39453,90.42383,83.39453,90.42382-37.38379,90.42382-83.39453S662.73383,67.09912,613.20844,67.09912Zm0,120.77832c-20.12989,0-37.06446-16.93457-37.06446-37.06445s16.93457-37.06445,37.06446-37.06445,37.38378,16.93457,37.38378,37.06445S633.33832,187.87744,613.20844,187.87744ZM814.81879,113.4292c15.65625,0,28.4375,8.94678,33.23047,21.40771h53.998c-5.43164-37.064-41.53711-67.73779-86.26953-67.73779-49.8457,0-91.0635,37.70313-91.0635,83.71387s41.2178,83.39453,91.0635,83.39453c43.77344,0,81.15723-29.396,86.26953-68.05762h-53.998c-5.752,13.1001-17.57422,21.40772-33.23047,21.40772A36.9551,36.9551,0,0,1,778.07465,150.813C778.07465,130.68311,794.36957,113.4292,814.81879,113.4292Z" />
-    </svg>`
-
-    const dynamicContent = dynamicFields.reduce((acc: any[], key: string) => {
-      const value = data[key]
-      if (value) {
-        acc.push({
-          text: value,
-          bold: key === 'supplierName',
-          margin: [0, 0, 0, 8],
-        })
-      }
-      return acc
-    }, [])
-
-    const docDefinition = {
-      content: [
-        { text: 'Receipt Number:', color: 'black', margin: [0, 0, 0, 8] },
-        { text: `#${data.receiptNumber}`, bold: true, margin: [0, 0, 0, 16] },
-        { text: 'Transaction Date:', margin: [0, 0, 0, 8] },
-        {
-          text: new Date(data.timestamp * 1000).toDateString(),
-          bold: true,
-          margin: [0, 0, 0, 16],
-        },
-        { text: 'Transaction Hash:', margin: [0, 0, 0, 8] },
-        { text: data.id, bold: true, margin: [0, 0, 0, 16] },
-        ...dynamicContent,
-        {
-          text: 'Service Performed:',
-          color: '#603DEB',
-          bold: true,
-          margin: [0, 0, 0, 8],
-        },
-        { text: data.service || 'NFT membership', margin: [0, 0, 0, 16] },
-        { text: 'Amount:', color: '#603DEB', bold: true, margin: [0, 0, 0, 8] },
-        {
-          columns: [
-            { text: 'TOTAL', margin: [0, 0, 0, 16] },
-            {
-              text: amount,
-              bold: true,
-              margin: [0, 0, 0, 16],
-              alignment: 'right',
-            },
-          ],
-        },
-        {
-          columns: [
-            {
-              text: 'Powered by ',
-              fontSize: 10,
-              width: 'auto',
-              margin: [220, 0, 0, 0],
-            },
-            { svg: svgContent, width: 50, height: 12, margin: [5, 0, 0, 0] },
-          ],
-        },
-      ],
-    }
-
-    return new Promise((resolve, reject) => {
-      const pdfDoc = pdfmake.createPdf(docDefinition as TDocumentDefinitions)
-      pdfDoc.getBuffer((buffer) => {
-        if (buffer) resolve(Buffer.from(buffer))
-        else reject(new Error('Failed to create PDF buffer'))
-      })
-    })
-  }
 
   const createZipBuffer = async (receiptsToZip: any) => {
     return new Promise((resolve, reject) => {
@@ -221,7 +221,7 @@ export const zipReceiptsAndSendtos3 = async (
       })
       ;(async () => {
         for (const receipt of receiptsToZip) {
-          const pdfBuffer = await createPDFBuffer(receipt)
+          const pdfBuffer = await createReceiptPDFBuffer(receipt, lock)
           archive.append(pdfBuffer as Buffer, {
             name: `receipt_${receipt.receiptNumber}.pdf`,
           })

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -1725,6 +1725,47 @@ paths:
         500:
           $ref: '#/components/responses/500.InternalError'
 
+  /v2/api/ticket/{network}/{lockAddress}/{keyId}/membership-email:
+    post:
+      operationId: emailMembershipDetails
+      security:
+        - User: ['LockManager']
+      description: Send membership details and receipt PDFs by email.
+      parameters:
+        - $ref: '#/components/parameters/Network'
+        - $ref: '#/components/parameters/LockAddress'
+        - $ref: '#/components/parameters/KeyId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                  description: Custom message to include in the email.
+      responses:
+        200:
+          description: Email sent.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sent:
+                    type: boolean
+                    default: true
+                    nullable: false
+        403:
+          $ref: '#/components/responses/403.NotAuthenticatedOrAuthorized'
+
+        404:
+          $ref: '#/components/responses/404.NotFound'
+
+        500:
+          $ref: '#/components/responses/500.InternalError'
+
   /v2/api/ticket/{network}/{lockAddress}/{keyId}/qr:
     get:
       operationId: ticketQRCode

--- a/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
+++ b/unlock-app/src/components/interface/locks/Manage/elements/MetadataCard.tsx
@@ -14,7 +14,8 @@ import { useLockManager } from '~/hooks/useLockManager'
 import { FiExternalLink as ExternalLinkIcon } from 'react-icons/fi'
 import { ADDRESS_ZERO, MAX_UINT, UNLIMITED_RENEWAL_LIMIT } from '~/constants'
 import { durationAsText } from '~/utils/durations'
-import { locksmith } from '~/config/locksmith'
+import { locksmith, locksmithClient } from '~/config/locksmith'
+import { config } from '~/config/app'
 import { receiptsUrl, useGetReceiptsForKey } from '~/hooks/useReceipts'
 import Link from 'next/link'
 import { TbReceipt as ReceiptIcon } from 'react-icons/tb'
@@ -239,6 +240,65 @@ const ChangeManagerModal = ({
     </>
   )
 }
+
+const EmailMembershipDetailsModal = ({
+  isOpen,
+  setIsOpen,
+  defaultContent,
+  loading,
+  onSubmit,
+}: {
+  isOpen: boolean
+  setIsOpen: (status: boolean) => void
+  defaultContent: string
+  loading: boolean
+  onSubmit: (values: { content: string }) => Promise<void>
+}) => {
+  const { register, handleSubmit, reset } = useForm<{ content: string }>({
+    defaultValues: {
+      content: defaultContent,
+    },
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        content: defaultContent,
+      })
+    }
+  }, [defaultContent, isOpen, reset])
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen}>
+      <form className="flex flex-col gap-3" onSubmit={handleSubmit(onSubmit)}>
+        <span className="mr-0 font-semibold text-md">
+          Email membership details
+        </span>
+        <textarea
+          className="w-full min-h-36 rounded-lg border border-gray-300 p-3 text-sm text-gray-900 focus:border-brand-ui-primary focus:outline-none focus:ring-1 focus:ring-brand-ui-primary"
+          disabled={loading}
+          {...register('content', {
+            required: true,
+          })}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={() => setIsOpen(false)}
+            disabled={loading}
+          >
+            Abort
+          </Button>
+          <Button type="submit" disabled={loading} loading={loading}>
+            Send email
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+
 export const MetadataCard = ({
   metadata,
   owner,
@@ -252,6 +312,8 @@ export const MetadataCard = ({
   const [data, setData] = useState(metadata)
 
   const [addEmailModalOpen, setAddEmailModalOpen] = useState(false)
+  const [emailMembershipDetailsModalOpen, setEmailMembershipDetailsModalOpen] =
+    useState(false)
 
   const items = Object.entries(data || {}).filter(([key]) => {
     return !keysToIgnore.includes(key)
@@ -269,6 +331,9 @@ export const MetadataCard = ({
     Object.entries(types ?? {}).find(([, value]) => value === true) ?? []
 
   const { lockAddress, token: tokenId } = data ?? {}
+  const membershipName =
+    lockMetadata?.name || data?.lockName || 'your membership'
+  const defaultMembershipEmailContent = `To access your receipt for ${membershipName}, visit Unlock's Keychain. From Unlock's Keychain, you can view, edit, and print a PDF of your receipt.`
 
   const { isManager: isLockManager } = useLockManager({
     lockAddress,
@@ -306,6 +371,17 @@ export const MetadataCard = ({
     mutationFn: sendEmail,
   })
 
+  const sendMembershipDetailsMutation = useMutation({
+    mutationFn: ({ content }: { content: string }) => {
+      return locksmithClient.post(
+        `${config.locksmithHost}/v2/api/ticket/${network}/${lockAddress}/${tokenId}/membership-email`,
+        {
+          content,
+        }
+      )
+    },
+  })
+
   const onSendQrCode = async () => {
     if (!network) return
 
@@ -316,6 +392,19 @@ export const MetadataCard = ({
 
       error: 'We could not send email.',
     })
+  }
+
+  const onSendMembershipDetails = async (values: { content: string }) => {
+    if (!network) return
+
+    const sendPromise = sendMembershipDetailsMutation.mutateAsync(values)
+    ToastHelper.promise(sendPromise, {
+      success: 'Email sent',
+      loading: 'Sending email...',
+      error: 'We could not send email.',
+    })
+    await sendPromise
+    setEmailMembershipDetailsModalOpen(false)
   }
 
   const hasEmail = Object.entries(data || {})
@@ -360,6 +449,14 @@ export const MetadataCard = ({
         hasEmail={hasEmail}
         extraDataItems={items as any}
         onEmailChange={onEmailChange}
+      />
+
+      <EmailMembershipDetailsModal
+        isOpen={emailMembershipDetailsModalOpen}
+        setIsOpen={setEmailMembershipDetailsModalOpen}
+        defaultContent={defaultMembershipEmailContent}
+        loading={sendMembershipDetailsMutation.isPending}
+        onSubmit={onSendMembershipDetails}
       />
 
       <div className="flex flex-col gap-3 md:flex-row">
@@ -412,21 +509,37 @@ export const MetadataCard = ({
                       </Button>
 
                       {lockSettings?.sendEmail ? (
-                        SendEmailMapping[eventType as keyof LockType] && (
+                        <>
+                          {SendEmailMapping[eventType as keyof LockType] && (
+                            <Button
+                              size="tiny"
+                              variant="outlined-primary"
+                              onClick={onSendQrCode}
+                              disabled={
+                                sendEmailMutation.isPending ||
+                                sendEmailMutation.isSuccess
+                              }
+                            >
+                              {sendEmailMutation.isSuccess
+                                ? 'Email sent'
+                                : SendEmailMapping[eventType as keyof LockType]}
+                            </Button>
+                          )}
                           <Button
                             size="tiny"
                             variant="outlined-primary"
-                            onClick={onSendQrCode}
+                            onClick={() =>
+                              setEmailMembershipDetailsModalOpen(true)
+                            }
                             disabled={
-                              sendEmailMutation.isPending ||
-                              sendEmailMutation.isSuccess
+                              isLoadingReceipts ||
+                              !receipts?.length ||
+                              sendMembershipDetailsMutation.isPending
                             }
                           >
-                            {sendEmailMutation.isSuccess
-                              ? 'Email sent'
-                              : SendEmailMapping[eventType as keyof LockType]}
+                            Email membership details
                           </Button>
-                        )
+                        </>
                       ) : (
                         <Button size="tiny" variant="outlined-primary" disabled>
                           Email are disabled


### PR DESCRIPTION
Closes #12570.

## Summary
- add a lock-manager-only membership details email endpoint for a member key
- attach generated receipt PDFs using the existing receipt PDF generation path
- let managers edit the message before sending from the member metadata card
- include transaction receipt hashes in the existing key email path so receipt links are populated

## Validation
- `git diff --check`
- `npx --yes prettier@3.5.3 --write ...` on changed files
- `npx --yes esbuild@0.25.11 ...` syntax transform for touched TS/TSX files
- Targeted test: `yarn test locksmith/__tests__/utils/middlewares/getAttachments.test.ts --runInBand -t "membership details"` passed 2 tests, 10 skipped.
- Full `getAttachments.test.ts` was not completed locally because the DB-backed cases require the repository's local test database and fixtures.
