### PR TITLE
fix(locksmith): trim whitespace from custom-email recipients

### DIFF
--- a/locksmith/__tests__/utils/normalizer.test.ts
+++ b/locksmith/__tests__/utils/normalizer.test.ts
@@ -8,6 +8,13 @@ describe('Normalizer', () => {
         'test@example.com'
       )
     })
+
+    it('trims surrounding whitespace', () => {
+      expect.assertions(1)
+      expect(Normalizer.emailAddress('  igor@gateway.fm  ')).toEqual(
+        'igor@gateway.fm'
+      )
+    })
   })
 
   describe('ethereumAddress', () => {

--- a/locksmith/__tests__/worker/tasks/sendToAll.test.ts
+++ b/locksmith/__tests__/worker/tasks/sendToAll.test.ts
@@ -1,0 +1,25 @@
+import { resolveRecipientEmail } from '../../../src/worker/tasks/sendToAll'
+
+describe('sendToAll', () => {
+  describe('resolveRecipientEmail', () => {
+    it('trims and lowercases the email so whitespace addresses are not dropped', () => {
+      expect(
+        resolveRecipientEmail({ email: '  Igor@Gateway.fm  ' })
+      ).toEqual('igor@gateway.fm')
+    })
+
+    it('reads alternative email keys regardless of case', () => {
+      expect(resolveRecipientEmail({ EmailAddress: 'a@b.com' })).toEqual(
+        'a@b.com'
+      )
+      expect(resolveRecipientEmail({ email_address: 'c@d.com' })).toEqual(
+        'c@d.com'
+      )
+    })
+
+    it('returns undefined when there is no email', () => {
+      expect(resolveRecipientEmail({ name: 'no email here' })).toBeUndefined()
+      expect(resolveRecipientEmail(undefined)).toBeUndefined()
+    })
+  })
+})

--- a/locksmith/__tests__/worker/tasks/sendToAll.test.ts
+++ b/locksmith/__tests__/worker/tasks/sendToAll.test.ts
@@ -3,9 +3,9 @@ import { resolveRecipientEmail } from '../../../src/worker/tasks/sendToAll'
 describe('sendToAll', () => {
   describe('resolveRecipientEmail', () => {
     it('trims and lowercases the email so whitespace addresses are not dropped', () => {
-      expect(
-        resolveRecipientEmail({ email: '  Igor@Gateway.fm  ' })
-      ).toEqual('igor@gateway.fm')
+      expect(resolveRecipientEmail({ email: '  Igor@Gateway.fm  ' })).toEqual(
+        'igor@gateway.fm'
+      )
     })
 
     it('reads alternative email keys regardless of case', () => {

--- a/locksmith/src/utils/normalizer.ts
+++ b/locksmith/src/utils/normalizer.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { Request } from 'express'
 export function emailAddress(input: string): string {
-  return input.toLocaleLowerCase()
+  return input.trim().toLocaleLowerCase()
 }
 
 export function ethereumAddress(input?: string): string {

--- a/locksmith/src/worker/tasks/sendToAll.ts
+++ b/locksmith/src/worker/tasks/sendToAll.ts
@@ -16,6 +16,24 @@ const Payload = z.object({
   subject: z.string(),
 })
 
+// Extracts the recipient email from a member's protected metadata, trimming
+// and lowercasing it. Returns undefined when no email is present so that
+// members without an email are skipped rather than enqueued as failing jobs.
+export const resolveRecipientEmail = (
+  protectedMetadata?: Record<string, unknown>
+): string | undefined => {
+  if (!protectedMetadata) {
+    return undefined
+  }
+  const lowercased = normalizer.toLowerCaseKeys(protectedMetadata)
+  const raw =
+    lowercased.email || lowercased.emailaddress || lowercased.email_address
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return undefined
+  }
+  return normalizer.emailAddress(raw)
+}
+
 export const sendToAllJob: Task = async (payload, helper) => {
   const parsed = await Payload.parse(payload)
   const users = await UserTokenMetadata.findAll({
@@ -24,15 +42,13 @@ export const sendToAllJob: Task = async (payload, helper) => {
       chain: parsed.network,
     },
   })
-  const recipients = await users.map((item) => {
-    const metadata = item.data?.userMetadata?.protected
-    if (!metadata) {
+  const recipients = users.map((item) => {
+    const email = resolveRecipientEmail(item.data?.userMetadata?.protected)
+    if (!email) {
       return null
     }
-    const lowercased = normalizer.toLowerCaseKeys(metadata)
     return {
-      email:
-        lowercased.email || lowercased.emailaddress || lowercased.email_address,
+      email,
       walletAddress: item.userAddress,
     }
   })


### PR DESCRIPTION
## Problem

Customers reported transactional/custom emails not arriving. Investigation traced it to the **custom email sender** ("email all members" from the dashboard): member email addresses stored with leading/trailing whitespace (e.g. `"igor@gateway.fm "`) were passed unmodified into `sendEmailJob`, whose `recipient: z.string().email()` validation rejected them.

Those recipients were **silently dropped** — the job failed and exhausted retries — while clean addresses went through. In production this is a chronic drip: ~195 member emails currently carry surrounding whitespace, and the graphile-worker failed-jobs table shows a long tail of `sendEmailJob` failures with `"Invalid email"` on whitespace addresses.

> Note: this is **separate** from the worker outage that triggered the original report (the job executor was wedged and was restarted). This PR fixes the underlying data-handling bug so these recipients stop being dropped once the queue is healthy.

## Fix

- `Normalizer.emailAddress` now **trims** in addition to lowercasing (mirrors `ethereumAddress`, which already trims).
- `sendToAllJob` resolves each recipient's email through a new pure helper `resolveRecipientEmail`, which normalizes the value and returns `undefined` when no email is present — so members without an email are **skipped** rather than enqueued as jobs guaranteed to fail.

## Tests (TDD)

- `normalizer.test.ts`: `emailAddress` trims surrounding whitespace.
- `sendToAll.test.ts`: `resolveRecipientEmail` trims/lowercases, reads alternative email keys case-insensitively, and returns `undefined` when absent.

Both written test-first (watched fail, then implemented). `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)