### PR TITLE
Free runner disk before Docker test builds

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -51,6 +51,17 @@ jobs:
         target: ${{fromJson( inputs.changed )}}
     steps:
       - uses: actions/checkout@v4
+      - name: Free runner disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo apt-get clean
+          df -h
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       # Only one matrix entry writes the shared GHA cache; siblings restore from GHA or Docker Hub fallback.


### PR DESCRIPTION
## Summary
- free unused GitHub-hosted runner toolchains before Docker buildx setup in the shared test workflow
- prevents Docker deps image restore/import from exhausting the runner disk before tests run

## Context
The post-merge master staging run for PR #16542 failed before deployment:
- run: https://github.com/unlock-protocol/unlock/actions/runs/28467912673
- failing job: run-all-tests / Unit Tests wedlocks
- failing step: Restore Docker deps layer
- error: `no space left on device` while buildx imported the deps image

## Validation
- parsed .github/workflows/_tests.yml with Ruby YAML loader
- git diff --check