### PR TITLE
Add ETH transfers for Privy accounts

### DIFF
--- a/unlock-app/src/components/interface/user-account/Funding.tsx
+++ b/unlock-app/src/components/interface/user-account/Funding.tsx
@@ -1,17 +1,38 @@
-import { LoginModal as FundingModal, useFundWallet } from '@privy-io/react-auth'
+import {
+  LoginModal as FundingModal,
+  useFundWallet,
+  usePrivy,
+} from '@privy-io/react-auth'
 
-import { Badge, Button, Modal, Placeholder } from '@unlock-protocol/ui'
+import {
+  AddressInput,
+  Badge,
+  Button,
+  Input,
+  Modal,
+  Placeholder,
+} from '@unlock-protocol/ui'
 import { useState } from 'react'
 import { ToastHelper } from '@unlock-protocol/ui'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
 import { useWeb3Service } from '~/utils/withWeb3Service'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { base } from 'viem/chains'
 import { SettingCard } from '../locks/Settings/elements/SettingCard'
 import { useEthPrice } from '~/hooks/useEthPrice'
+import { useEmbeddedWallet } from '~/hooks/useEmbeddedWallet'
+import { Controller, useForm } from 'react-hook-form'
+import { ethers } from 'ethers'
+
+interface TransferForm {
+  recipient: string
+  amount: number
+}
 
 export const Funding = () => {
   const { account } = useAuthenticate()
+  const { sendTransaction } = usePrivy()
+  const { isEmbeddedWallet } = useEmbeddedWallet()
   const web3Service = useWeb3Service()
   const { fundWallet } = useFundWallet({
     onUserExited: () => {
@@ -19,8 +40,27 @@ export const Funding = () => {
     },
   })
   const [showFundingModal, setShowFundingModal] = useState(false)
+  const {
+    register,
+    control,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<TransferForm>({
+    mode: 'onChange',
+    defaultValues: {
+      recipient: '',
+      amount: 0,
+    },
+  })
 
-  const { isPending: isLoadingBalance, data: userBalance } = useQuery({
+  const {
+    isPending: isLoadingBalance,
+    data: userBalance,
+    refetch: refetchBalance,
+  } = useQuery({
     queryKey: ['getBalance', account, 8453],
     queryFn: async () => {
       return parseFloat(await web3Service.getAddressBalance(account!, 8453))
@@ -39,6 +79,31 @@ export const Funding = () => {
     })
   }
 
+  const transferEth = async ({ recipient, amount }: TransferForm) => {
+    const value = ethers.parseEther(amount.toString())
+    return await sendTransaction({
+      to: recipient,
+      value: `0x${value.toString(16)}`,
+    })
+  }
+
+  const transferMutation = useMutation({
+    mutationFn: transferEth,
+    onSuccess: async (tx) => {
+      reset()
+      await refetchBalance()
+      ToastHelper.success(
+        tx?.hash
+          ? `ETH transfer submitted: ${tx.hash}`
+          : 'ETH transfer submitted'
+      )
+    },
+    onError: (error: Error) => {
+      ToastHelper.error(error.message || 'ETH transfer failed')
+    },
+  })
+
+  const transferAmount = watch('amount')
   const ethPriceNumber =
     typeof ethPrice === 'string' ? parseFloat(ethPrice) : ethPrice
 
@@ -77,6 +142,90 @@ export const Funding = () => {
             </div>
 
             <Button onClick={handleFundWallet}>Fund Account</Button>
+
+            {isEmbeddedWallet && (
+              <form
+                className="grid max-w-md gap-4 border-t pt-5"
+                onSubmit={handleSubmit((form) =>
+                  transferMutation.mutateAsync(form)
+                )}
+              >
+                <div className="space-y-1">
+                  <h3 className="text-base font-semibold text-brand-dark">
+                    Transfer ETH
+                  </h3>
+                  <p className="text-sm text-gray-600">
+                    Send ETH from this Privy wallet to another wallet on Base.
+                  </p>
+                </div>
+
+                <Controller
+                  name="recipient"
+                  control={control}
+                  rules={{
+                    required: 'Enter a recipient wallet address.',
+                    validate: (value) =>
+                      ethers.isAddress(value) ||
+                      'Enter a valid wallet address.',
+                  }}
+                  render={({ field }) => (
+                    <AddressInput
+                      withIcon
+                      value={field.value}
+                      label="Recipient wallet"
+                      onChange={(value: string) => {
+                        setValue('recipient', value, {
+                          shouldDirty: true,
+                          shouldValidate: true,
+                        })
+                      }}
+                    />
+                  )}
+                />
+                {errors.recipient?.message && (
+                  <span className="text-sm text-red-600">
+                    {errors.recipient.message}
+                  </span>
+                )}
+
+                <Input
+                  label={`Amount to transfer${
+                    transferAmount ? `: ${transferAmount} ETH` : ''
+                  }`}
+                  size="small"
+                  type="number"
+                  min={0}
+                  max={userBalance}
+                  step="any"
+                  disabled={transferMutation.isPending}
+                  {...register('amount', {
+                    valueAsNumber: true,
+                    validate: (value) => {
+                      if (!value || value <= 0) {
+                        return 'The transfer amount should be greater than 0.'
+                      }
+
+                      if (userBalance !== undefined && value > userBalance) {
+                        return `The amount should be less than the current balance of ${userBalance.toFixed(
+                          4
+                        )} ETH.`
+                      }
+
+                      return true
+                    },
+                  })}
+                  error={errors.amount?.message}
+                />
+
+                <Button
+                  type="submit"
+                  loading={transferMutation.isPending}
+                  disabled={transferMutation.isPending}
+                >
+                  Transfer ETH
+                </Button>
+              </form>
+            )}
 
             <Modal
               isOpen={showFundingModal}


### PR DESCRIPTION
Fixes #15511.

This adds the missing transfer path for Privy-based Unlock accounts that can already be funded with ETH.

What changed:
- Keeps the existing Base ETH funding flow in account settings.
- Shows a `Transfer ETH` form only when the active wallet is a Privy embedded wallet.
- Validates recipient wallet address and transfer amount against the current Base ETH balance.
- Sends native ETH on Base through Privy's existing `sendTransaction` flow.
- Refreshes the balance and shows a submitted-transaction toast after success.

Verification:
- `yarn workspace @unlock-protocol/unlock-app exec eslint src/components/interface/user-account/Funding.tsx`
- `git diff --check`

Bounty payout wallet if accepted: `0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9` for the 300 USDC on Base bounty confirmed in #15511.
