### PR TITLE
chore: add wilber123451-design to CLA bot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,7 +100,8 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
-    "claude[bot]"
+    "claude[bot]",
+    "wilber123451-design"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "
 }


### PR DESCRIPTION
Adds `wilber123451-design` to `.clabot`, as requested by the CLA bot on #16580.

This PR intentionally contains no other changes. After merge, please rerun the `verification/cla-signed` check on #16580.