### PR TITLE
Add Mixer159 to CLA bot contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,6 +100,7 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
+    "Mixer159",
     "claude[bot]"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "


### PR DESCRIPTION
Adds @Mixer159 to `.clabot` as requested by cla-bot on #16405.

This PR only updates the CLA bot contributor list.