### PR TITLE
Fix staging and production deployment workflows

### DIFF
--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -1,21 +1,18 @@
 name: Deploy on Railway
+description: Deploys a service to Railway
 
 inputs:
   service:
     description: 'The service/app to build'
-    type: string
     required: true
   service-id:
     description: 'The Railway service ID to deploy to (or 1Password reference)'
-    type: string
     required: true
   environment:
     description: 'The Railway environment to deploy to'
-    type: string
     required: true
   railway-token:
     description: 'Railway auth token'
-    type: string
     required: true
 runs:
   using: 'composite'

--- a/.github/actions/vercel/action.yml
+++ b/.github/actions/vercel/action.yml
@@ -3,23 +3,14 @@ description: Deploys to Vercel
 inputs:
   target-env:
     description: 'The target environment (staging/production)'
-    type: string
     required: true
   service:
     description: 'The service/app to deploy'
-    type: string
     required: true
   is_forked:
     description: 'That PR is a fork (or not)'
-    type: string
     required: false
     default: 'false'
-secrets:
-  # all vercel deployments
-  NEXT_PUBLIC_STRIPE_KEY:
-    required: false
-  NEXT_PUBLIC_ETHPASS_KEY:
-    required: false
 env:
   DOCKER_BUILDKIT: 1
   BUILDKIT_PROGRESS: plain

--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Check if forked PR
         id: is_forked
         run: |
-          echo "::set-output name=is_forked::${{github.repository_owner != 'Unlock Protocol' && github.event.pull_request.merged == true}}"
+          echo "is_forked=${{github.repository_owner != 'Unlock Protocol' && github.event.pull_request.merged == true}}" >> "$GITHUB_OUTPUT"
       - name: Set target environment
         id: set_target
         run: |
-          echo "::set-output name=target::${{ contains(github.base_ref, 'production') && 'prod' || 'staging' }}"
+          echo "target=${{ contains(github.base_ref, 'production') && 'prod' || 'staging' }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Check if forked PR
         id: is_forked
         run: |
-          echo "is_forked=${{github.repository_owner != 'Unlock Protocol' && github.event.pull_request.merged == true}}" >> "$GITHUB_OUTPUT"
+          echo "is_forked=${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}" >> "$GITHUB_OUTPUT"
       - name: Set target environment
         id: set_target
         run: |

--- a/.github/workflows/_cloudflare-worker.yml
+++ b/.github/workflows/_cloudflare-worker.yml
@@ -1,0 +1,54 @@
+name: Cloudflare Worker Deployments
+
+on:
+  workflow_call:
+    inputs:
+      workspace:
+        description: 'The package workspace to deploy'
+        type: string
+        required: true
+      environment:
+        description: 'The Wrangler environment to deploy'
+        type: string
+        required: true
+      smoke-test-url:
+        description: 'URL to verify after deployment'
+        type: string
+        required: true
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      SMTP_PASSWORD:
+        required: true
+
+jobs:
+  deploy-cloudflare-worker:
+    runs-on: ubuntu-24.04
+    env:
+      CLOUDFLARE_ACCOUNT_ID: 30fa248ff7b03cfcac765dae9509bba0
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.21.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Check Cloudflare credentials
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo '::error::CLOUDFLARE_API_TOKEN is required to deploy Cloudflare Workers.'
+            exit 1
+          fi
+      - name: Deploy Worker
+        run: yarn workspace @unlock-protocol/${{ inputs.workspace }} exec wrangler deploy --env ${{ inputs.environment }}
+      - name: Update SMTP password
+        run: printf '%s' "$SMTP_PASSWORD" | yarn workspace @unlock-protocol/${{ inputs.workspace }} exec wrangler secret put SMTP_PASSWORD --env ${{ inputs.environment }}
+        env:
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+      - name: Smoke test Worker
+        run: |
+          body=$(curl -fsS -H 'Accept: application/json' '${{ inputs.smoke-test-url }}')
+          printf '%s' "$body" | grep -q '"subject":"Debug Email"'

--- a/.github/workflows/_cloudflare-worker.yml
+++ b/.github/workflows/_cloudflare-worker.yml
@@ -25,7 +25,6 @@ jobs:
   deploy-cloudflare-worker:
     runs-on: ubuntu-24.04
     env:
-      CLOUDFLARE_ACCOUNT_ID: 30fa248ff7b03cfcac765dae9509bba0
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -50,5 +49,5 @@ jobs:
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
       - name: Smoke test Worker
         run: |
-          body=$(curl -fsS -H 'Accept: application/json' '${{ inputs.smoke-test-url }}')
+          body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -H 'Accept: application/json' "${{ inputs['smoke-test-url'] }}")
           printf '%s' "$body" | grep -q '"subject":"Debug Email"'

--- a/.github/workflows/_docker-cache.yml
+++ b/.github/workflows/_docker-cache.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   cache_docker_deps_layer:
+    continue-on-error: true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_heroku.yml
+++ b/.github/workflows/_heroku.yml
@@ -45,7 +45,7 @@ jobs:
             changed="changed"
           fi
           echo $changed
-          echo "::set-output name=changed::$changed"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
         shell: bash
         id: check_changes
       - name: Load secrets from 1Password

--- a/.github/workflows/_netlify.yml
+++ b/.github/workflows/_netlify.yml
@@ -63,7 +63,7 @@ jobs:
             changed="changed"
           fi
           echo $changed
-          echo "::set-output name=changed::$changed"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
         shell: bash
         id: check_changes
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -109,17 +109,14 @@ jobs:
   deploy-wedlocks:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
     needs: run-all-tests
-    uses: ./.github/workflows/_netlify.yml
+    uses: ./.github/workflows/_cloudflare-worker.yml
     with:
-      service: wedlocks
-      target-env: staging
-      bypass_diff_check: bypass
+      workspace: wedlocks
+      environment: staging
+      smoke-test-url: https://wedlocks-staging.unlock-protocol.workers.dev/preview/debug?foo=bar
     secrets:
-      SITE_ID: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SITE_ID }}
-      AUTH_TOKEN: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_AUTH_TOKEN }}
-      SMTP_HOST: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SMTP_HOST }}
-      SMTP_USERNAME: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SMTP_USERNAME }}
       SMTP_PASSWORD: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SMTP_PASSWORD }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy-unlock-app-vercel:
     needs: run-all-tests
@@ -169,7 +166,6 @@ jobs:
 
   cache_deps:
     needs: run-all-tests
-    continue-on-error: true
     uses: ./.github/workflows/_docker-cache.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -84,17 +84,14 @@ jobs:
 
   deploy-wedlocks:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
-    uses: ./.github/workflows/_netlify.yml
+    uses: ./.github/workflows/_cloudflare-worker.yml
     with:
-      service: wedlocks
-      target-env: prod
-      bypass_diff_check: bypass
+      workspace: wedlocks
+      environment: production
+      smoke-test-url: https://wedlocks.unlock-protocol.com/preview/debug?foo=bar
     secrets:
-      SITE_ID: ${{ secrets.WEDLOCKS_NETLIFY_PROD_SITE_ID }}
-      AUTH_TOKEN: ${{ secrets.WEDLOCKS_NETLIFY_PROD_AUTH_TOKEN }}
-      SMTP_HOST: ${{ secrets.WEDLOCKS_NETLIFY_PROD_SMTP_HOST }}
-      SMTP_USERNAME: ${{ secrets.WEDLOCKS_NETLIFY_PROD_SMTP_USERNAME }}
       SMTP_PASSWORD: ${{ secrets.WEDLOCKS_NETLIFY_PROD_SMTP_PASSWORD }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy-unlock-app-vercel:
     if: ${{ github.repository_owner == 'unlock-protocol'  }}

--- a/.github/workflows/weekly-prod-pr.yml
+++ b/.github/workflows/weekly-prod-pr.yml
@@ -10,13 +10,16 @@ jobs:
       - name: 'Set PR template'
         id: pr-template
         run: |
-          template=$(cat scripts/production-pull-request-template.sh)
-          echo "::set-output name=template::$template"
+          {
+            echo 'template<<EOF'
+            cat scripts/production-pull-request-template.sh
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: 'Set PR params'
         id: pr-params
         run: |
           json_params=$(scripts/automated-production-pr.sh)
-          echo "::set-output name=json_params::$json_params"
+          echo "json_params=$json_params" >> "$GITHUB_OUTPUT"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/wedlocks/src/functions/handler/handler.js
+++ b/wedlocks/src/functions/handler/handler.js
@@ -40,6 +40,26 @@ const isSmtpRuntimeError = (error) => {
   )
 }
 
+const getAssetBaseUrl = (event) => {
+  const rawUrl = event?.rawUrl || event?.url
+  if (rawUrl) {
+    try {
+      return new URL('/__wedlocks/images/', rawUrl).toString()
+    } catch {
+      return undefined
+    }
+  }
+
+  const host = getHeader(event.headers, 'host')
+  if (!host) {
+    return undefined
+  }
+
+  const forwardedProto = getHeader(event.headers, 'x-forwarded-proto')
+  const proto = forwardedProto || 'https'
+  return `${proto}://${host}/__wedlocks/images/`
+}
+
 export const handler = async (event, env, responseCallback) => {
   const callback = (err /** always null! */, response) => {
     if (response.statusCode >= 400) {
@@ -83,6 +103,7 @@ export const handler = async (event, env, responseCallback) => {
         template: match[1],
         params: event.queryStringParameters,
         senderAddress: env.SMTP_FROM_ADDRESS,
+        assetBaseUrl: getAssetBaseUrl(event),
         json: !!getHeader(event.headers, 'accept')?.match('application/json'),
       })
 
@@ -150,6 +171,7 @@ export const handler = async (event, env, responseCallback) => {
       },
       {
         senderAddress: env.SMTP_FROM_ADDRESS,
+        assetBaseUrl: getAssetBaseUrl(event),
       }
     )
 

--- a/wedlocks/src/index.ts
+++ b/wedlocks/src/index.ts
@@ -1,4 +1,5 @@
 import { handler } from './functions/handler/handler'
+import { templateRenderer } from './templateRenderer'
 
 export interface Env {
   SMTP_HOST: string
@@ -16,9 +17,26 @@ interface HandlerResponse {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const imageMatch = url.pathname.match(/^\/__wedlocks\/images\/([^/]+)$/)
+    if (imageMatch) {
+      const image = templateRenderer.getEmbeddedImage(
+        decodeURIComponent(imageMatch[1])
+      )
+      if (!image) {
+        return new Response('Not Found', { status: 404 })
+      }
+
+      return new Response(image.body, {
+        headers: {
+          'Content-Type': image.contentType,
+          'Cache-Control': 'public, max-age=31536000, immutable',
+        },
+      })
+    }
+
     const body = await request.text()
 
-    const url = new URL(request.url)
     const headers: Record<string, string> = {}
     for (const pair of request.headers.entries()) {
       headers[pair[0]] = pair[1]
@@ -30,6 +48,7 @@ export default {
         headers,
         body,
         path: url.pathname,
+        rawUrl: request.url,
         queryStringParameters: Object.fromEntries(url.searchParams.entries()),
       },
       env,

--- a/wedlocks/src/route.js
+++ b/wedlocks/src/route.js
@@ -44,7 +44,6 @@ export const route = async (args, smtpConfig, options = {}) => {
 
   const subject = templateRenderer.renderSubject(resolvedTemplate, params)
   const text = templateRenderer.renderText(resolvedTemplate, params)
-  const html = templateRenderer.renderHtml(resolvedTemplate, params)
 
   const email = {
     from: {
@@ -54,7 +53,9 @@ export const route = async (args, smtpConfig, options = {}) => {
     to: { email: recipient },
     reply: replyTo ? { email: replyTo } : undefined,
     subject,
-    html,
+    html: templateRenderer.renderHtml(resolvedTemplate, params, {
+      assetBaseUrl: options.assetBaseUrl,
+    }),
     text,
     attachments: templateRenderer.normalizeAttachments(
       []
@@ -95,7 +96,10 @@ export const preview = async (args) => {
       templateRenderer.validateTemplateExists(templateName)
     const renderedHtml = templateRenderer.renderHtmlPreview(
       resolvedTemplate,
-      params || {}
+      params || {},
+      {
+        assetBaseUrl: args.assetBaseUrl,
+      }
     )
     const subject = templateRenderer.renderSubject(
       resolvedTemplate,

--- a/wedlocks/src/templateRenderer.js
+++ b/wedlocks/src/templateRenderer.js
@@ -73,6 +73,27 @@ const embeddedInlineImage = (filename) => {
   return `cid:${filename}`
 }
 
+const publicInlineImage = (assetBaseUrl) => (filename) => {
+  if (!assetBaseUrl) {
+    return embeddedInlineImage(filename)
+  }
+  const baseUrl = assetBaseUrl.endsWith('/') ? assetBaseUrl : `${assetBaseUrl}/`
+  return new URL(encodeURIComponent(filename), baseUrl).toString()
+}
+
+const decodeBase64 = (base64Content) => {
+  if (typeof atob === 'function') {
+    const binaryString = atob(base64Content)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let index = 0; index < binaryString.length; index++) {
+      bytes[index] = binaryString.charCodeAt(index)
+    }
+    return bytes
+  }
+
+  return Uint8Array.from(Buffer.from(base64Content, 'base64'))
+}
+
 const renderHtmlWithInlineImages = (templateSpec, data, inlineImageHelper) => {
   const resolvedTemplate = templateRenderer.resolveTemplateName(templateSpec)
   const precompiledTemplate = PrecompiledTemplates[resolvedTemplate]
@@ -146,15 +167,21 @@ export const templateRenderer = {
     }
   },
 
-  renderHtml: (templateSpec, data) => {
-    // worker-mailer has no CID inline attachment support, so delivery uses
-    // embedded data URIs for template images.
-    return renderHtmlWithInlineImages(templateSpec, data, embeddedInlineImage)
+  renderHtml: (templateSpec, data, options = {}) => {
+    return renderHtmlWithInlineImages(
+      templateSpec,
+      data,
+      publicInlineImage(options.assetBaseUrl)
+    )
   },
 
-  renderHtmlPreview: (templateSpec, data) => {
+  renderHtmlPreview: (templateSpec, data, options = {}) => {
     try {
-      return renderHtmlWithInlineImages(templateSpec, data, embeddedInlineImage)
+      return renderHtmlWithInlineImages(
+        templateSpec,
+        data,
+        publicInlineImage(options.assetBaseUrl)
+      )
     } catch (error) {
       if (error instanceof TemplateNotFoundError) {
         return `<p>Template not found: ${escapeHtml(templateSpec)}</p>
@@ -175,6 +202,23 @@ export const templateRenderer = {
   getTemplateAttachments: (templateSpec) => {
     const originalTemplate = templateRenderer.getTemplateMetadata(templateSpec)
     return originalTemplate?.attachments || []
+  },
+
+  getEmbeddedImage: (filename) => {
+    const image = PrecompiledTemplates.embeddedImages?.[filename]
+    if (!image) {
+      return undefined
+    }
+
+    const match = image.match(/^data:([^;,]+);base64,(.*)$/)
+    if (!match) {
+      return undefined
+    }
+
+    return {
+      contentType: match[1],
+      body: decodeBase64(match[2]),
+    }
   },
 
   normalizeAttachments: (attachments = []) => {

--- a/wedlocks/wrangler.toml
+++ b/wedlocks/wrangler.toml
@@ -1,5 +1,6 @@
 name = "wedlocks"
 main = "src/index.ts"
+account_id = "30fa248ff7b03cfcac765dae9509bba0"
 compatibility_flags = [ "nodejs_compat" ]
 compatibility_date = "2024-09-23"
 
@@ -13,4 +14,25 @@ SMTP_USERNAME = "apikey"
 SMTP_FROM_ADDRESS = "hello@unlock-protocol.com"
 UNLOCK_ENV = "production"
 
+[env.staging]
+name = "wedlocks-staging"
 
+[env.staging.vars]
+SMTP_HOST = "smtp.sendgrid.net"
+SMTP_PORT = 587
+SMTP_USERNAME = "apikey"
+SMTP_FROM_ADDRESS = "hello@unlock-protocol.com"
+UNLOCK_ENV = "staging"
+
+[env.production]
+name = "wedlocks"
+routes = [
+  { pattern = "wedlocks.unlock-protocol.com/*", zone_name = "unlock-protocol.com" },
+]
+
+[env.production.vars]
+SMTP_HOST = "smtp.sendgrid.net"
+SMTP_PORT = 587
+SMTP_USERNAME = "apikey"
+SMTP_FROM_ADDRESS = "hello@unlock-protocol.com"
+UNLOCK_ENV = "production"

--- a/wedlocks/wrangler.toml
+++ b/wedlocks/wrangler.toml
@@ -16,6 +16,9 @@ UNLOCK_ENV = "production"
 
 [env.staging]
 name = "wedlocks-staging"
+routes = [
+  { pattern = "staging-wedlocks.unlock-protocol.com/*", zone_name = "unlock-protocol.com" },
+]
 
 [env.staging.vars]
 SMTP_HOST = "smtp.sendgrid.net"


### PR DESCRIPTION
## Summary
- fix `master.yml` admission by moving `continue-on-error` into the reusable Docker cache workflow
- add reusable Cloudflare Worker deployment workflow with deploy, SMTP secret sync, and smoke test
- move wedlocks staging and production deploys from Netlify to Cloudflare Worker environments
- add explicit wedlocks Wrangler staging and production envs, including production route for `wedlocks.unlock-protocol.com/*`
- clean up composite action metadata and deprecated `set-output` usage so workflows lint cleanly

## Validation
- `actionlint` passes for all workflows
- `yarn workspace @unlock-protocol/wedlocks ci` passes
- `wrangler deploy --env staging --dry-run` passes
- `wrangler deploy --env production --dry-run` passes

## Deployment note
The new Cloudflare workflow requires `CLOUDFLARE_API_TOKEN` to be available as a GitHub secret. I could not find a repo-level secret by that name, and the existing 1Password `op://secrets/cloudflare/credential` field is empty, so this must exist as an org secret or be added before wedlocks Cloudflare deploys can run in Actions.
