### PR TITLE
Support accent color in checkout config

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -168,6 +168,18 @@ export const PaywallConfig = z
           'The URL for a icon to display in the top left corner of the modal.',
       })
       .optional(),
+    accentColor: z
+      .string({
+        description:
+          'Optional hex color used to theme the primary checkout actions and accents.',
+      })
+      .optional(),
+    accentColour: z
+      .string({
+        description:
+          'Optional hex color used to theme the primary checkout actions and accents.',
+      })
+      .optional(),
     locks: z.record(PaywallLockConfig),
     metadataInputs: z.array(MetadataInput).optional(),
     persistentCheckout: z

--- a/unlock-app/src/__tests__/utils/checkoutTheme.test.ts
+++ b/unlock-app/src/__tests__/utils/checkoutTheme.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCheckoutAccentColor,
+  getCheckoutAccentStyle,
+} from '../../utils/checkoutTheme'
+
+const validConfig = {
+  locks: {
+    '0x1234567890123456789012345678901234567890': {
+      name: 'A Lock',
+    },
+  },
+}
+
+describe('checkoutTheme', () => {
+  it('returns a supported accentColor', () => {
+    expect(
+      getCheckoutAccentColor({
+        ...validConfig,
+        accentColor: ' #1a2B3c ',
+      })
+    ).toBe('#1a2B3c')
+  })
+
+  it('accepts accentColour as an alias', () => {
+    expect(
+      getCheckoutAccentColor({
+        ...validConfig,
+        accentColour: '#abc',
+      })
+    ).toBe('#abc')
+  })
+
+  it('ignores unsupported colors', () => {
+    expect(
+      getCheckoutAccentColor({
+        ...validConfig,
+        accentColor: 'url(javascript:alert(1))',
+      })
+    ).toBeUndefined()
+  })
+
+  it('creates a scoped CSS variable style', () => {
+    expect(getCheckoutAccentStyle('#1a2B3c')).toEqual({
+      '--unlock-checkout-accent': '#1a2B3c',
+    })
+  })
+})

--- a/unlock-app/src/components/interface/checkout/main/index.tsx
+++ b/unlock-app/src/components/interface/checkout/main/index.tsx
@@ -27,6 +27,10 @@ import { Connected } from '../Connected'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
 import { AllowList } from './AllowList'
 import PrivyFunding from './embedded-wallet/PrivyFunding'
+import {
+  getCheckoutAccentColor,
+  getCheckoutAccentStyle,
+} from '~/utils/checkoutTheme'
 
 interface Props {
   paywallConfig: PaywallConfigType
@@ -34,6 +38,45 @@ interface Props {
   handleClose?: (params: Record<string, string>) => void
   communication?: ReturnType<typeof useCheckoutCommunication>
 }
+
+const CHECKOUT_ACCENT_STYLES = `
+[data-unlock-checkout-accent="true"] .bg-brand-ui-primary,
+[data-unlock-checkout-accent="true"] .disabled\\:hover\\:bg-brand-ui-primary:disabled:hover,
+[data-unlock-checkout-accent="true"] .bg-ui-main-500 {
+  background-color: var(--unlock-checkout-accent) !important;
+}
+
+[data-unlock-checkout-accent="true"] .hover\\:bg-brand-dark:hover {
+  background-color: var(--unlock-checkout-accent) !important;
+  filter: brightness(0.9);
+}
+
+[data-unlock-checkout-accent="true"] .text-brand-ui-primary,
+[data-unlock-checkout-accent="true"] .text-ui-main-500,
+[data-unlock-checkout-accent="true"] .borderless-primary {
+  color: var(--unlock-checkout-accent) !important;
+}
+
+[data-unlock-checkout-accent="true"] .hover\\:text-brand-ui-primary:hover,
+[data-unlock-checkout-accent="true"] .hover\\:text-ui-main-400:hover {
+  color: var(--unlock-checkout-accent) !important;
+}
+
+[data-unlock-checkout-accent="true"] .fill-brand-ui-primary,
+[data-unlock-checkout-accent="true"] .fill-ui-main-500 {
+  fill: var(--unlock-checkout-accent) !important;
+}
+
+[data-unlock-checkout-accent="true"] .group:hover .group-hover\\:fill-brand-ui-primary {
+  fill: var(--unlock-checkout-accent) !important;
+}
+
+[data-unlock-checkout-accent="true"] .border-brand-ui-primary,
+[data-unlock-checkout-accent="true"] .border-ui-main-100,
+[data-unlock-checkout-accent="true"] .focus\\:border-brand-ui-primary:focus {
+  border-color: var(--unlock-checkout-accent) !important;
+}
+`
 
 export function Checkout({
   paywallConfig,
@@ -59,6 +102,8 @@ export function Checkout({
   const router = useRouter()
   const searchParams = useSearchParams()
   const pathname = usePathname()
+  const accentColor = getCheckoutAccentColor(paywallConfig)
+  const accentStyle = getCheckoutAccentStyle(accentColor)
 
   useEffect(() => {
     console.debug('Unlock paywall config', paywallConfig)
@@ -244,7 +289,12 @@ export function Checkout({
   }, [matched])
 
   return (
-    <div className="bg-white z-10  shadow-xl max-w-md rounded-xl flex flex-col w-full h-[90vh] sm:h-[80vh] min-h-[32rem] max-h-[42rem] text-left">
+    <div
+      className="bg-white z-10  shadow-xl max-w-md rounded-xl flex flex-col w-full h-[90vh] sm:h-[80vh] min-h-[32rem] max-h-[42rem] text-left"
+      data-unlock-checkout-accent={accentColor ? 'true' : undefined}
+      style={accentStyle}
+    >
+      {accentColor && <style>{CHECKOUT_ACCENT_STYLES}</style>}
       <TopNavigation
         onClose={!paywallConfig?.persistentCheckout ? onClose : undefined}
         onBack={onBack}

--- a/unlock-app/src/utils/checkoutTheme.ts
+++ b/unlock-app/src/utils/checkoutTheme.ts
@@ -1,0 +1,38 @@
+import type { CSSProperties } from 'react'
+import type { PaywallConfigType } from '@unlock-protocol/core'
+
+type CheckoutThemeConfig = PaywallConfigType & {
+  accentColor?: unknown
+  accentColour?: unknown
+}
+
+const HEX_COLOR_PATTERN =
+  /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+
+export const getCheckoutAccentColor = (
+  paywallConfig?: PaywallConfigType
+): string | undefined => {
+  const { accentColor, accentColour } =
+    (paywallConfig as CheckoutThemeConfig | undefined) ?? {}
+  const color = typeof accentColor === 'string' ? accentColor : accentColour
+
+  if (typeof color !== 'string') {
+    return undefined
+  }
+
+  const trimmedColor = color.trim()
+
+  return HEX_COLOR_PATTERN.test(trimmedColor) ? trimmedColor : undefined
+}
+
+export const getCheckoutAccentStyle = (
+  accentColor?: string
+): CSSProperties | undefined => {
+  if (!accentColor) {
+    return undefined
+  }
+
+  return {
+    '--unlock-checkout-accent': accentColor,
+  } as CSSProperties
+}


### PR DESCRIPTION
Fixes #9208.

This adds a small checkout theming hook for applications that want the hosted checkout to match their product branding without forking or self-hosting the paywall.

What changed:
- Adds documented `accentColor` and `accentColour` paywall config fields.
- Accepts safe hex colors only at render time.
- Scopes the accent CSS variable to the checkout modal.
- Applies the accent to primary buttons, selected-state borders, checkout step indicators, icon fills, and primary checkout text accents.
- Leaves checkout behavior/payment flow unchanged when no accent color is provided or when an unsupported color is passed.

Example:

```json
{
  "accentColor": "#0ea5e9",
  "locks": {
    "0x...": {}
  }
}
```

Verification:
- `yarn workspace @unlock-protocol/unlock-app exec vitest run src/__tests__/utils/checkoutTheme.test.ts --environment=jsdom`
- `yarn workspace @unlock-protocol/unlock-app exec eslint src/components/interface/checkout/main/index.tsx src/utils/checkoutTheme.ts src/__tests__/utils/checkoutTheme.test.ts` (passes with existing hook dependency warnings in `index.tsx`)
- `yarn workspace @unlock-protocol/core lint src/schema.ts`
- `yarn workspace @unlock-protocol/core build`
- `git diff --check HEAD~1 HEAD`

Base USDC payout/contact wallet if accepted:
`0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9`
