### PR TITLE
Add guide links to creation flows

### DIFF
--- a/unlock-app/src/components/content/event/Form.tsx
+++ b/unlock-app/src/components/content/event/Form.tsx
@@ -35,6 +35,7 @@ import Link from 'next/link'
 import { regexUrlPattern } from '~/utils/regexUrlPattern'
 import { ProtocolFee } from '~/components/interface/locks/Create/elements/ProtocolFee'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 // TODO replace with zod, but only once we have replaced Lock and MetadataFormData as well
 export interface NewEventForm {
@@ -252,6 +253,11 @@ export const Form = ({ onSubmit, compact = false }: FormProps) => {
 
       <form className="mb-6" onSubmit={methods.handleSubmit(processAndSubmit)}>
         <div className="grid gap-6">
+          <GuideCallout
+            description="If you are setting up ticketing for an event, this guide walks through ticket setup, RSVPs, distribution, checkout links, attendee data, and check-in."
+            href="https://unlock-protocol.com/guides/how-to-sell-nft-tickets-for-an-event/"
+            linkLabel="Read the event ticketing guide"
+          />
           <Disclosure label="Basic Information" defaultOpen>
             <p className="mb-5">
               All of these fields can also be adjusted later.

--- a/unlock-app/src/components/content/events-collection/Form.tsx
+++ b/unlock-app/src/components/content/events-collection/Form.tsx
@@ -23,6 +23,7 @@ import { WrappedAddress } from '~/components/interface/WrappedAddress'
 import { FiTrash as TrashIcon } from 'react-icons/fi'
 import { LinksField } from './LinksField'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 interface Links {
   farcaster?: string
@@ -194,6 +195,11 @@ export const EventCollectionForm = ({
 
         <form className="mb-6" onSubmit={methods.handleSubmit(handleSubmit)}>
           <div className="grid gap-6">
+            <GuideCallout
+              description="When a collection groups ticketed events, start with the event ticketing guide so each event has the right ticket, RSVP, and check-in setup."
+              href="https://unlock-protocol.com/guides/how-to-sell-nft-tickets-for-an-event/"
+              linkLabel="Read the event ticketing guide"
+            />
             {/* Basic Information */}
             <Disclosure label="Basic Information" defaultOpen>
               <p className="mb-5">

--- a/unlock-app/src/components/interface/GuideCallout.tsx
+++ b/unlock-app/src/components/interface/GuideCallout.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+
+interface GuideCalloutProps {
+  description: string
+  href: string
+  linkLabel: string
+  className?: string
+}
+
+export const GuideCallout = ({
+  description,
+  href,
+  linkLabel,
+  className = '',
+}: GuideCalloutProps) => {
+  return (
+    <div
+      className={`rounded-lg border border-brand-ui-primary bg-brand-primary p-4 text-sm text-brand-dark ${className}`}
+    >
+      <span className="font-semibold">Need help?</span> {description}{' '}
+      <Link
+        className="font-semibold underline text-brand-ui-primary"
+        href={href}
+        target="_blank"
+      >
+        {linkLabel}
+      </Link>
+    </div>
+  )
+}

--- a/unlock-app/src/components/interface/Launcher.tsx
+++ b/unlock-app/src/components/interface/Launcher.tsx
@@ -43,6 +43,26 @@ const options = [
     cta: 'Deploy a custom membership',
     href: '/locks/create',
   },
+  {
+    image: {
+      src: '/images/illustrations/deploy-lock/custom-membership.png',
+      width: 250,
+      height: 250,
+      alt: 'launch an art collection',
+    },
+    cta: 'Launch an art collection',
+    href: '/locks/create',
+  },
+  {
+    image: {
+      src: '/images/illustrations/deploy-lock/subscription.png',
+      width: 250,
+      height: 250,
+      alt: 'sell products or merchandise',
+    },
+    cta: 'Sell products or merchandise',
+    href: '/locks/create',
+  },
 ]
 
 export const Launcher = () => {

--- a/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
+++ b/unlock-app/src/components/interface/locks/Create/CreateLock.tsx
@@ -16,6 +16,7 @@ import { BsArrowLeft as ArrowBack } from 'react-icons/bs'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useProvider } from '~/hooks/useProvider'
+import { GuideCallout } from '~/components/interface/GuideCallout'
 
 export type Step = 'data' | 'summary' | 'deploy'
 
@@ -211,6 +212,12 @@ const CreateLock = ({ onSubmit, defaultValues }: CreateLockProps) => {
           />
         </div>
         <div className="md:max-w-lg">
+          <GuideCallout
+            className="mb-6"
+            description="Before deploying a membership contract, review the planning guide for benefits, tiers, duration, supply, pricing, and checkout setup."
+            href="https://unlock-protocol.com/guides/how-to-create-a-membership-program/"
+            linkLabel="Read the membership guide"
+          />
           <CreateLockForm onSubmit={onSubmit} defaultValues={defaultValues} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds a reusable creation-flow guide callout.
- Shows direct guide links at the top of membership, event, and event-collection creation forms.
- Adds Art Collection and Product/Merchandise starting points to the launcher.

Fixes #16186

## Validation
- yarn workspace @unlock-protocol/unlock-app exec eslint src/components/interface/GuideCallout.tsx src/components/interface/Launcher.tsx src/components/interface/locks/Create/CreateLock.tsx src/components/content/event/Form.tsx src/components/content/events-collection/Form.tsx
- git diff --check

Payout wallet for the bounty: 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9