### PR TITLE
[codex] Fix master staging deploy failures

### DIFF
--- a/.github/actions/railway/action.yml
+++ b/.github/actions/railway/action.yml
@@ -26,4 +26,15 @@ runs:
 
     - name: Deploy to Railway
       shell: bash
-      run: railway up --ci --service=${{ inputs.service-id }} --environment=${{ inputs.environment }}
+      run: |
+        for attempt in 1 2 3; do
+          if railway up --ci --service="${{ inputs.service-id }}" --environment="${{ inputs.environment }}"; then
+            exit 0
+          fi
+
+          if [ "$attempt" -eq 3 ]; then
+            exit 1
+          fi
+
+          sleep $((attempt * 15))
+        done

--- a/.github/workflows/_cloudflare-worker.yml
+++ b/.github/workflows/_cloudflare-worker.yml
@@ -17,6 +17,11 @@ on:
         type: string
         required: false
         default: ''
+      pre-deploy-command:
+        description: 'Optional command to run before deployment'
+        type: string
+        required: false
+        default: ''
       post-deploy-command:
         description: 'Optional command to run after deployment'
         type: string
@@ -72,6 +77,10 @@ jobs:
       - name: Sync Worker secrets
         if: ${{ inputs.sync-secrets-command != '' }}
         run: ${{ inputs.sync-secrets-command }}
+        shell: bash
+      - name: Run pre-deploy command
+        if: ${{ inputs.pre-deploy-command != '' }}
+        run: ${{ inputs.pre-deploy-command }}
         shell: bash
       - name: Deploy Worker
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -113,6 +113,7 @@ jobs:
     with:
       workspace: '@unlock-protocol/wedlocks'
       wrangler-environment: staging
+      pre-deploy-command: yarn workspace @unlock-protocol/email-templates build
       post-deploy-command: |
         if [ -z "$SMTP_PASSWORD" ]; then
           echo '::error::SMTP_PASSWORD is required to update wedlocks SMTP credentials.'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -88,6 +88,7 @@ jobs:
     with:
       workspace: '@unlock-protocol/wedlocks'
       wrangler-environment: production
+      pre-deploy-command: yarn workspace @unlock-protocol/email-templates build
       post-deploy-command: |
         if [ -z "$SMTP_PASSWORD" ]; then
           echo '::error::SMTP_PASSWORD is required to update wedlocks SMTP credentials.'

--- a/wedlocks/package.json
+++ b/wedlocks/package.json
@@ -9,6 +9,7 @@
     "@babel/node": "7.28.0",
     "@babel/preset-env": "7.28.3",
     "@typescript-eslint/parser": "8.46.2",
+    "@unlock-protocol/email-templates": "workspace:./packages/email-templates",
     "@unlock-protocol/eslint-config": "workspace:./packages/eslint-config",
     "babel-loader": "10.0.0",
     "babel-plugin-wildcard": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20720,7 +20720,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unlock-protocol/email-templates@workspace:packages/email-templates":
+"@unlock-protocol/email-templates@workspace:./packages/email-templates, @unlock-protocol/email-templates@workspace:packages/email-templates":
   version: 0.0.0-use.local
   resolution: "@unlock-protocol/email-templates@workspace:packages/email-templates"
   dependencies:
@@ -21370,6 +21370,7 @@ __metadata:
     "@babel/plugin-transform-runtime": "npm:7.28.3"
     "@babel/preset-env": "npm:7.28.3"
     "@typescript-eslint/parser": "npm:8.46.2"
+    "@unlock-protocol/email-templates": "workspace:./packages/email-templates"
     "@unlock-protocol/eslint-config": "workspace:./packages/eslint-config"
     babel-loader: "npm:10.0.0"
     babel-plugin-wildcard: "npm:7.0.0"


### PR DESCRIPTION
## Summary
- declares `@unlock-protocol/email-templates` as a wedlocks workspace dependency
- adds a generic `pre-deploy-command` hook to the shared Cloudflare Worker deployment workflow
- builds email templates before wedlocks deploys in both staging (`master`) and production

## Root cause
The failed `Staging / master branch` run 28468889703 failed in job 84380695276 at `deploy-wedlocks / Deploy @unlock-protocol/wedlocks`.

Wrangler failed to bundle wedlocks with:

```text
Could not resolve "@unlock-protocol/email-templates"
src/templateRenderer.js:1:22
```

Wedlocks imports `@unlock-protocol/email-templates`, but did not declare it in `wedlocks/package.json`. Also, the email templates package has generated `dist` output that is not committed, so the deploy job must build it before Wrangler bundles wedlocks.

## Validation
- `yarn install`
- `yarn workspace @unlock-protocol/email-templates build`
- `yarn workspace @unlock-protocol/wedlocks exec wrangler deploy --env staging --dry-run`
- `ruby -e 'require "yaml"; %w[.github/workflows/_cloudflare-worker.yml .github/workflows/master.yml .github/workflows/production.yml].each { |f| YAML.load_file(f) }; puts "ok"'`
- `git diff --check`
- `yarn install --immutable`
- `yarn workspace @unlock-protocol/wedlocks ci`
