### PR TITLE
Fix wedlocks staging smoke test URL

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -113,7 +113,7 @@ jobs:
     with:
       workspace: wedlocks
       environment: staging
-      smoke-test-url: https://wedlocks-staging.unlock-protocol.workers.dev/preview/debug?foo=bar
+      smoke-test-url: https://staging-wedlocks.unlock-protocol.com/preview/debug?foo=bar
     secrets:
       SMTP_PASSWORD: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SMTP_PASSWORD }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- point the master wedlocks Cloudflare smoke test at the routed staging hostname instead of workers.dev
- keep production unchanged; it already uses the routed hostname

## Root cause
The post-merge wedlocks deploy job would fail its smoke test even after credentials are fixed because https://wedlocks-staging.unlock-protocol.workers.dev currently returns Cloudflare 1042/404, while the deployed Worker is exposed at staging-wedlocks.unlock-protocol.com.

## Validation
- curl -H 'Accept: application/json' https://staging-wedlocks.unlock-protocol.com/preview/debug?foo=bar returned subject=Debug Email
- verified rendered HTML has hosted __wedlocks/images URLs and no data:image sources
- git diff --check -- .github/workflows/master.yml