### PR TITLE
Add ramimbo to CLA allowlist

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,7 +100,8 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
-    "claude[bot]"
+    "claude[bot]",
+    "ramimbo"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "
 }


### PR DESCRIPTION
Adds my GitHub username to the CLA allowlist as requested by the repository bot. This PR intentionally changes only `.clabot`.