### PR TITLE
bounty: expose discount codes in lock settings

### DIFF
--- a/unlock-app/src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts
+++ b/unlock-app/src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowDiscountCodesTab } from '~/components/interface/locks/Settings/settingsTabs'
+
+describe('lock settings tabs', () => {
+  it('shows discount codes for paid locks only after lock data loads', () => {
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: '0.01' },
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: '0' },
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: true,
+        lock: { keyPrice: '1' },
+      })
+    ).toBe(false)
+  })
+})

--- a/unlock-app/src/components/content/lock/LocksSettingsContent.tsx
+++ b/unlock-app/src/components/content/lock/LocksSettingsContent.tsx
@@ -10,6 +10,7 @@ export type SettingTab =
   | 'general'
   | 'terms'
   | 'payments'
+  | 'discountCodes'
   | 'roles'
   | 'advanced'
   | 'emails'

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingDiscountCodes.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingDiscountCodes.tsx
@@ -1,0 +1,36 @@
+import { UpdateDiscountCodesForm } from '../forms/UpdateDiscountCodesForm'
+import { SettingCard } from './SettingCard'
+
+interface SettingDiscountCodesProps {
+  lockAddress: string
+  network: number
+  isManager: boolean
+  isLoading: boolean
+  publicLockVersion?: bigint
+}
+
+export const SettingDiscountCodes = ({
+  lockAddress,
+  network,
+  isManager,
+  isLoading,
+  publicLockVersion,
+}: SettingDiscountCodesProps) => {
+  return (
+    <div className="grid grid-cols-1 gap-6">
+      <SettingCard
+        label="Discount Codes"
+        description="Create discount codes for this paid lock without opening the advanced hooks settings."
+        isLoading={isLoading || publicLockVersion === undefined}
+        defaultOpen
+      >
+        <UpdateDiscountCodesForm
+          lockAddress={lockAddress}
+          network={network}
+          disabled={!isManager}
+          version={publicLockVersion}
+        />
+      </SettingCard>
+    </div>
+  )
+}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateDiscountCodesForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateDiscountCodesForm.tsx
@@ -1,0 +1,135 @@
+import { HookType } from '@unlock-protocol/types'
+import { ToastHelper } from '@unlock-protocol/ui'
+import { useMutation } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useCustomHook } from '~/hooks/useCustomHooks'
+import { useProvider } from '~/hooks/useProvider'
+import { useConfig } from '~/utils/withConfig'
+import { PromoCodeHook } from './hooksComponents/PromoCodeHook'
+
+interface UpdateDiscountCodesFormProps {
+  lockAddress: string
+  network: number
+  disabled: boolean
+  version?: bigint
+}
+
+interface DiscountCodesFormProps {
+  keyPurchase: string
+  promo?: {
+    code?: string
+    discount?: number
+    cap?: number
+  }
+}
+
+export const UpdateDiscountCodesForm = ({
+  lockAddress,
+  network,
+  disabled,
+  version,
+}: UpdateDiscountCodesFormProps) => {
+  const { networks } = useConfig()
+  const { getWalletService } = useProvider()
+  const promoCodeHook = networks?.[network]?.hooks?.onKeyPurchaseHook?.find(
+    ({ id }) => id === HookType.PROMO_CODE_CAPPED
+  )
+  const hasRequiredVersion = version !== undefined && version >= BigInt(7)
+  const { isPending, refetch, getHookValues } = useCustomHook({
+    lockAddress,
+    network,
+    version,
+  })
+
+  const methods = useForm<DiscountCodesFormProps>({
+    mode: 'onChange',
+    defaultValues: {
+      keyPurchase: promoCodeHook?.address ?? '',
+    },
+  })
+
+  const { register, reset, setValue } = methods
+
+  useEffect(() => {
+    if (promoCodeHook?.address) {
+      setValue('keyPurchase', promoCodeHook.address, {
+        shouldValidate: true,
+      })
+    }
+  }, [promoCodeHook?.address, setValue])
+
+  const setEventsHooks = async (
+    fields: Pick<DiscountCodesFormProps, 'keyPurchase'>
+  ) => {
+    const values = (await getHookValues()) as Partial<DiscountCodesFormProps>
+
+    if (values.keyPurchase === fields.keyPurchase) {
+      return
+    }
+
+    const walletService = await getWalletService(network)
+
+    await ToastHelper.promise(
+      walletService.setEventHooks({
+        lockAddress,
+        ...fields,
+      }),
+      {
+        success: 'Discount code hook enabled.',
+        loading: 'Enabling discount codes on the contract...',
+        error: 'Failed to enable discount codes.',
+      }
+    )
+  }
+
+  const setEventsHooksMutation = useMutation({
+    mutationFn: setEventsHooks,
+    onSuccess: async () => {
+      const values = await getHookValues()
+      if (promoCodeHook?.address) {
+        reset({
+          keyPurchase: promoCodeHook.address,
+        })
+      }
+      refetch()
+
+      return values
+    },
+  })
+
+  const disabledInput =
+    disabled || setEventsHooksMutation.isPending || isPending
+
+  if (!hasRequiredVersion) {
+    return (
+      <span className="text-base">
+        Discount codes require PublicLock version 7 or later.
+      </span>
+    )
+  }
+
+  if (!promoCodeHook) {
+    return (
+      <span className="text-base">
+        Discount codes are not available on this network yet.
+      </span>
+    )
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <input type="hidden" {...register('keyPurchase')} />
+      <PromoCodeHook
+        name="keyPurchase"
+        disabled={disabledInput}
+        lockAddress={lockAddress}
+        network={network}
+        hookAddress={promoCodeHook.address}
+        defaultValue={promoCodeHook.address}
+        setEventsHooksMutation={setEventsHooksMutation}
+        selectedOption={HookType.PROMO_CODE_CAPPED}
+      />
+    </FormProvider>
+  )
+}

--- a/unlock-app/src/components/interface/locks/Settings/index.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/index.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 import { SettingTerms } from './elements/SettingTerms'
@@ -20,11 +21,20 @@ import { SettingPayments } from './elements/SettingPayments'
 import { SettingEmail } from './elements/SettingEmail'
 import { SettingTab } from '~/components/content/lock/LocksSettingsContent'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { SettingDiscountCodes } from './elements/SettingDiscountCodes'
+import { shouldShowDiscountCodesTab } from './settingsTabs'
 
 interface LockSettingsPageProps {
   lockAddress: string
   network: number
   defaultTab?: SettingTab
+}
+
+type SettingsTabConfig = {
+  label: string
+  description?: string
+  id: SettingTab
+  children: ReactNode
 }
 
 export const NotManagerBanner = () => {
@@ -90,112 +100,137 @@ const LockSettingsPage = ({
 
   const isLoading = isLoadingLock || isLoadingManager
 
+  const tabs = useMemo<SettingsTabConfig[]>(() => {
+    const settingsTabs: SettingsTabConfig[] = [
+      {
+        id: 'general',
+        label: 'General',
+        children: (
+          <SettingGeneral
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            lock={lock}
+          />
+        ),
+      },
+      {
+        id: 'terms',
+        label: 'Membership Terms',
+        children: (
+          <SettingTerms
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            lock={lock}
+            isLoading={isLoading}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'Membership Terms include the price, currency, duration, payment mechanisms... as well as cancellation terms and transfer fees.',
+      },
+      {
+        id: 'payments',
+        label: 'Payments',
+        children: (
+          <SettingPayments
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            lock={lock}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          'Payments settings lets you change the price and currency of your memberships, as well as enable credit cards and recurring payments.',
+      },
+      {
+        id: 'roles',
+        label: 'Roles',
+        children: (
+          <SettingRoles
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          'Your Lock includes multiple roles, such as "Lock Manager". Here you can configure which addresses are assigned which roles.',
+      },
+      {
+        id: 'emails',
+        label: 'Emails',
+        children: (
+          <SettingEmail
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          "Customize the emails sent to users when they purchase your lock's membership NFTs.",
+      },
+      {
+        id: 'advanced',
+        label: 'Advanced',
+        children: (
+          <SettingMisc
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            publicLockLatestVersion={publicLockLatestVersion}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'This section lets you configure referral fees, hooks and upgrade your lock to the latest version of the protocol.',
+      },
+    ]
+
+    if (shouldShowDiscountCodesTab({ isLoading, lock })) {
+      settingsTabs.splice(3, 0, {
+        id: 'discountCodes',
+        label: 'Discount Codes',
+        children: (
+          <SettingDiscountCodes
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'Create and manage discount codes directly for this paid lock.',
+      })
+    }
+
+    return settingsTabs
+  }, [
+    isLoading,
+    isManager,
+    lock,
+    lockAddress,
+    network,
+    publicLockLatestVersion,
+    publicLockVersion,
+  ])
+
   /**
    * Open default tab by id
    */
   useEffect(() => {
     if (!defaultTab) return
-    const defaultTabIndex = tabs?.findIndex(({ id }) => id === defaultTab)
-    if (defaultTabIndex === undefined) return
+    const defaultTabIndex = tabs.findIndex(({ id }) => id === defaultTab)
+    if (defaultTabIndex < 0) return
 
     setSelectedIndex(defaultTabIndex)
-  }, [defaultTab])
-
-  const tabs: {
-    label: string
-    description?: string
-    id: SettingTab
-    children: ReactNode
-  }[] = [
-    {
-      id: 'general',
-      label: 'General',
-      children: (
-        <SettingGeneral
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-          lock={lock}
-        />
-      ),
-    },
-    {
-      id: 'terms',
-      label: 'Membership Terms',
-      children: (
-        <SettingTerms
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          lock={lock}
-          isLoading={isLoading}
-          publicLockVersion={publicLockVersion}
-        />
-      ),
-      description:
-        'Membership Terms include the price, currency, duration, payment mechanisms... as well as cancellation terms and transfer fees.',
-    },
-    {
-      id: 'payments',
-      label: 'Payments',
-      children: (
-        <SettingPayments
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          lock={lock}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        'Payments settings lets you change the price and currency of your memberships, as well as enable credit cards and recurring payments.',
-    },
-    {
-      id: 'roles',
-      label: 'Roles',
-      children: (
-        <SettingRoles
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        'Your Lock includes multiple roles, such as "Lock Manager". Here you can configure which addresses are assigned which roles.',
-    },
-    {
-      id: 'emails',
-      label: 'Emails',
-      children: (
-        <SettingEmail
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        "Customize the emails sent to users when they purchase your lock's membership NFTs.",
-    },
-    {
-      id: 'advanced',
-      label: 'Advanced',
-      children: (
-        <SettingMisc
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-          publicLockLatestVersion={publicLockLatestVersion}
-          publicLockVersion={publicLockVersion}
-        />
-      ),
-      description:
-        'This section lets you configure referral fees, hooks and upgrade your lock to the latest version of the protocol.',
-    },
-  ]
+  }, [defaultTab, tabs])
 
   return (
     <SettingsContext.Provider

--- a/unlock-app/src/components/interface/locks/Settings/settingsTabs.ts
+++ b/unlock-app/src/components/interface/locks/Settings/settingsTabs.ts
@@ -1,0 +1,19 @@
+interface DiscountCodesTabLock {
+  keyPrice?: number | string | null
+}
+
+interface ShouldShowDiscountCodesTabProps {
+  isLoading: boolean
+  lock?: DiscountCodesTabLock
+}
+
+export const shouldShowDiscountCodesTab = ({
+  isLoading,
+  lock,
+}: ShouldShowDiscountCodesTabProps) => {
+  if (isLoading || lock?.keyPrice === undefined || lock?.keyPrice === null) {
+    return false
+  }
+
+  return Number(lock.keyPrice) > 0
+}


### PR DESCRIPTION
## Summary
- Add a paid-lock-only Discount Codes tab to lock settings.
- Reuse the existing capped promo code hook flow so discount codes can be created without opening Advanced hooks.
- Keep free locks on the existing settings tabs and add a tab-visibility regression test.

Fixes #16191

## Testing
- node .yarn/releases/yarn-4.10.3.cjs workspace @unlock-protocol/unlock-app vitest run src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts --environment=jsdom
- node .yarn/releases/yarn-4.10.3.cjs workspace @unlock-protocol/unlock-app eslint src/components/content/lock/LocksSettingsContent.tsx src/components/interface/locks/Settings/index.tsx src/components/interface/locks/Settings/elements/SettingDiscountCodes.tsx src/components/interface/locks/Settings/forms/UpdateDiscountCodesForm.tsx src/components/interface/locks/Settings/settingsTabs.ts src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts
- git diff --check