### PR TITLE
chore: add chico10117 to CLA bot list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -99,6 +99,7 @@
     "rejected-l",
     "toosolid2003",
     "alvarengao",
+    "chico10117",
     "9alekc1",
     "claude[bot]"
   ],


### PR DESCRIPTION
Adds `chico10117` to `.clabot` as the single required CLA housekeeping change for upcoming Unlock contributions.