### PR TITLE
fix: keep saved metadata properties in cache

### DIFF
--- a/unlock-app/src/__tests__/hooks/metadata.test.tsx
+++ b/unlock-app/src/__tests__/hooks/metadata.test.tsx
@@ -1,0 +1,104 @@
+import React, { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUpdateMetadata } from '~/hooks/metadata'
+import { locksmith } from '~/config/locksmith'
+
+vi.mock('@unlock-protocol/ui', () => ({
+  ToastHelper: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('~/config/locksmith', () => ({
+  locksmith: {
+    keyMetadata: vi.fn(),
+    lockMetadata: vi.fn(),
+    updateKeyMetadata: vi.fn(),
+    updateLockMetadata: vi.fn(),
+  },
+}))
+
+const createWrapper = (queryClient: QueryClient) => {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+describe('useUpdateMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates the metadata query cache with the saved lock metadata', async () => {
+    const lockAddress = '0x1234567890123456789012345678901234567890'
+    const network = 1
+    const queryKey = ['metadata', network, lockAddress, undefined]
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const previousMetadata = {
+      attributes: [],
+      name: 'Membership',
+    }
+    const savedMetadata = {
+      attributes: [
+        {
+          trait_type: 'Color',
+          value: 'Blue',
+        },
+        {
+          trait_type: 'Size',
+          value: 'Large',
+        },
+        {
+          trait_type: 'Access',
+          value: 'VIP',
+        },
+      ],
+      image: 'https://example.com/icon.png',
+      name: 'Membership',
+    }
+
+    queryClient.setQueryData(queryKey, previousMetadata)
+    vi.mocked(locksmith.updateLockMetadata).mockResolvedValue({
+      data: savedMetadata,
+    })
+
+    const { result } = renderHook(
+      () =>
+        useUpdateMetadata({
+          lockAddress,
+          network,
+        }),
+      {
+        wrapper: createWrapper(queryClient),
+      }
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync(savedMetadata)
+    })
+
+    expect(locksmith.updateLockMetadata).toHaveBeenCalledWith(
+      network,
+      lockAddress,
+      {
+        metadata: savedMetadata,
+      }
+    )
+    expect(queryClient.getQueryData(queryKey)).toEqual(savedMetadata)
+  })
+})

--- a/unlock-app/src/hooks/metadata.ts
+++ b/unlock-app/src/hooks/metadata.ts
@@ -43,10 +43,13 @@ export const useUpdateMetadata = ({
       console.error(error)
       ToastHelper.error('Metadata update failed')
     },
-    onSuccess: () => {
+    onSuccess: async (metadata) => {
       ToastHelper.success('Metadata updated')
-      queryClient.invalidateQueries({
-        queryKey: ['metadata', lockAddress],
+      const queryKey = ['metadata', network, lockAddress, keyId]
+
+      queryClient.setQueryData(queryKey, metadata)
+      await queryClient.invalidateQueries({
+        queryKey,
       })
     },
   })


### PR DESCRIPTION
Fixes #16246

## Summary
- update the metadata query cache with the saved metadata returned by the mutation
- invalidate the same metadata query key used by useMetadata
- add regression coverage for saving more than two properties without keeping stale zero-property metadata in cache

## Tests
- node ../.yarn/releases/yarn-4.10.3.cjs vitest run src/__tests__/hooks/metadata.test.tsx --environment=jsdom --coverage=false
- node .yarn/releases/yarn-4.10.3.cjs workspace @unlock-protocol/unlock-app lint src/hooks/metadata.ts src/__tests__/hooks/metadata.test.tsx

Note: CLA username PR is #16526.