### PR TITLE
Sync event image changes to ticket metadata

### DIFF
--- a/locksmith/__tests__/operations/eventOperations.test.ts
+++ b/locksmith/__tests__/operations/eventOperations.test.ts
@@ -1,6 +1,11 @@
 import { expect, vi } from 'vitest'
 
-import { CheckoutConfig, EventData, KeyMetadata } from '../../src/models'
+import {
+  CheckoutConfig,
+  EventData,
+  KeyMetadata,
+  LockMetadata,
+} from '../../src/models'
 import { getEventFixture } from '../../__tests__/fixtures/events'
 
 import {
@@ -42,6 +47,7 @@ describe('eventOperations', () => {
     await EventData.truncate({ cascade: true })
     await CheckoutConfig.truncate()
     await KeyMetadata.truncate()
+    await LockMetadata.truncate()
   })
   describe('createEventSlug', () => {
     it('should create the event with the correct slug', async () => {
@@ -228,6 +234,75 @@ describe('eventOperations', () => {
 
       const savedEventWithoutProtectedData = await getEventBySlug(slug, false)
       expect(savedEventWithoutProtectedData!.data.replyTo).toEqual(undefined)
+    })
+
+    it('should update lock NFT images that still match the previous event image', async () => {
+      expect.assertions(3)
+      const network = 11155111
+      const matchingLock = '0xF174cc512D9aac892cc53330F829028046d0fF6B'
+      const customLock = '0x1234567890AbcdEF1234567890aBcdef12345678'
+      const eventParams = getEventFixture({
+        data: {
+          name: 'Image Sync Event',
+          image: 'https://example.com/old-event.jpg',
+        },
+        checkoutConfig: {
+          config: {
+            locks: {
+              [matchingLock]: {
+                network,
+              },
+              [customLock]: {
+                network,
+              },
+            },
+          },
+        },
+      })
+      const [event] = await saveEvent(eventParams, '0x123')
+      await LockMetadata.upsert({
+        address: matchingLock,
+        chain: network,
+        data: {
+          name: 'Ticket for Image Sync Event',
+          image: 'https://example.com/old-event.jpg',
+          description: 'Keep me',
+        },
+      })
+      await LockMetadata.upsert({
+        address: customLock,
+        chain: network,
+        data: {
+          name: 'Custom Ticket',
+          image: 'https://example.com/custom-ticket.jpg',
+        },
+      })
+
+      await saveEvent(
+        {
+          data: {
+            slug: event.slug,
+            name: 'Image Sync Event',
+            image: 'https://example.com/new-event.jpg',
+          },
+        },
+        '0x123'
+      )
+
+      const updatedMatchingLock = await LockMetadata.findOne({
+        where: { address: matchingLock, chain: network },
+      })
+      const untouchedCustomLock = await LockMetadata.findOne({
+        where: { address: customLock, chain: network },
+      })
+
+      expect(updatedMatchingLock!.data.image).toEqual(
+        'https://example.com/new-event.jpg'
+      )
+      expect(updatedMatchingLock!.data.description).toEqual('Keep me')
+      expect(untouchedCustomLock!.data.image).toEqual(
+        'https://example.com/custom-ticket.jpg'
+      )
     })
   })
 

--- a/locksmith/src/operations/eventOperations.ts
+++ b/locksmith/src/operations/eventOperations.ts
@@ -10,12 +10,13 @@ import {
   toFormData,
   formDataToMetadata,
 } from '@unlock-protocol/core'
-import { CheckoutConfig, EventData, KeyMetadata } from '../models'
+import { CheckoutConfig, EventData, KeyMetadata, LockMetadata } from '../models'
 import { saveCheckoutConfig } from './checkoutConfigOperations'
 import { EventBodyType } from '../controllers/v2/eventsController'
 import { Op } from 'sequelize'
 import { removeProtectedAttributesFromObject } from '../utils/protectedAttributes'
 import { EventStatus } from '@unlock-protocol/types'
+import normalizer from '../utils/normalizer'
 
 interface AttributeProps {
   value: string
@@ -227,6 +228,13 @@ export const saveEvent = async (
   const previousEvent = await EventData.scope('withoutId').findOne({
     where: { slug },
   })
+  const previousImage = previousEvent?.data?.image
+  const nextImage = parsed.data?.image
+  const checkoutConfig =
+    parsed.checkoutConfig ??
+    (previousEvent?.checkoutConfigId
+      ? await CheckoutConfig.findByPk(previousEvent.checkoutConfigId)
+      : undefined)
 
   if (previousEvent) {
     data = defaultsDeep(
@@ -255,6 +263,19 @@ export const saveEvent = async (
     }
   )
 
+  if (
+    previousEvent &&
+    previousImage &&
+    nextImage &&
+    previousImage !== nextImage
+  ) {
+    await syncEventImageToLockMetadata(
+      checkoutConfig?.config,
+      previousImage,
+      nextImage
+    )
+  }
+
   if (!savedEvent.checkoutConfigId && parsed.checkoutConfig) {
     const checkoutConfig = await PaywallConfig.strip().parseAsync(
       parsed.checkoutConfig.config
@@ -270,6 +291,44 @@ export const saveEvent = async (
   }
 
   return [savedEvent, !parsed.data.slug]
+}
+
+const syncEventImageToLockMetadata = async (
+  checkoutConfig: PaywallConfigType | undefined,
+  previousImage: string,
+  nextImage: string
+) => {
+  const locks = checkoutConfig?.locks
+  if (!locks) {
+    return
+  }
+
+  await Promise.all(
+    Object.entries(locks).map(async ([lockAddress, lockConfig]) => {
+      const network = lockConfig.network || checkoutConfig.network
+      if (!network) {
+        return
+      }
+      const normalizedLockAddress = normalizer.ethereumAddress(lockAddress)
+
+      const lockMetadata = await LockMetadata.findOne({
+        where: {
+          address: normalizedLockAddress,
+          chain: network,
+        },
+      })
+
+      if (!lockMetadata || lockMetadata.data?.image !== previousImage) {
+        return
+      }
+
+      lockMetadata.data = {
+        ...lockMetadata.data,
+        image: nextImage,
+      }
+      await lockMetadata.save()
+    })
+  )
 }
 
 export const getCheckedInAttendees = async (slug: string) => {


### PR DESCRIPTION
## Summary
- Sync event image updates into lock NFT metadata only when the NFT image still matches the previous event image
- Preserve custom NFT images that have already diverged from the event image
- Add regression coverage for matching vs custom lock metadata images

Fixes #13545

## Verification
- `NODE_ENV=test ../node_modules/.bin/vitest run __tests__/operations/eventOperations.test.ts --coverage=false`

Note: I also attempted `yarn workspace @unlock-protocol/locksmith build`; in this sparse checkout it fails because local generated/dist workspace artifacts for `@unlock-protocol/unlock-js`, `@unlock-protocol/ui`, and `@unlock-protocol/contracts` are missing. The focused locksmith event operations test passes after running the repo migrations locally.
