### PR TITLE
Add Snooz1e to CLA list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,6 +100,7 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
+    "Snooz1e",
     "claude[bot]"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "


### PR DESCRIPTION
## Summary
- adds Snooz1e to the CLA bot contributor allowlist, as requested by the CLA bot on #16418

## Validation
- commit hook completed; no staged files matched lint-staged tasks for this JSON-only update
