### PR TITLE
Add canonical checkout URLs

### DIFF
--- a/unlock-app/app/checkout/[id]/page.tsx
+++ b/unlock-app/app/checkout/[id]/page.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Metadata } from 'next'
+import { CheckoutPage as CheckoutPageComponent } from '~/components/interface/checkout'
+import { getConfig } from '../../frames/checkout/components/utils'
+import { config as appConfig } from '~/config/app'
+
+type Props = {
+  params: { id: string }
+}
+
+const getCanonicalCheckoutUrl = (id: string) => {
+  return `${appConfig.unlockApp}/checkout/${encodeURIComponent(id)}`
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const id = params?.id?.trim()
+  const baseMetadata: Metadata = {
+    title: 'Checkout | Unlock Protocol',
+    alternates: id
+      ? {
+          canonical: getCanonicalCheckoutUrl(id),
+        }
+      : undefined,
+  }
+
+  if (!id) {
+    return baseMetadata
+  }
+
+  try {
+    const config = await getConfig(id)
+
+    if (!config) {
+      return baseMetadata
+    }
+
+    return {
+      title: config.title || baseMetadata.title,
+      openGraph: {
+        images: [`/og/checkout?id=${id}`],
+      },
+      other: {
+        'fc:frame': 'vNext',
+        'fc:frame:image': `${appConfig.unlockApp}/og/checkout?id=${id}`,
+        'fc:frame:post_url': `${appConfig.unlockApp}/frames/checkout?id=${id}`,
+      },
+      alternates: {
+        canonical: getCanonicalCheckoutUrl(id),
+      },
+    }
+  } catch (error) {
+    console.error(
+      `Error generating metadata for checkout config '${id}':`,
+      error
+    )
+    return baseMetadata
+  }
+}
+
+const CheckoutPage: React.FC = () => {
+  return <CheckoutPageComponent />
+}
+
+export default CheckoutPage

--- a/unlock-app/app/checkout/page.tsx
+++ b/unlock-app/app/checkout/page.tsx
@@ -4,15 +4,44 @@ import { fetchMetadata } from 'frames.js/next'
 import { CheckoutPage as CheckoutPageComponent } from '~/components/interface/checkout'
 import { getConfig } from '../frames/checkout/components/utils'
 import { config as appConfig } from '~/config/app'
+import { permanentRedirect } from 'next/navigation'
 
 type Props = {
-  searchParams: { id: string }
+  searchParams: Record<string, string | string[] | undefined>
+}
+
+const getSearchParam = (
+  searchParams: Props['searchParams'],
+  key: string
+): string | undefined => {
+  const value = searchParams?.[key]
+  return Array.isArray(value) ? value[0] : value
+}
+
+const getPathCheckoutUrl = (
+  id: string,
+  searchParams: Props['searchParams']
+) => {
+  const remainingParams = new URLSearchParams()
+
+  Object.entries(searchParams || {}).forEach(([key, value]) => {
+    if (key === 'id' || value === undefined) {
+      return
+    }
+
+    const values = Array.isArray(value) ? value : [value]
+    values.forEach((item) => remainingParams.append(key, item))
+  })
+
+  const queryString = remainingParams.toString()
+  const path = `/checkout/${encodeURIComponent(id)}`
+  return queryString ? `${path}?${queryString}` : path
 }
 
 export async function generateMetadata({
   searchParams,
 }: Props): Promise<Metadata> {
-  const id = searchParams?.id?.trim()
+  const id = getSearchParam(searchParams, 'id')?.trim()
 
   // Default metadata without frame data
   const baseMetadata: Metadata = {
@@ -42,16 +71,28 @@ export async function generateMetadata({
           new URL(`/frames/checkout?id=${id}`, appConfig.unlockApp)
         )),
       },
+      alternates: {
+        canonical: `${appConfig.unlockApp}/checkout/${encodeURIComponent(id)}`,
+      },
     }
 
     return metadata
   } catch (error) {
-    console.error('Error generating metadata:', error)
+    console.error(
+      `Error generating metadata for checkout config '${id}':`,
+      error
+    )
     return baseMetadata
   }
 }
 
-const CheckoutPage: React.FC = () => {
+const CheckoutPage: React.FC<Props> = ({ searchParams }) => {
+  const id = getSearchParam(searchParams, 'id')?.trim()
+
+  if (id) {
+    permanentRedirect(getPathCheckoutUrl(id, searchParams))
+  }
+
   return <CheckoutPageComponent />
 }
 

--- a/unlock-app/src/__tests__/components/content/event/utils.test.ts
+++ b/unlock-app/src/__tests__/components/content/event/utils.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { CheckoutConfig } from '@unlock-protocol/core'
+import { describe, expect, it, vi } from 'vitest'
+import { getCheckoutUrl } from '~/components/content/event/utils'
+
+vi.mock('~/config/app', () => ({
+  config: {
+    unlockApp: 'https://app.unlock-protocol.com',
+  },
+}))
+
+describe('getCheckoutUrl', () => {
+  it('uses canonical path-based checkout URLs when a checkout ID exists', () => {
+    expect(
+      getCheckoutUrl({
+        id: '2c1549c0-baea-4445-82e9-ab3bd3251162',
+        config: {
+          locks: {},
+        },
+      } as unknown as CheckoutConfig)
+    ).toBe(
+      `${window.location.origin}/checkout/2c1549c0-baea-4445-82e9-ab3bd3251162`
+    )
+  })
+
+  it('keeps query-based checkout config URLs when there is no checkout ID', () => {
+    const config = {
+      title: 'Direct checkout config',
+      redirectUri: '',
+      locks: {},
+    }
+
+    const url = new URL(
+      getCheckoutUrl({
+        config,
+      } as unknown as CheckoutConfig)
+    )
+
+    expect(url.pathname).toBe('/checkout')
+    expect(url.searchParams.has('paywallConfig')).toBe(true)
+    expect(JSON.parse(url.searchParams.get('paywallConfig')!)).toEqual({
+      title: 'Direct checkout config',
+      locks: {},
+    })
+    expect(config.redirectUri).toBe('')
+  })
+})

--- a/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
+++ b/unlock-app/src/__tests__/utils/getConfigFromSearch.test.ts
@@ -1,5 +1,11 @@
 import { getPaywallConfigFromQuery } from '../../utils/paywallConfig'
-import { it, describe, expect } from 'vitest'
+import { it, describe, expect, vi } from 'vitest'
+
+vi.mock('~/config/app', () => ({
+  config: {
+    env: 'dev',
+  },
+}))
 
 const lock = '0x1234567890123456789012345678901234567890'
 const validConfig = {
@@ -48,6 +54,20 @@ describe('getPaywallConfigFromQuery', () => {
         skipRecipient: false,
         minRecipients: 1,
         maxRecipients: 5,
+      })
+    )
+  })
+
+  it('should support legacy checkoutConfig query params', () => {
+    expect.assertions(1)
+    expect(
+      getPaywallConfigFromQuery({
+        checkoutConfig: JSON.stringify(validConfig),
+      })
+    ).toEqual(
+      expect.objectContaining({
+        title: 'Valid Title',
+        locks: validConfig.locks,
       })
     )
   })

--- a/unlock-app/src/components/content/event/utils.tsx
+++ b/unlock-app/src/components/content/event/utils.tsx
@@ -67,20 +67,25 @@ export const getEventUrl = ({
 }
 
 export const getCheckoutUrl = (checkoutConfig: CheckoutConfig) => {
-  const url = new URL(`${window.location.origin}/checkout`)
+  const checkoutConfigPayload = checkoutConfig.config
+    ? { ...checkoutConfig.config }
+    : checkoutConfig.config
 
   // remove redirectUri if not applicable
-  if (checkoutConfig.config?.redirectUri?.length === 0) {
-    delete checkoutConfig.config.redirectUri
+  if (checkoutConfigPayload?.redirectUri?.length === 0) {
+    delete checkoutConfigPayload.redirectUri
   }
 
   if (checkoutConfig.id) {
-    url.searchParams.append('id', checkoutConfig.id)
+    return `${window.location.origin}/checkout/${encodeURIComponent(
+      checkoutConfig.id
+    )}`
   } else {
+    const url = new URL(`${window.location.origin}/checkout`)
     url.searchParams.append(
-      'checkoutConfig',
-      JSON.stringify(checkoutConfig.config)
+      'paywallConfig',
+      JSON.stringify(checkoutConfigPayload)
     )
+    return url.toString()
   }
-  return url.toString()
 }

--- a/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
+++ b/unlock-app/src/components/interface/checkout/CheckoutContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useSearchParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import { useCheckoutCommunication } from '~/hooks/useCheckoutCommunication'
 import { getPaywallConfigFromQuery } from '~/utils/paywallConfig'
 import getOauthConfigFromQuery from '~/utils/oauth'
@@ -16,11 +16,16 @@ import { isInIframe } from '~/utils/iframe'
 
 export function CheckoutContainer() {
   const searchParams = useSearchParams()
+  const params = useParams<{ id?: string | string[] }>()
+  const checkoutIdFromPath = Array.isArray(params?.id)
+    ? params.id[0]
+    : params?.id
+  const checkoutId = checkoutIdFromPath || searchParams.get('id')?.toString()
 
   // Fetch config from parent in iframe context
   const communication = useCheckoutCommunication()
   const { isLoading, data: checkout } = useCheckoutConfig({
-    id: searchParams.get('id')?.toString(),
+    id: checkoutId,
   })
 
   const referrerAddress = searchParams.get('referrerAddress')?.toString()
@@ -52,7 +57,7 @@ export function CheckoutContainer() {
       })?.[1]
       ?.toString()
 
-  if (!(paywallConfig || oauthConfig) || isLoading) {
+  if (checkoutId && isLoading) {
     return <LoadingIcon size={20} className="animate-spin" />
   }
 

--- a/unlock-app/src/utils/paywallConfig.ts
+++ b/unlock-app/src/utils/paywallConfig.ts
@@ -42,8 +42,10 @@ export function getPaywallConfigFromQuery(
   }
 
   // Attempt to parse and validate a full PaywallConfig
-  if (typeof queryObj.paywallConfig === 'string') {
-    const rawConfig = queryObj.paywallConfig
+  const fullConfig = queryObj.paywallConfig || queryObj.checkoutConfig
+
+  if (typeof fullConfig === 'string') {
+    const rawConfig = fullConfig
     const decodedConfig = rawConfig
 
     let parsedConfig: any


### PR DESCRIPTION
## Description

This PR completes the canonical checkout URL work from #16078 with the reviewer feedback from #16079 folded in.

It adds `/checkout/[id]` as the canonical checkout route, permanently redirects legacy `/checkout?id=...` URLs to `/checkout/:id`, and preserves query params such as `referrerAddress` during that redirect. Metadata now includes a canonical URL and logs the checkout config ID when metadata generation fails.

It also keeps no-ID checkout flows working: direct `?paywallConfig=...` links continue to render without waiting on a checkout ID, generated no-ID checkout URLs now use `paywallConfig`, and legacy `checkoutConfig` query params are still accepted for compatibility.

Bounty payout wallet if accepted: `0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9`.

Fixes #16078

## Verification

- `yarn workspace @unlock-protocol/unlock-app exec vitest run src/__tests__/components/content/event/utils.test.ts src/__tests__/utils/getConfigFromSearch.test.ts --environment=jsdom`
- `yarn workspace @unlock-protocol/unlock-app exec eslint app/checkout/page.tsx 'app/checkout/[id]/page.tsx' src/components/interface/checkout/CheckoutContainer.tsx src/components/content/event/utils.tsx src/utils/paywallConfig.ts src/__tests__/components/content/event/utils.test.ts src/__tests__/utils/getConfigFromSearch.test.ts`
- `git diff --check`

Note: the focused eslint command exits successfully with existing `no-explicit-any` warnings in touched legacy files.
