### PR TITLE
Improve certificate presentation and metadata display

### DIFF
--- a/packages/ui/lib/components/Certificate/Certificate.stories.tsx
+++ b/packages/ui/lib/components/Certificate/Certificate.stories.tsx
@@ -9,6 +9,36 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const certificateWithRecipientDetailsArgs = {
+  name: 'Unlock Certification Builder',
+  description:
+    'Awarded for completing the Unlock certification workshop, including lock setup, airdrop delivery, metadata review, and credential sharing. This description intentionally spans multiple sentences so the certificate preview can exercise long-form wrapping without crowding the issuer panel or the verification details.',
+  owner: 'Ada Lovelace',
+  issuer: 'Unlock Labs',
+  network: 8453,
+  tokenId: 2026,
+  lockAddress: '0xF3850C690BFF6c1E343D2449bBbbb00b0E934f7b',
+  transactionsHash: '0x0dEADBEEF1234567890abcdef1234567890abcdef',
+  issueDate: '13 May 2026',
+  image:
+    'https://www.pngkit.com/png/detail/99-993245_atrc-certified-logo-certification.png',
+  externalUrl: 'https://unlock-protocol.com',
+  customMetadata: [
+    {
+      trait_type: 'Cohort',
+      value: 'Spring 2026',
+    },
+    {
+      trait_type: 'Level',
+      value: 'Advanced',
+    },
+    {
+      trait_type: 'Credential ID',
+      value: 'CERT-2026-BASE-0001',
+    },
+  ],
+}
+
 export const CertificateBase = {
   args: {
     name: 'Example Certification',
@@ -43,5 +73,16 @@ export const CertificateWithBadge = {
     image:
       'https://www.pngkit.com/png/detail/99-993245_atrc-certified-logo-certification.png',
     externalUrl: 'https://example.it',
+  },
+} satisfies Story
+
+export const CertificateWithRecipientDetails = {
+  args: certificateWithRecipientDetailsArgs,
+} satisfies Story
+
+export const CertificateWithRecipientDetailsMobile = {
+  args: {
+    ...certificateWithRecipientDetailsArgs,
+    isMobile: true,
   },
 } satisfies Story

--- a/packages/ui/lib/components/Certificate/Certificate.tsx
+++ b/packages/ui/lib/components/Certificate/Certificate.tsx
@@ -40,6 +40,7 @@ const ValueWrapper = ({ children }: Props) => {
         textAlign: 'left',
         flex: 1,
         minWidth: '150px',
+        maxWidth: '100%',
       }}
     >
       {children}
@@ -55,6 +56,9 @@ const CertificateLabel = ({ children }: Props) => {
         color: '#374151',
         fontSize: '12px',
         lineHeight: '16px',
+        fontWeight: 600,
+        letterSpacing: 0,
+        textTransform: 'uppercase',
       }}
     >
       {children}
@@ -79,13 +83,37 @@ const CertificateValue = ({ children, size = 'medium' }: Props) => {
   return (
     <span
       style={{
-        display: 'flex',
+        display: 'block',
         fontSize: sizes[size],
         fontWeight: weights[size],
+        lineHeight: size === 'large' ? '30px' : '22px',
+        color: '#111827',
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
       }}
     >
       {children}
     </span>
+  )
+}
+
+const CertificateDescription = ({ children }: Props) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        color: '#4b5563',
+        fontSize: '14px',
+        lineHeight: '22px',
+        maxWidth: '680px',
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
+      }}
+    >
+      {children}
+    </div>
   )
 }
 
@@ -147,13 +175,14 @@ export const Certificate = ({
         background: '#FFFDF8',
         display: 'flex',
         position: 'relative',
-        border: '1px solid #e5e7eb',
+        border: '1px solid #e0d7c7',
         overflow: 'hidden',
         flexDirection: isMobile ? 'column' : 'row',
         width: '100%',
         minHeight: '500px',
         height: '100%',
         alignItems: 'stretch',
+        borderRadius: '8px',
       }}
     >
       {badge && <Badge>{badge}</Badge>}
@@ -161,30 +190,42 @@ export const Certificate = ({
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: isMobile ? '40px' : '96px',
-          padding: isMobile ? '24px' : '44px 48px',
-          marginTop: '12px',
+          justifyContent: 'space-between',
+          gap: isMobile ? '32px' : '56px',
+          padding: isMobile ? '28px 24px' : '48px 56px',
           height: '100%',
           flex: 2,
+          minWidth: 0,
         }}
       >
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <h2
             style={{
               display: 'flex',
-              fontSize: isMobile ? '20px' : '36px',
+              fontSize: isMobile ? '22px' : '40px',
+              lineHeight: isMobile ? '30px' : '48px',
               fontWeight: 700,
-              textTransform: 'uppercase',
+              color: '#111827',
             }}
           >
-            Certification
+            Certificate of Completion
           </h2>
           <div
             style={{
               display: 'flex',
+              width: '72px',
+              height: '4px',
+              marginTop: '16px',
+              background: '#ff6771',
+              borderRadius: '999px',
+            }}
+          />
+          <div
+            style={{
+              display: 'flex',
               flexDirection: 'column',
-              gap: '24px',
-              marginTop: '12px',
+              gap: '28px',
+              marginTop: '28px',
             }}
           >
             {issueDate && <CertificateValue>{issueDate}</CertificateValue>}
@@ -196,7 +237,9 @@ export const Certificate = ({
               }}
             >
               <CertificateLabel>This is to certify</CertificateLabel>
-              <CertificateValue>{minifyAddress(owner)}</CertificateValue>
+              <CertificateValue size="large">
+                {minifyAddress(owner)}
+              </CertificateValue>
             </div>
             <div
               style={{
@@ -208,22 +251,7 @@ export const Certificate = ({
               <CertificateLabel>has completed</CertificateLabel>
               <CertificateValue size="large">{name}</CertificateValue>
               {description && (
-                <div
-                  style={{
-                    display: 'flex',
-                    marginTop: '10px',
-                  }}
-                >
-                  <CertificateLabel>
-                    <span
-                      style={{
-                        display: 'flex',
-                      }}
-                    >
-                      {description}
-                    </span>
-                  </CertificateLabel>
-                </div>
+                <CertificateDescription>{description}</CertificateDescription>
               )}
             </div>
 
@@ -233,16 +261,31 @@ export const Certificate = ({
                   display: 'flex',
                   flexDirection: isMobile ? 'column' : 'row',
                   justifyContent: 'flex-start',
-                  gap: isMobile ? '16px' : '8px',
-                  marginTop: '24px',
+                  gap: '12px',
+                  marginTop: '8px',
                   flexWrap: 'wrap',
                 }}
               >
                 {customMetadata.map((attribute, index) => (
-                  <ValueWrapper key={index}>
+                  <div
+                    key={index}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '6px',
+                      minWidth: isMobile ? '100%' : '180px',
+                      flex: 1,
+                      padding: '12px 14px',
+                      background: '#ffffff',
+                      border: '1px solid #e5e7eb',
+                      borderRadius: '8px',
+                    }}
+                  >
                     <CertificateLabel>{attribute.trait_type}</CertificateLabel>
-                    <CertificateValue>{attribute.value}</CertificateValue>
-                  </ValueWrapper>
+                    <CertificateValue size="small">
+                      {attribute.value}
+                    </CertificateValue>
+                  </div>
                 ))}
               </div>
             )}
@@ -254,9 +297,10 @@ export const Certificate = ({
               display: 'flex',
               flexDirection: isMobile ? 'column' : 'row',
               justifyContent: 'space-between',
-              gap: isMobile ? '16px' : '8px',
-              marginTop: isMobile ? '30px' : '100px',
+              gap: isMobile ? '16px' : '12px',
               flexWrap: 'wrap',
+              paddingTop: '24px',
+              borderTop: '1px solid #e5e0d8',
             }}
           >
             {expiration && (
@@ -281,6 +325,8 @@ export const Certificate = ({
                 <div
                   style={{
                     display: 'flex',
+                    overflowWrap: 'break-word',
+                    wordBreak: 'break-word',
                   }}
                 >
                   {transactionsHash}
@@ -307,6 +353,7 @@ export const Certificate = ({
           width: '100%',
           minWidth: '300px',
           flex: 1,
+          background: '#f6f3ee',
         }}
       >
         <div
@@ -324,10 +371,10 @@ export const Certificate = ({
               flexDirection: 'column',
               gap: '16px',
               width: isMobile ? '100%' : '300px',
-              background: '#FAFBFC',
-              borderRight: isMobile ? 'none' : '1px solid #9ca3af',
-              borderLeft: isMobile ? 'none' : '1px solid #9ca3af',
-              padding: isMobile ? '0 16px 40px 16px' : '40px 24px 0 24px',
+              background: '#ffffff',
+              borderRight: isMobile ? 'none' : '1px solid #e5e7eb',
+              borderLeft: isMobile ? 'none' : '1px solid #e5e7eb',
+              padding: isMobile ? '0 24px 40px 24px' : '40px 24px 0 24px',
               marginLeft: 'auto',
               marginRight: isMobile ? 'none' : '50px',
             }}
@@ -335,8 +382,9 @@ export const Certificate = ({
             <img
               style={{
                 width: '100%',
-                borderRadius: '16px',
+                borderRadius: '8px',
                 overflow: 'hidden',
+                border: '1px solid #e5e7eb',
               }}
               width={200}
               height={200}

--- a/unlock-app/src/components/content/certification/CertificationDetails.tsx
+++ b/unlock-app/src/components/content/certification/CertificationDetails.tsx
@@ -34,6 +34,11 @@ import { UpdateTransferFee } from '~/components/interface/locks/Settings/forms/U
 import { PaywallConfigType, getLockTypeByMetadata } from '@unlock-protocol/core'
 import { useLockData } from '~/hooks/useLockData'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import {
+  getCertificateDetailsMetadata,
+  getCertificationRecipientName,
+  getCustomCertificationMetadata,
+} from './utils'
 
 interface CertificationDetailsProps {
   lockAddress: string
@@ -209,6 +214,10 @@ export const CertificationDetails = ({
   }
 
   const certificationData = toFormData(metadata!)
+  const customMetadata = getCustomCertificationMetadata(metadata)
+  const recipientName = getCertificationRecipientName(customMetadata)
+  const certificateDetailsMetadata =
+    getCertificateDetailsMetadata(customMetadata)
 
   const transactionsHash: string = key?.transactionsHash?.[0] || '22'
 
@@ -371,11 +380,16 @@ export const CertificationDetails = ({
               ) : undefined
             }
             issuer={issuer}
-            owner={!hasValidKey ? key?.owner : addressMinify(key?.owner)}
+            owner={
+              recipientName ||
+              (!hasValidKey ? key?.owner : addressMinify(key?.owner)) ||
+              ''
+            }
             expiration={showExpiration ? expiration : undefined}
             transactionsHash={<TransactionHashButton />}
             externalUrl={certificationData.external_url}
             isMobile={isMobile}
+            customMetadata={certificateDetailsMetadata}
           />
         )}
 

--- a/unlock-app/src/components/content/certification/CertificationPreview.tsx
+++ b/unlock-app/src/components/content/certification/CertificationPreview.tsx
@@ -13,6 +13,11 @@ import { MAX_UINT } from '~/constants'
 import LinkedinShareButton from './LinkedInShareButton'
 import { useCertification } from '~/hooks/useCertification'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import {
+  getCertificateDetailsMetadata,
+  getCertificationRecipientName,
+  getCustomCertificationMetadata,
+} from './utils'
 
 interface CertificationPreviewProps {
   lockAddress?: string
@@ -112,14 +117,10 @@ export const CertificationPreviewContent = ({
   const isMobile = window?.innerWidth < 768
 
   // Get all custom metadata that aren't `minted` or `certification_issuer`
-  const customMetadata =
-    metadata?.attributes?.filter(
-      (attr: any) =>
-        attr.trait_type !== 'Minted' &&
-        attr.trait_type !== 'certification_issuer' &&
-        attr.trait_type &&
-        attr.value
-    ) || []
+  const customMetadata = getCustomCertificationMetadata(metadata)
+  const recipientName = getCertificationRecipientName(customMetadata)
+  const certificateDetailsMetadata =
+    getCertificateDetailsMetadata(customMetadata)
 
   const certificateProps = {
     tokenId: certification?.tokenId,
@@ -134,14 +135,17 @@ export const CertificationPreviewContent = ({
       <span className="text-xl">Preview</span>
     ) : undefined,
     issuer,
-    owner: !hasValidKey
-      ? certification?.owner
-      : addressMinify(certification?.owner),
+    owner:
+      recipientName ||
+      (!hasValidKey
+        ? certification?.owner
+        : addressMinify(certification?.owner)) ||
+      '',
     expiration: showExpiration ? expiration : undefined,
     transactionsHash: <TransactionHashButton />,
     externalUrl: certificationData.external_url,
     isMobile,
-    ...customMetadata,
+    customMetadata: certificateDetailsMetadata,
   }
 
   return (

--- a/unlock-app/src/components/content/certification/utils.tsx
+++ b/unlock-app/src/components/content/certification/utils.tsx
@@ -1,4 +1,7 @@
-import { Metadata } from '~/components/interface/locks/metadata/utils'
+import type {
+  Attribute,
+  Metadata,
+} from '~/components/interface/locks/metadata/utils'
 
 interface CertificationUrlProps {
   metadata?: Partial<Metadata>
@@ -22,4 +25,62 @@ export const getCertificationPath = ({
   }
 
   return `/certification/${slug}`
+}
+
+const normalizeTraitType = (traitType = '') => {
+  return traitType
+    .replace(/[_-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+const hiddenCertificationTraits = new Set(['minted', 'certification issuer'])
+
+const recipientTraits = new Set([
+  'attendee',
+  'attendee name',
+  'full name',
+  'fullname',
+  'holder',
+  'holder name',
+  'name',
+  'recipient',
+  'recipient name',
+])
+
+export const getCustomCertificationMetadata = (
+  metadata?: Partial<Metadata>
+): Attribute[] => {
+  return (
+    metadata?.attributes?.filter((attribute) => {
+      const normalizedTraitType = normalizeTraitType(attribute.trait_type)
+      return (
+        !!attribute.trait_type &&
+        attribute.value !== undefined &&
+        attribute.value !== null &&
+        `${attribute.value}`.trim() !== '' &&
+        !hiddenCertificationTraits.has(normalizedTraitType)
+      )
+    }) || []
+  )
+}
+
+export const getCertificationRecipientName = (
+  customMetadata: Attribute[]
+): string | undefined => {
+  const recipient = customMetadata.find((attribute) =>
+    recipientTraits.has(normalizeTraitType(attribute.trait_type))
+  )
+
+  return recipient?.value?.toString()
+}
+
+export const getCertificateDetailsMetadata = (
+  customMetadata: Attribute[]
+): Attribute[] => {
+  return customMetadata.filter(
+    (attribute) =>
+      !recipientTraits.has(normalizeTraitType(attribute.trait_type))
+  )
 }


### PR DESCRIPTION
## Summary
- refreshes the shared certificate layout with cleaner spacing, stronger title/recipient hierarchy, wrapped long descriptions, and boxed credential metadata
- passes certification custom metadata into the certificate on both detail and preview pages
- uses recipient-like metadata fields (for example Name, Full Name, Recipient) as the certified person when available, instead of always showing only a wallet address

Closes #16197

## Validation
- git diff --check
- lint-staged pre-commit hook completed: yarn run lint --fix and prettier on the staged files
- corepack yarn workspace @unlock-protocol/types build
- corepack yarn workspace @unlock-protocol/networks build
- corepack yarn workspace @unlock-protocol/ui build:lib
- Storybook visual check for CertificateWithRecipientDetails at 1280x720: title, recipient, and credential metadata visible
- Storybook visual check for CertificateWithRecipientDetailsMobile at 390x844: title, recipient, and credential metadata visible

## Bounty payout
USDC on Base: 0x69fBC7BE3700f3c22701670C89458De3173Dc1F6
