### PR TITLE
[codex] Fix Claude PR review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # The code-review plugin only posts GitHub feedback when --comment is provided.
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary
- grants the Claude PR review workflow write access for PR and issue comments
- runs the code-review plugin with `--comment` so CI posts review feedback instead of only writing to the hidden terminal output

## Root cause
The automatic `Claude Code Review` workflow was triggering on PR events, but the plugin was invoked without `--comment`. Upstream plugin docs say `/code-review` outputs to terminal by default and only posts GitHub feedback when `--comment` is provided. Recent workflow logs showed Claude completed successfully and then posted `No buffered inline comments`, leaving the PR with no visible review.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "ok"'`
- `git diff --check`
- PR #16546 `claude-review` check triggered with the updated permissions and prompt, then skipped by Claude's default-branch workflow validation because this PR changes the workflow file itself. The new behavior can only execute after this workflow file is merged to `master`.