### PR TITLE
feat: add canonical checkout URLs

### DIFF
--- a/unlock-app/app/checkout/[id]/page.tsx
+++ b/unlock-app/app/checkout/[id]/page.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { Metadata } from 'next'
+import { fetchMetadata } from 'frames.js/next'
+import { CheckoutPage as CheckoutPageComponent } from '~/components/interface/checkout'
+import { config as appConfig } from '~/config/app'
+
+type Props = {
+  params: {
+    id: string
+  }
+}
+
+type CheckoutConfig = {
+  title?: string
+}
+
+const getCheckoutConfig = async (
+  id: string
+): Promise<CheckoutConfig | null> => {
+  const response = await fetch(`${appConfig.locksmithHost}/v2/checkout/${id}`)
+
+  if (!response.ok) {
+    return null
+  }
+
+  const { config } = await response.json()
+  return config || null
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const id = params.id.trim()
+  const canonical = `${appConfig.unlockApp}/checkout/${encodeURIComponent(id)}`
+
+  const baseMetadata: Metadata = {
+    title: 'Checkout | Unlock Protocol',
+    alternates: {
+      canonical,
+    },
+  }
+
+  try {
+    const config = await getCheckoutConfig(id)
+
+    if (!config) {
+      return baseMetadata
+    }
+
+    return {
+      title: config.title || baseMetadata.title,
+      openGraph: {
+        images: [`/og/checkout?id=${encodeURIComponent(id)}`],
+      },
+      other: {
+        ...(await fetchMetadata(
+          new URL(
+            `/frames/checkout?id=${encodeURIComponent(id)}`,
+            appConfig.unlockApp
+          )
+        )),
+      },
+      alternates: {
+        canonical,
+      },
+    }
+  } catch (error) {
+    console.error(`Error generating metadata for checkout config ${id}:`, error)
+    return baseMetadata
+  }
+}
+
+const CheckoutPage: React.FC = () => {
+  return <CheckoutPageComponent />
+}
+
+export default CheckoutPage

--- a/unlock-app/app/checkout/page.tsx
+++ b/unlock-app/app/checkout/page.tsx
@@ -4,15 +4,50 @@ import { fetchMetadata } from 'frames.js/next'
 import { CheckoutPage as CheckoutPageComponent } from '~/components/interface/checkout'
 import { getConfig } from '../frames/checkout/components/utils'
 import { config as appConfig } from '~/config/app'
+import { permanentRedirect } from 'next/navigation'
 
 type Props = {
-  searchParams: { id: string }
+  searchParams?: Record<string, string | string[] | undefined>
+}
+
+const getFirstSearchParam = (
+  searchParams: Props['searchParams'],
+  key: string
+) => {
+  const value = searchParams?.[key]
+  return Array.isArray(value) ? value[0] : value
+}
+
+const getRedirectSearchParams = (searchParams: Props['searchParams']) => {
+  const nextSearchParams = new URLSearchParams()
+
+  Object.entries(searchParams || {}).forEach(([key, value]) => {
+    if (key === 'id' || value === undefined) {
+      return
+    }
+
+    const values = Array.isArray(value) ? value : [value]
+    values.forEach((item) => {
+      nextSearchParams.append(key, item)
+    })
+  })
+
+  return nextSearchParams.toString()
+}
+
+const getCheckoutPath = (
+  id: string,
+  searchParams: Props['searchParams'] = {}
+) => {
+  const queryString = getRedirectSearchParams(searchParams)
+  const path = `/checkout/${encodeURIComponent(id)}`
+  return queryString ? `${path}?${queryString}` : path
 }
 
 export async function generateMetadata({
   searchParams,
 }: Props): Promise<Metadata> {
-  const id = searchParams?.id?.trim()
+  const id = getFirstSearchParam(searchParams, 'id')?.trim()
 
   // Default metadata without frame data
   const baseMetadata: Metadata = {
@@ -42,6 +77,9 @@ export async function generateMetadata({
           new URL(`/frames/checkout?id=${id}`, appConfig.unlockApp)
         )),
       },
+      alternates: {
+        canonical: `${appConfig.unlockApp}/checkout/${encodeURIComponent(id)}`,
+      },
     }
 
     return metadata
@@ -51,7 +89,13 @@ export async function generateMetadata({
   }
 }
 
-const CheckoutPage: React.FC = () => {
+const CheckoutPage: React.FC<Props> = ({ searchParams }) => {
+  const id = getFirstSearchParam(searchParams, 'id')?.trim()
+
+  if (id) {
+    permanentRedirect(getCheckoutPath(id, searchParams))
+  }
+
   return <CheckoutPageComponent />
 }
 

--- a/unlock-app/src/__tests__/components/content/event/utils.test.ts
+++ b/unlock-app/src/__tests__/components/content/event/utils.test.ts
@@ -1,0 +1,47 @@
+import { CheckoutConfig } from '@unlock-protocol/core'
+import { describe, expect, it } from 'vitest'
+import { getCheckoutUrl } from '~/components/content/event/utils'
+
+describe('getCheckoutUrl', () => {
+  it('uses canonical path-based URLs for saved checkout configs', () => {
+    const checkoutConfig = {
+      id: '2c1549c0-baea-4445-82e9-ab3bd3251162',
+      config: {
+        locks: {},
+      },
+    } as CheckoutConfig
+
+    const url = getCheckoutUrl(checkoutConfig)
+
+    expect(url).toBe(
+      'http://localhost:3000/checkout/2c1549c0-baea-4445-82e9-ab3bd3251162'
+    )
+  })
+
+  it('keeps inline checkout configs on the query-string checkout route', () => {
+    const checkoutConfig = {
+      config: {
+        locks: {
+          '0x123': {
+            network: 1,
+          },
+        },
+        redirectUri: '',
+      },
+    } as CheckoutConfig
+
+    const url = new URL(getCheckoutUrl(checkoutConfig))
+
+    expect(url.pathname).toBe('/checkout')
+    expect(url.searchParams.get('checkoutConfig')).toBe(
+      JSON.stringify({
+        locks: {
+          '0x123': {
+            network: 1,
+          },
+        },
+      })
+    )
+    expect(checkoutConfig.config.redirectUri).toBe('')
+  })
+})

--- a/unlock-app/src/components/content/event/utils.tsx
+++ b/unlock-app/src/components/content/event/utils.tsx
@@ -68,19 +68,20 @@ export const getEventUrl = ({
 
 export const getCheckoutUrl = (checkoutConfig: CheckoutConfig) => {
   const url = new URL(`${window.location.origin}/checkout`)
+  const config = { ...checkoutConfig.config }
 
   // remove redirectUri if not applicable
-  if (checkoutConfig.config?.redirectUri?.length === 0) {
-    delete checkoutConfig.config.redirectUri
+  if (config?.redirectUri?.length === 0) {
+    delete config.redirectUri
   }
 
   if (checkoutConfig.id) {
-    url.searchParams.append('id', checkoutConfig.id)
+    return new URL(
+      `/checkout/${encodeURIComponent(checkoutConfig.id)}`,
+      window.location.origin
+    ).toString()
   } else {
-    url.searchParams.append(
-      'checkoutConfig',
-      JSON.stringify(checkoutConfig.config)
-    )
+    url.searchParams.append('checkoutConfig', JSON.stringify(config))
   }
   return url.toString()
 }

--- a/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useSearchParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 import { getPaywallConfigFromQuery } from '~/utils/paywallConfig'
 import getOauthConfigFromQuery from '~/utils/oauth'
@@ -15,12 +15,14 @@ import { Connect } from './Connect'
 import { isInIframe } from '~/utils/iframe'
 
 export function CheckoutContainer() {
+  const params = useParams<{ id?: string }>()
   const searchParams = useSearchParams()
+  const checkoutId = params?.id || searchParams.get('id')?.toString()
 
   // Fetch config from parent in iframe context
   const communication = useCheckoutCommunication()
   const { isLoading, data: checkout } = useCheckoutConfig({
-    id: searchParams.get('id')?.toString(),
+    id: checkoutId,
   })
 
   const referrerAddress = searchParams.get('referrerAddress')?.toString()


### PR DESCRIPTION
# Description

Adds canonical path-based checkout URLs while preserving the existing inline checkout configuration flow.

- Adds `/checkout/[id]` with server-generated checkout metadata and canonical links
- Redirects `/checkout?id=...` to `/checkout/[id]`, preserving unrelated query params
- Keeps `/checkout?paywallConfig=...` and other inline config flows on the existing route
- Updates generated checkout URLs to use the canonical path when a saved checkout config ID exists
- Adds coverage for saved config URLs and inline checkout config URLs

This is intentionally scoped around the open review feedback on #16079: inline config checkouts still work without a checkout ID, the `[id]` metadata fetch is local to the route, and metadata errors include the checkout config ID.

# Issues

Fixes #16078

# Validation

- `npm exec --yes --package=corepack -- corepack yarn workspace @unlock-protocol/types build`
- `npm exec --yes --package=corepack -- corepack yarn workspace @unlock-protocol/networks build`
- `npm exec --yes --package=corepack -- corepack yarn workspace @unlock-protocol/unlock-app exec vitest run src/__tests__/components/content/event/utils.test.ts --config vite.config.js --environment=jsdom --coverage.enabled=false`
- `npm exec --yes --package=corepack -- corepack yarn workspace @unlock-protocol/unlock-app exec eslint app/checkout/page.tsx 'app/checkout/[id]/page.tsx' src/components/interface/checkout/CheckoutContainer.tsx src/components/content/event/utils.tsx src/__tests__/components/content/event/utils.test.ts`
- `git diff --check`

Note: `yarn install --immutable` completed dependency resolution/fetching but failed during `netlify-cli@15.11.0` postinstall under local Node `v25.2.1`; the targeted build/test/lint commands above were run after the dependencies needed for this change were available.


# Bounty payout

If this is accepted for the bounty, Base USDC payout address: `0x63C07C527bF38A531484e91848DB2538A8688835`.
