### PR TITLE
Add 694410194 to cla bot contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,6 +100,7 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
+    "694410194",
     "claude[bot]"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "


### PR DESCRIPTION
Adds `694410194` to `.clabot` as requested by cla-bot on #16415.

This PR intentionally contains only the CLA registry update.

Related: https://github.com/unlock-protocol/unlock/pull/16415#issuecomment-4432049427
