### PR TITLE
[codex] unify Cloudflare Worker deployments

### DIFF
--- a/.github/workflows/_cloudflare-worker.yml
+++ b/.github/workflows/_cloudflare-worker.yml
@@ -43,7 +43,7 @@ jobs:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
       WORKSPACE: ${{ inputs.workspace }}
-      WRANGLER_ENVIRONMENT: ${{ inputs.wrangler-environment }}
+      WRANGLER_ENVIRONMENT: ${{ inputs['wrangler-environment'] }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6

--- a/.github/workflows/_cloudflare-worker.yml
+++ b/.github/workflows/_cloudflare-worker.yml
@@ -7,25 +7,43 @@ on:
         description: 'The package workspace to deploy'
         type: string
         required: true
-      environment:
-        description: 'The Wrangler environment to deploy'
+      wrangler-environment:
+        description: 'The optional Wrangler environment to deploy'
         type: string
-        required: true
-      smoke-test-url:
-        description: 'URL to verify after deployment'
+        required: false
+        default: ''
+      sync-secrets-command:
+        description: 'Optional command to sync Worker secrets before deployment'
+        type: string
+        required: false
+        default: ''
+      post-deploy-command:
+        description: 'Optional command to run after deployment'
+        type: string
+        required: false
+        default: ''
+      smoke-test-command:
+        description: 'Command to verify the Worker after deployment'
         type: string
         required: true
     secrets:
       CLOUDFLARE_API_TOKEN:
         required: true
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: false
       SMTP_PASSWORD:
-        required: true
+        required: false
 
 jobs:
   deploy-cloudflare-worker:
+    name: Deploy ${{ inputs.workspace }}
     runs-on: ubuntu-24.04
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+      WORKSPACE: ${{ inputs.workspace }}
+      WRANGLER_ENVIRONMENT: ${{ inputs.wrangler-environment }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -41,13 +59,32 @@ jobs:
             echo '::error::CLOUDFLARE_API_TOKEN is required to deploy Cloudflare Workers.'
             exit 1
           fi
-      - name: Deploy Worker
-        run: yarn workspace @unlock-protocol/${{ inputs.workspace }} exec wrangler deploy --env ${{ inputs.environment }}
-      - name: Update SMTP password
-        run: printf '%s' "$SMTP_PASSWORD" | yarn workspace @unlock-protocol/${{ inputs.workspace }} exec wrangler secret put SMTP_PASSWORD --env ${{ inputs.environment }}
-        env:
-          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-      - name: Smoke test Worker
+      - name: Check 1Password credentials
+        if: ${{ inputs.sync-secrets-command != '' }}
         run: |
-          body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -H 'Accept: application/json' "${{ inputs['smoke-test-url'] }}")
-          printf '%s' "$body" | grep -q '"subject":"Debug Email"'
+          if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+            echo '::error::OP_SERVICE_ACCOUNT_TOKEN is required to sync Cloudflare Worker secrets from 1Password.'
+            exit 1
+          fi
+      - name: Install 1Password CLI
+        if: ${{ inputs.sync-secrets-command != '' }}
+        uses: 1Password/install-cli-action@v1
+      - name: Sync Worker secrets
+        if: ${{ inputs.sync-secrets-command != '' }}
+        run: ${{ inputs.sync-secrets-command }}
+        shell: bash
+      - name: Deploy Worker
+        run: |
+          args=(deploy)
+          if [ -n "$WRANGLER_ENVIRONMENT" ]; then
+            args+=(--env "$WRANGLER_ENVIRONMENT")
+          fi
+
+          yarn workspace "$WORKSPACE" exec wrangler "${args[@]}"
+      - name: Run post-deploy command
+        if: ${{ inputs.post-deploy-command != '' }}
+        run: ${{ inputs.post-deploy-command }}
+        shell: bash
+      - name: Smoke test Worker
+        run: ${{ inputs.smoke-test-command }}
+        shell: bash

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -21,6 +21,7 @@ on:
           "unlock-protocol-com",
           "wedlocks",
           "provider",
+          "graph-service",
           "unlock-app",
           "governance-app",
           "packages/core"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -111,9 +111,18 @@ jobs:
     needs: run-all-tests
     uses: ./.github/workflows/_cloudflare-worker.yml
     with:
-      workspace: wedlocks
-      environment: staging
-      smoke-test-url: https://staging-wedlocks.unlock-protocol.com/preview/debug?foo=bar
+      workspace: '@unlock-protocol/wedlocks'
+      wrangler-environment: staging
+      post-deploy-command: |
+        if [ -z "$SMTP_PASSWORD" ]; then
+          echo '::error::SMTP_PASSWORD is required to update wedlocks SMTP credentials.'
+          exit 1
+        fi
+
+        printf '%s' "$SMTP_PASSWORD" | yarn workspace "$WORKSPACE" exec wrangler secret put SMTP_PASSWORD --env "$WRANGLER_ENVIRONMENT"
+      smoke-test-command: |
+        body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -H 'Accept: application/json' 'https://staging-wedlocks.unlock-protocol.com/preview/debug?foo=bar')
+        printf '%s' "$body" | grep -q '"subject":"Debug Email"'
     secrets:
       SMTP_PASSWORD: ${{ secrets.WEDLOCKS_NETLIFY_STAGING_SMTP_PASSWORD }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -86,12 +86,51 @@ jobs:
     if: ${{ github.repository_owner == 'unlock-protocol' }}
     uses: ./.github/workflows/_cloudflare-worker.yml
     with:
-      workspace: wedlocks
-      environment: production
-      smoke-test-url: https://wedlocks.unlock-protocol.com/preview/debug?foo=bar
+      workspace: '@unlock-protocol/wedlocks'
+      wrangler-environment: production
+      post-deploy-command: |
+        if [ -z "$SMTP_PASSWORD" ]; then
+          echo '::error::SMTP_PASSWORD is required to update wedlocks SMTP credentials.'
+          exit 1
+        fi
+
+        printf '%s' "$SMTP_PASSWORD" | yarn workspace "$WORKSPACE" exec wrangler secret put SMTP_PASSWORD --env "$WRANGLER_ENVIRONMENT"
+      smoke-test-command: |
+        body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -H 'Accept: application/json' 'https://wedlocks.unlock-protocol.com/preview/debug?foo=bar')
+        printf '%s' "$body" | grep -q '"subject":"Debug Email"'
     secrets:
       SMTP_PASSWORD: ${{ secrets.WEDLOCKS_NETLIFY_PROD_SMTP_PASSWORD }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-rpc-provider:
+    if: ${{ github.repository_owner == 'unlock-protocol' }}
+    uses: ./.github/workflows/_cloudflare-worker.yml
+    with:
+      workspace: '@unlock-protocol/provider'
+      sync-secrets-command: yarn workspace @unlock-protocol/provider set-env-vars
+      smoke-test-command: |
+        body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS \
+          -H 'Content-Type: application/json' \
+          --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+          'https://rpc.unlock-protocol.com/1')
+        printf '%s' "$body" | grep -q '"result":"0x1"'
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  deploy-graph-service:
+    if: ${{ github.repository_owner == 'unlock-protocol' }}
+    uses: ./.github/workflows/_cloudflare-worker.yml
+    with:
+      workspace: graph-service
+      sync-secrets-command: yarn workspace graph-service set-graph-urls
+      smoke-test-command: |
+        headers=$(mktemp)
+        curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -D "$headers" -o /dev/null 'https://subgraph.unlock-protocol.com/1'
+        grep -iq '^location: https://thegraph.com/explorer/subgraphs/' "$headers"
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
   deploy-unlock-app-vercel:
     if: ${{ github.repository_owner == 'unlock-protocol'  }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,7 @@ jobs:
         "subgraph",
         "governance",
         "provider",
+        "graph-service",
         "unlock-protocol-com",
         "wedlocks",
         "unlock-app",
@@ -49,6 +50,30 @@ jobs:
   # the check for changes in network files is included within the workflow itself
   networks-changed:
     uses: ./.github/workflows/_networks.yml
+
+  cloudflare-deploy-credentials:
+    needs: check-changes
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (contains(fromJson(needs.check-changes.outputs.changed), 'wedlocks') || contains(fromJson(needs.check-changes.outputs.changed), 'provider') || contains(fromJson(needs.check-changes.outputs.changed), 'graph-service')) }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify Cloudflare API token
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo '::error::CLOUDFLARE_API_TOKEN is required to deploy Cloudflare Workers.'
+            exit 1
+          fi
+
+          response=$(curl -sS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/30fa248ff7b03cfcac765dae9509bba0")
+          success=$(printf '%s' "$response" | jq -r '.success')
+
+          if [ "$success" != "true" ]; then
+            echo '::error::CLOUDFLARE_API_TOKEN cannot access Cloudflare account 30fa248ff7b03cfcac765dae9509bba0.'
+            printf '%s' "$response" | jq -r '.errors[]?.message'
+            exit 1
+          fi
 
   # Vercel Deployments
   deploy-unlock-protocol-com:

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -103,7 +103,7 @@ services:
       args:
         BUILD_DIR: graph-service
     ports:
-      - 8788:8788
+      - 8788:8787
 
   unlock-protocol-com:
     # Container for the static site

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -90,6 +90,21 @@ services:
     ports:
       - 8787:8787
 
+  graph-service:
+    # Container for the Cloudflare Graph Service worker
+    env_file:
+      - ./${UNLOCK_ENV}.env
+    image: graph-service
+    build:
+      context: ../
+      target: dev
+      cache_from:
+        - unlockprotocol/unlock-dev
+      args:
+        BUILD_DIR: graph-service
+    ports:
+      - 8788:8788
+
   unlock-protocol-com:
     # Container for the static site
     env_file:

--- a/graph-service/README.md
+++ b/graph-service/README.md
@@ -37,6 +37,8 @@ The tests cover various scenarios including:
 
 ## Deployment
 
+Production deployments run from the `production` branch through the shared Cloudflare Worker GitHub Actions workflow.
+
 To deploy the service to Cloudflare Workers:
 
 ```

--- a/graph-service/package.json
+++ b/graph-service/package.json
@@ -12,6 +12,7 @@
     "dev": "yarn wrangler dev",
     "deploy": "yarn wrangler deploy",
     "set-graph-urls": "op run --env-file=.op.env -- ./src/scripts/set-graph-urls.sh",
+    "ci": "yarn test",
     "test": "vitest"
   }
 }

--- a/graph-service/src/index.ts
+++ b/graph-service/src/index.ts
@@ -2,6 +2,14 @@ import { getSubgraphUrl } from './networks'
 import { Env, GraphQLRequest } from './types'
 import networks from '@unlock-protocol/networks'
 
+const getHostname = (value: string) => {
+  try {
+    return new URL(value).hostname
+  } catch {
+    return 'invalid-url'
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Define CORS headers to allow cross-origin requests
@@ -90,12 +98,12 @@ export default {
       })
 
       if (graphResponse.status !== 200) {
-        console.log({
+        console.log('Graph service upstream returned non-200', {
           status: graphResponse.status,
-          subgraphUrl,
-          query,
-          variables,
-          responseData,
+          statusText: graphResponse.statusText,
+          networkId,
+          subgraphHost: getHostname(subgraphUrl),
+          responseBytes: responseData.length,
         })
       }
 

--- a/graph-service/src/index.ts
+++ b/graph-service/src/index.ts
@@ -29,8 +29,9 @@ export default {
       })
     }
     const networkId = matched[1]
+    const networkConfig = networks[networkId]
 
-    const { graphId } = networks[networkId].subgraph
+    const graphId = networkConfig?.subgraph?.graphId
 
     if (request.method === 'GET' && graphId) {
       return new Response(JSON.stringify({ graphId }), {
@@ -69,38 +70,46 @@ export default {
       })
     }
 
-    // Forward the GraphQL request to the subgraph
-    const graphResponse = await fetch(subgraphUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query, variables }),
-    })
+    try {
+      // Forward the GraphQL request to the subgraph
+      const graphResponse = await fetch(subgraphUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+      })
 
-    // Extract response data and headers
-    const responseData = await graphResponse.text()
-    const responseHeaders = new Headers(graphResponse.headers)
+      // Extract response data and headers
+      const responseData = await graphResponse.text()
+      const responseHeaders = new Headers(graphResponse.headers)
 
-    // Append CORS headers to the response
-    Object.entries(corsHeaders).forEach(([key, value]) => {
-      responseHeaders.set(key, value)
-    })
+      // Append CORS headers to the response
+      Object.entries(corsHeaders).forEach(([key, value]) => {
+        responseHeaders.set(key, value)
+      })
 
-    if (graphResponse.status !== 200) {
-      console.log({
+      if (graphResponse.status !== 200) {
+        console.log({
+          status: graphResponse.status,
+          subgraphUrl,
+          query,
+          variables,
+          responseData,
+        })
+      }
+
+      // Return the response from the subgraph
+      return new Response(responseData, {
         status: graphResponse.status,
-        subgraphUrl,
-        query,
-        variables,
-        responseData,
+        headers: responseHeaders,
+      })
+    } catch (error) {
+      console.error('Error forwarding graph request:', error)
+      return new Response('Internal Server Error', {
+        status: 500,
+        headers: corsHeaders,
       })
     }
-
-    // Return the response from the subgraph
-    return new Response(responseData, {
-      status: graphResponse.status,
-      headers: responseHeaders,
-    })
   },
 }

--- a/graph-service/src/scripts/set-graph-urls.sh
+++ b/graph-service/src/scripts/set-graph-urls.sh
@@ -1,23 +1,74 @@
 #!/bin/bash
 
-read -r -d '' FILE << EOM
-{
-  "MAINNET_SUBGRAPH": "$MAINNET_SUBGRAPH",
-  "OPTIMISM_SUBGRAPH": "$OPTIMISM_SUBGRAPH",
-  "BSC_SUBGRAPH": "$BSC_SUBGRAPH",
-  "GNOSIS_SUBGRAPH": "$GNOSIS_SUBGRAPH",
-  "POLYGON_SUBGRAPH": "$POLYGON_SUBGRAPH",
-  "ARBITRUM_SUBGRAPH": "$ARBITRUM_SUBGRAPH",
-  "CELO_SUBGRAPH": "$CELO_SUBGRAPH",
-  "AVALANCHE_SUBGRAPH": "$AVALANCHE_SUBGRAPH",
-  "BASE_SUBGRAPH": "$BASE_SUBGRAPH",
-  "BASE_SEPOLIA_SUBGRAPH": "$BASE_SEPOLIA_SUBGRAPH",
-  "SEPOLIA_SUBGRAPH": "$SEPOLIA_SUBGRAPH",
-  "LINEA_SUBGRAPH": "$LINEA_SUBGRAPH",
-  "SCROLL_SUBGRAPH": "$SCROLL_SUBGRAPH",
-  "ZKSYNC_SUBGRAPH": "$ZKSYNC_SUBGRAPH",
-  "ZKEVM_SUBGRAPH": "$ZKEVM_SUBGRAPH"
-} 
-EOM
+set -eu
 
-echo $FILE | yarn wrangler secret:bulk
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not installed."; exit 1; }
+
+REQUIRED_VARS=(
+  MAINNET_SUBGRAPH
+  OPTIMISM_SUBGRAPH
+  BSC_SUBGRAPH
+  GNOSIS_SUBGRAPH
+  POLYGON_SUBGRAPH
+  ARBITRUM_SUBGRAPH
+  CELO_SUBGRAPH
+  AVALANCHE_SUBGRAPH
+  BASE_SUBGRAPH
+  BASE_SEPOLIA_SUBGRAPH
+  SEPOLIA_SUBGRAPH
+  LINEA_SUBGRAPH
+  SCROLL_SUBGRAPH
+  ZKSYNC_SUBGRAPH
+  ZKEVM_SUBGRAPH
+)
+
+MISSING=()
+for VAR in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!VAR:-}" ]; then
+    MISSING+=("$VAR")
+  fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "ERROR: The following required environment variables are not set:"
+  for VAR in "${MISSING[@]}"; do
+    echo "  - $VAR"
+  done
+  echo "Run 'op run --env-file=.op.env -- ./src/scripts/set-graph-urls.sh' to load from 1Password."
+  exit 1
+fi
+
+echo "All required graph endpoint variables are set. Pushing secrets to Cloudflare..."
+jq -n \
+  --arg mainnet "$MAINNET_SUBGRAPH" \
+  --arg optimism "$OPTIMISM_SUBGRAPH" \
+  --arg bsc "$BSC_SUBGRAPH" \
+  --arg gnosis "$GNOSIS_SUBGRAPH" \
+  --arg polygon "$POLYGON_SUBGRAPH" \
+  --arg arbitrum "$ARBITRUM_SUBGRAPH" \
+  --arg celo "$CELO_SUBGRAPH" \
+  --arg avalanche "$AVALANCHE_SUBGRAPH" \
+  --arg base "$BASE_SUBGRAPH" \
+  --arg baseSepolia "$BASE_SEPOLIA_SUBGRAPH" \
+  --arg sepolia "$SEPOLIA_SUBGRAPH" \
+  --arg linea "$LINEA_SUBGRAPH" \
+  --arg scroll "$SCROLL_SUBGRAPH" \
+  --arg zksync "$ZKSYNC_SUBGRAPH" \
+  --arg zkevm "$ZKEVM_SUBGRAPH" \
+  '{
+    MAINNET_SUBGRAPH: $mainnet,
+    OPTIMISM_SUBGRAPH: $optimism,
+    BSC_SUBGRAPH: $bsc,
+    GNOSIS_SUBGRAPH: $gnosis,
+    POLYGON_SUBGRAPH: $polygon,
+    ARBITRUM_SUBGRAPH: $arbitrum,
+    CELO_SUBGRAPH: $celo,
+    AVALANCHE_SUBGRAPH: $avalanche,
+    BASE_SUBGRAPH: $base,
+    BASE_SEPOLIA_SUBGRAPH: $baseSepolia,
+    SEPOLIA_SUBGRAPH: $sepolia,
+    LINEA_SUBGRAPH: $linea,
+    SCROLL_SUBGRAPH: $scroll,
+    ZKSYNC_SUBGRAPH: $zksync,
+    ZKEVM_SUBGRAPH: $zkevm
+  }' | yarn wrangler secret bulk

--- a/graph-service/src/scripts/set-graph-urls.sh
+++ b/graph-service/src/scripts/set-graph-urls.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not installed."; exit 1; }
 

--- a/graph-service/tests/index.test.ts
+++ b/graph-service/tests/index.test.ts
@@ -37,10 +37,22 @@ describe('Graph Service', () => {
     expect(await response.text()).toBe('Unsupported network ID: 999999')
   })
 
-  // Test for non-POST requests
-  it('should return 405 for non-POST requests', async () => {
+  // Test for GET explorer redirects
+  it('should redirect GET requests to The Graph explorer', async () => {
     const request = new Request('https://example.com/1', {
       method: 'GET',
+    })
+    const response = await worker.fetch(request, mockEnv)
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain(
+      'https://thegraph.com/explorer/subgraphs/'
+    )
+  })
+
+  // Test for non-POST requests
+  it('should return 405 for non-GET/POST requests', async () => {
+    const request = new Request('https://example.com/1', {
+      method: 'PUT',
     })
     const response = await worker.fetch(request, mockEnv)
     expect(response.status).toBe(405)

--- a/graph-service/wrangler.toml
+++ b/graph-service/wrangler.toml
@@ -1,5 +1,6 @@
 name = "graph-service"
 main = "src/index.ts"
+account_id = "30fa248ff7b03cfcac765dae9509bba0"
 compatibility_date = "2024-07-29"
 tail_consumers = [{service = "graph-service-tail"}]
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -108,6 +108,8 @@ You can use the `yarn dev` to run locally.
 
 # Deployment
 
+Production deployments run from the `production` branch through the shared Cloudflare Worker GitHub Actions workflow.
+
 You can use the `yarn deploy` to deploy to Cloudflare.
 
 # KV Namespaces
@@ -157,5 +159,4 @@ Then set it in 1Password, under `secrets/rpc-providers`.
 
 ## TODO
 
-- Deploy through Github action
 - Measure all the things

--- a/provider/wrangler.toml
+++ b/provider/wrangler.toml
@@ -1,5 +1,6 @@
 name = "rpc-provider"
 main = "src/index.ts"
+account_id = "30fa248ff7b03cfcac765dae9509bba0"
 # 2024-09-23 is the minimum date required for global_fetch_strictly_public (added ~late 2024).
 # The Cloudflare compatibility changelog between the previous date (2022-08-17) and this one
 # was reviewed before this change landed: the only flags that affect this worker are fetch-related

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -9,7 +9,14 @@ BASE_DOCKER_COMPOSE=$REPO_ROOT/docker/docker-compose.yml
 DOCKER_COMPOSE_FILE=$REPO_ROOT/docker/docker-compose.ci.yml
 
 UNLOCK_SERVICE_NAME="${SERVICE/packages\//}"
-COMMAND="yarn workspace @unlock-protocol/$UNLOCK_SERVICE_NAME run ci"
+PACKAGE_JSON_PATH="$REPO_ROOT/$SERVICE/package.json"
+if [ ! -f "$PACKAGE_JSON_PATH" ]; then
+  echo "No package.json found for $SERVICE at $PACKAGE_JSON_PATH"
+  exit 1
+fi
+
+WORKSPACE_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$PACKAGE_JSON_PATH")
+COMMAND="yarn workspace $WORKSPACE_NAME run ci"
 
 # Setting the right env var
 export UNLOCK_ENV=test

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -15,8 +15,17 @@ if [ ! -f "$PACKAGE_JSON_PATH" ]; then
   exit 1
 fi
 
-WORKSPACE_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$PACKAGE_JSON_PATH")
-COMMAND="yarn workspace $WORKSPACE_NAME run ci"
+WORKSPACE_NAME=$(node -e "const { name } = require(process.argv[1]); if (typeof name === 'string') console.log(name)" "$PACKAGE_JSON_PATH")
+if [ -z "$WORKSPACE_NAME" ]; then
+  echo "No workspace name found in $PACKAGE_JSON_PATH"
+  exit 1
+fi
+if [[ "$WORKSPACE_NAME" =~ [[:space:]] ]]; then
+  echo "Invalid workspace name in $PACKAGE_JSON_PATH: $WORKSPACE_NAME"
+  exit 1
+fi
+
+COMMAND=(yarn workspace "$WORKSPACE_NAME" run ci)
 
 # Setting the right env var
 export UNLOCK_ENV=test
@@ -25,10 +34,13 @@ export UNLOCK_ENV=test
 # UNLOCK_APP_X will be passed to the container for tests in unlock_app as X.
 UPCASE_SERVICE="${UNLOCK_SERVICE_NAME^^}"
 ENV_VARS_PREFIX="${UPCASE_SERVICE//-/_}_"
-ENV_VARS=$(env | grep "^$ENV_VARS_PREFIX" | awk '{print "-e ",$1}' ORS=' ' | sed -e "s/$ENV_VARS_PREFIX//g")
+ENV_VARS=()
+while IFS='=' read -r NAME VALUE; do
+  ENV_VARS+=("-e" "${NAME#$ENV_VARS_PREFIX}=$VALUE")
+done < <(env | grep "^$ENV_VARS_PREFIX" || true)
 
 # First we need to build the base
-docker compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE build $UNLOCK_SERVICE_NAME
+docker compose -f "$BASE_DOCKER_COMPOSE" -f "$DOCKER_COMPOSE_FILE" build "$UNLOCK_SERVICE_NAME"
 
 # Run tests
-docker compose -f $BASE_DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE run -e CI=true $ENV_VARS $UNLOCK_SERVICE_NAME $COMMAND
+docker compose -f "$BASE_DOCKER_COMPOSE" -f "$DOCKER_COMPOSE_FILE" run -e CI=true "${ENV_VARS[@]}" "$UNLOCK_SERVICE_NAME" "${COMMAND[@]}"


### PR DESCRIPTION
## Summary
- make the reusable Cloudflare Worker workflow handle scoped and unscoped workspaces, optional Wrangler environments, optional 1Password secret sync, post-deploy secret updates, and per-worker smoke tests
- keep wedlocks staging/prod on the shared workflow and add production deploy jobs for rpc-provider and graph-service
- pin provider and graph-service Wrangler configs to Cloudflare account 30fa248ff7b03cfcac765dae9509bba0
- make graph-service a first-class PR/master CI test target with Docker CI wiring and a workspace ci script
- harden graph-service secret sync and fix graph-service request handling covered by tests

## Notes
- provider and graph-service do not currently define staging Wrangler environments or staging routes, so this PR does not invent staging deploys for them
- production deploys for all configured Cloudflare Workers now use the same reusable workflow
- graph-service changes now trigger the standard `run-tests` workflow, same as provider and wedlocks

## Validation
- yarn install --immutable
- yarn workspace @unlock-protocol/types build
- yarn workspace @unlock-protocol/networks build
- yarn workspace @unlock-protocol/contracts build
- yarn workspace @unlock-protocol/email-templates build
- yarn workspace graph-service test
- yarn workspace @unlock-protocol/provider test
- yarn workspace @unlock-protocol/wedlocks ci
- bash -n scripts/tests.sh graph-service/src/scripts/set-graph-urls.sh
- docker compose -f docker/docker-compose.yml -f docker/docker-compose.ci.yml config --quiet
- git diff --check
- YAML parse check for _tests.yml, pull-request.yml, _cloudflare-worker.yml, master.yml, production.yml
- live smoke commands passed for rpc.unlock-protocol.com and subgraph.unlock-protocol.com; staging wedlocks smoke passed
