### PR TITLE
Grey out expiring generated membership icons

### DIFF
--- a/locksmith/__tests__/operations/lockOperations.test.ts
+++ b/locksmith/__tests__/operations/lockOperations.test.ts
@@ -1,0 +1,88 @@
+import { ethers } from 'ethers'
+import { vi } from 'vitest'
+
+vi.mock('../../src/models', () => ({
+  LockIcons: {},
+  LockMetadata: {},
+  UserTokenMetadata: {},
+}))
+
+vi.mock('../../src/initializers', () => ({
+  getWeb3Service: vi.fn(),
+}))
+
+vi.mock('../../src/utils/keyData', () => ({
+  default: class KeyData {
+    get = vi.fn()
+  },
+}))
+
+vi.mock('../../src/utils/ticket', () => ({
+  ticketForFilBangalore: vi.fn(() => Promise.resolve('<svg>ticket</svg>')),
+}))
+
+import {
+  getKeyIcon,
+  getMembershipIconGrayscale,
+} from '../../src/operations/lockOperations'
+import { ticketForFilBangalore } from '../../src/utils/ticket'
+
+describe('lockOperations', () => {
+  describe('getMembershipIconGrayscale', () => {
+    const now = 1_700_000_000
+
+    it('returns fully grayscale for expired keys', () => {
+      expect(
+        getMembershipIconGrayscale({
+          expiration: now - 1,
+          expirationDuration: 60 * 60 * 24 * 30,
+          now,
+        })
+      ).toEqual(1)
+    })
+
+    it('returns partial grayscale as the key approaches expiration', () => {
+      expect(
+        getMembershipIconGrayscale({
+          expiration: now + 25,
+          expirationDuration: 100,
+          now,
+        })
+      ).toEqual(0.75)
+    })
+
+    it('does not grayscale non-expiring locks', () => {
+      expect(
+        getMembershipIconGrayscale({
+          expiration: now + 25,
+          expirationDuration: ethers.MaxUint256.toString(),
+          now,
+        })
+      ).toEqual(0)
+    })
+  })
+
+  describe('getKeyIcon', () => {
+    it('preserves the FilBangalore custom key icon for the configured Arbitrum lock', async () => {
+      expect.assertions(2)
+
+      const icon = await getKeyIcon({
+        network: 42161,
+        lockAddress: '0x02c510bE69fe87E052E065D8A40B437d55907B48',
+        keyId: '42',
+      })
+
+      expect(ticketForFilBangalore).toHaveBeenCalledWith({
+        network: 42161,
+        lockAddress: '0x02c510bE69fe87E052E065D8A40B437d55907B48',
+        tokenId: '42',
+      })
+      expect(icon).toEqual({
+        icon: '<svg>ticket</svg>',
+        isGenerated: false,
+        isURL: false,
+        type: 'image/svg+xml',
+      })
+    })
+  })
+})

--- a/locksmith/__tests__/utils/lockIcon.test.ts
+++ b/locksmith/__tests__/utils/lockIcon.test.ts
@@ -8,4 +8,15 @@ describe('lockIcon', () => {
     expect(lockIcon1).toMatch(/^<svg/)
     expect(lockIcon1).not.toEqual(lockIcon2)
   })
+
+  it('should apply grayscale saturation when requested', () => {
+    expect.assertions(2)
+
+    const icon = lockIcon('0x95da5F777A3e283bFf0c47374998E10D8A2183C7', {
+      grayscale: 0.75,
+    })
+
+    expect(icon).toContain('<filter id="grayscale">')
+    expect(icon).toContain('<feColorMatrix type="saturate" values="0.25" />')
+  })
 })

--- a/locksmith/src/controllers/lockController.ts
+++ b/locksmith/src/controllers/lockController.ts
@@ -7,6 +7,7 @@ import logger from '../logger'
 import { SubgraphService } from '@unlock-protocol/unlock-js'
 import {
   getGeneratedLockIcon,
+  getKeyIconGrayscale,
   getLockIcon,
   getKeyIcon,
 } from '../operations/lockOperations'
@@ -104,6 +105,14 @@ export const lockIcon = async (req: Request, res: Response) => {
     })
     if (keyIcon) {
       icon = keyIcon
+    } else if (icon.isGenerated) {
+      icon = getGeneratedLockIcon(lockAddress, {
+        grayscale: await getKeyIconGrayscale({
+          network,
+          lockAddress,
+          keyId: String(req.query.id || ''),
+        }),
+      })
     }
   }
 

--- a/locksmith/src/operations/lockOperations.ts
+++ b/locksmith/src/operations/lockOperations.ts
@@ -5,11 +5,14 @@ import parseDataUri from 'parse-data-uri'
 import lockIconUtils from '../utils/lockIcon'
 import { ticketForFilBangalore } from '../utils/ticket'
 import { getWeb3Service } from '../initializers'
+import KeyData from '../utils/keyData'
+import { ethers } from 'ethers'
 
 interface IconType {
   icon: string
   type: string | null
   isURL: boolean
+  isGenerated?: boolean
 }
 
 export async function getKeyHolderMetadata(
@@ -42,12 +45,77 @@ export async function isSoldOut(
   return keysAvailable < keysNeeded // true of keysAvailable smaller than keysNeeded
 }
 
-export const getGeneratedLockIcon = (lockAddress: string): IconType => {
-  const svg = lockIconUtils.lockIcon(lockAddress)
+export const getMembershipIconGrayscale = ({
+  expiration,
+  expirationDuration,
+  now = Math.floor(Date.now() / 1000),
+}: {
+  expiration?: number
+  expirationDuration?: number | string | bigint
+  now?: number
+}): number => {
+  if (
+    !expiration ||
+    expirationDuration === undefined ||
+    expirationDuration === null ||
+    expirationDuration.toString() === ethers.MaxUint256.toString()
+  ) {
+    return 0
+  }
+
+  if (expiration <= now) {
+    return 1
+  }
+
+  const totalDuration = Number(expirationDuration)
+  if (!Number.isFinite(totalDuration) || totalDuration <= 0) {
+    return 0
+  }
+
+  const remainingDuration = expiration - now
+  return Math.min(1, Math.max(0, 1 - remainingDuration / totalDuration))
+}
+
+export const getGeneratedLockIcon = (
+  lockAddress: string,
+  { grayscale = 0 }: { grayscale?: number } = {}
+): IconType => {
+  const svg = lockIconUtils.lockIcon(lockAddress, { grayscale })
   return {
     icon: svg,
     type: 'image/svg+xml',
     isURL: false,
+    isGenerated: true,
+  }
+}
+
+export const getKeyIconGrayscale = async ({
+  network,
+  lockAddress,
+  keyId,
+}: {
+  network: number
+  lockAddress: string
+  keyId: string
+}): Promise<number> => {
+  try {
+    const keyData = new KeyData()
+    const { expiration } = await keyData.get(lockAddress, keyId, network)
+    if (!expiration) {
+      return 0
+    }
+
+    const web3Service = getWeb3Service()
+    const lock = await web3Service.getLock(lockAddress, network, {
+      fields: ['expirationDuration'],
+    })
+
+    return getMembershipIconGrayscale({
+      expiration,
+      expirationDuration: lock?.expirationDuration,
+    })
+  } catch {
+    return 0
   }
 }
 
@@ -81,6 +149,7 @@ export const getLockIcon = async ({
           icon: lockImageUrl,
           type: null,
           isURL: true,
+          isGenerated: false,
         }
       }
     }
@@ -96,12 +165,14 @@ export const getLockIcon = async ({
           icon: parsedDataUri.data,
           type: parsedDataUri.mimeType,
           isURL: false,
+          isGenerated: false,
         }
       } else {
         return {
           icon: lockIcon.icon,
           type: null,
           isURL: true,
+          isGenerated: false,
         }
       }
     } else {
@@ -124,7 +195,8 @@ export const getKeyIcon = async ({
   // Temporary icon for FilBangalore
   if (
     network == 42161 &&
-    lockAddress.toLowerCase() === '0x02c510bE69fe87E052E065D8A40B437d55907B48'
+    lockAddress.toLowerCase() ===
+      '0x02c510bE69fe87E052E065D8A40B437d55907B48'.toLowerCase()
   ) {
     const icon = await ticketForFilBangalore({
       network,
@@ -132,7 +204,7 @@ export const getKeyIcon = async ({
       tokenId: keyId,
     })
 
-    return { type: 'image/svg+xml', icon, isURL: false }
+    return { type: 'image/svg+xml', icon, isURL: false, isGenerated: false }
   }
   return null
 }

--- a/locksmith/src/utils/lockIcon.ts
+++ b/locksmith/src/utils/lockIcon.ts
@@ -1,6 +1,14 @@
 import ColorScheme = require('color-scheme')
 
-export const lockIcon = (address: string) => {
+export type LockIconOptions = {
+  grayscale?: number
+}
+
+const clamp = (value: number) => Math.min(1, Math.max(0, value))
+
+export const lockIcon = (address: string, options: LockIconOptions = {}) => {
+  const saturation = 1 - clamp(options.grayscale ?? 0)
+
   /**
    * This computes how much rotation to apply to the lock glyph
    * @param {string} address
@@ -97,8 +105,11 @@ export const lockIcon = (address: string) => {
       <defs>
         <circle id="a" cx="108" cy="108" r="108" />
         <circle id="c" cx="108" cy="108" r="60.75" />
+        <filter id="grayscale">
+          <feColorMatrix type="saturate" values="${saturation}" />
+        </filter>
       </defs>
-      <g>
+      <g filter="url(#grayscale)">
         <mask id="b" fill="#fff">
           <use xlink:href="#a" />
         </mask>


### PR DESCRIPTION
## Summary

- add grayscale support to generated lock SVGs for key-specific icon requests
- compute grayscale from key expiration vs. lock expiration duration, with non-expiring locks left unchanged
- preserve custom key icons, including the existing FilBangalore special-case path

## Related work

This addresses #7294. I also checked the existing open attempt in #16312 before starting. It has been idle since April and is still blocked on contributor setup; its current diff also leaves the FilBangalore special-case icon comparison broken because it compares a lowercased address to a mixed-case constant. This PR keeps that path covered with a regression test.

Bounty payout route if accepted: Base USDC to `0x9d39802b6B65D360bFdA92c8221dB3EbA8cbF9D7`.

## Validation

- `corepack yarn workspace @unlock-protocol/locksmith vitest run __tests__/utils/lockIcon.test.ts __tests__/operations/lockOperations.test.ts`
- `corepack yarn workspace @unlock-protocol/locksmith eslint src/controllers/lockController.ts src/operations/lockOperations.ts src/utils/lockIcon.ts __tests__/operations/lockOperations.test.ts __tests__/utils/lockIcon.test.ts` (0 errors; existing require-import warning in `lockIcon.ts` remains)
- `corepack yarn workspaces foreach --recursive --from @unlock-protocol/locksmith --topological-dev run build`
- `corepack yarn workspace @unlock-protocol/locksmith build`
- `git diff --check`
