### PR TITLE
feat(unlock-app): expose discount codes for paid locks

### DIFF
--- a/unlock-app/src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts
+++ b/unlock-app/src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowDiscountCodesTab } from '~/components/interface/locks/Settings/settingsTabs'
+
+describe('lock settings tabs', () => {
+  it('shows discount codes for paid locks after lock data loads', () => {
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: '0.01' },
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: 1 },
+      })
+    ).toBe(true)
+  })
+
+  it('hides discount codes for free locks', () => {
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: '0' },
+      })
+    ).toBe(false)
+  })
+
+  it('hides discount codes until valid lock data is available', () => {
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: true,
+        lock: { keyPrice: '1' },
+      })
+    ).toBe(false)
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+      })
+    ).toBe(false)
+    expect(
+      shouldShowDiscountCodesTab({
+        isLoading: false,
+        lock: { keyPrice: 'not-a-number' },
+      })
+    ).toBe(false)
+  })
+})

--- a/unlock-app/src/components/content/lock/LocksSettingsContent.tsx
+++ b/unlock-app/src/components/content/lock/LocksSettingsContent.tsx
@@ -10,6 +10,7 @@ export type SettingTab =
   | 'general'
   | 'terms'
   | 'payments'
+  | 'discountCodes'
   | 'roles'
   | 'advanced'
   | 'emails'

--- a/unlock-app/src/components/interface/locks/Settings/elements/SettingDiscountCodes.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/elements/SettingDiscountCodes.tsx
@@ -1,0 +1,36 @@
+import { UpdateDiscountCodesForm } from '../forms/UpdateDiscountCodesForm'
+import { SettingCard } from './SettingCard'
+
+interface SettingDiscountCodesProps {
+  lockAddress: string
+  network: number
+  isManager: boolean
+  isLoading: boolean
+  publicLockVersion?: bigint
+}
+
+export const SettingDiscountCodes = ({
+  lockAddress,
+  network,
+  isManager,
+  isLoading,
+  publicLockVersion,
+}: SettingDiscountCodesProps) => {
+  return (
+    <div className="grid grid-cols-1 gap-6">
+      <SettingCard
+        label="Discount Codes"
+        description="Create and manage discount codes for this paid lock."
+        isLoading={isLoading || publicLockVersion === undefined}
+        defaultOpen
+      >
+        <UpdateDiscountCodesForm
+          lockAddress={lockAddress}
+          network={network}
+          disabled={!isManager}
+          version={publicLockVersion}
+        />
+      </SettingCard>
+    </div>
+  )
+}

--- a/unlock-app/src/components/interface/locks/Settings/forms/UpdateDiscountCodesForm.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/UpdateDiscountCodesForm.tsx
@@ -1,0 +1,133 @@
+import { HookType } from '@unlock-protocol/types'
+import { ToastHelper } from '@unlock-protocol/ui'
+import { useMutation } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useCustomHook } from '~/hooks/useCustomHooks'
+import { useProvider } from '~/hooks/useProvider'
+import { useConfig } from '~/utils/withConfig'
+import { PromoCodeHook } from './hooksComponents/PromoCodeHook'
+
+interface UpdateDiscountCodesFormProps {
+  lockAddress: string
+  network: number
+  disabled: boolean
+  version?: bigint
+}
+
+interface DiscountCodesFormProps {
+  keyPurchase: string
+  promo?: {
+    code?: string
+    discount?: number
+    cap?: number
+  }
+}
+
+export const UpdateDiscountCodesForm = ({
+  lockAddress,
+  network,
+  disabled,
+  version,
+}: UpdateDiscountCodesFormProps) => {
+  const { networks } = useConfig()
+  const { getWalletService } = useProvider()
+  const promoCodeHook = networks?.[network]?.hooks?.onKeyPurchaseHook?.find(
+    ({ id }) => id === HookType.PROMO_CODE_CAPPED
+  )
+  const hasRequiredVersion = version !== undefined && version >= BigInt(7)
+  const { isPending, refetch, getHookValues } = useCustomHook({
+    lockAddress,
+    network,
+    version,
+  })
+
+  const methods = useForm<DiscountCodesFormProps>({
+    mode: 'onChange',
+    defaultValues: {
+      keyPurchase: promoCodeHook?.address ?? '',
+    },
+  })
+
+  const { register, reset, setValue } = methods
+
+  useEffect(() => {
+    if (promoCodeHook?.address) {
+      setValue('keyPurchase', promoCodeHook.address, {
+        shouldValidate: true,
+      })
+    }
+  }, [promoCodeHook?.address, setValue])
+
+  const setEventsHooks = async (
+    fields: Pick<DiscountCodesFormProps, 'keyPurchase'>
+  ) => {
+    const values = (await getHookValues()) as Partial<DiscountCodesFormProps>
+
+    if (values.keyPurchase === fields.keyPurchase) {
+      return
+    }
+
+    const walletService = await getWalletService(network)
+
+    await ToastHelper.promise(
+      walletService.setEventHooks({
+        lockAddress,
+        ...fields,
+      }),
+      {
+        success: 'Discount code hook enabled.',
+        loading: 'Enabling discount codes on the contract...',
+        error: 'Failed to enable discount codes.',
+      }
+    )
+  }
+
+  const setEventsHooksMutation = useMutation({
+    mutationFn: setEventsHooks,
+    onSuccess: async () => {
+      await refetch()
+
+      if (promoCodeHook?.address) {
+        reset({
+          keyPurchase: promoCodeHook.address,
+        })
+      }
+    },
+  })
+
+  const disabledInput =
+    disabled || setEventsHooksMutation.isPending || isPending
+
+  if (!hasRequiredVersion) {
+    return (
+      <span className="text-base">
+        Discount codes require PublicLock version 7 or later.
+      </span>
+    )
+  }
+
+  if (!promoCodeHook) {
+    return (
+      <span className="text-base">
+        Discount codes are not available on this network yet.
+      </span>
+    )
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <input type="hidden" {...register('keyPurchase')} />
+      <PromoCodeHook
+        name="keyPurchase"
+        disabled={disabledInput}
+        lockAddress={lockAddress}
+        network={network}
+        hookAddress={promoCodeHook.address}
+        defaultValue={promoCodeHook.address}
+        setEventsHooksMutation={setEventsHooksMutation}
+        selectedOption={HookType.PROMO_CODE_CAPPED}
+      />
+    </FormProvider>
+  )
+}

--- a/unlock-app/src/components/interface/locks/Settings/forms/hooksComponents/PromoCodeHook.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/forms/hooksComponents/PromoCodeHook.tsx
@@ -20,6 +20,7 @@ export const PromoCodeHook = ({
   lockAddress,
   network,
   hookAddress,
+  disabled,
   setEventsHooksMutation,
 }: CustomComponentProps) => {
   const {
@@ -110,6 +111,7 @@ export const PromoCodeHook = ({
                 error={errors.code?.message as string}
                 placeholder="FRIENDS20"
                 label="Code:"
+                disabled={disabled}
                 {...register('promo.code', {
                   required: true,
                 })}
@@ -121,6 +123,7 @@ export const PromoCodeHook = ({
                 error={errors.discount?.message as string}
                 placeholder="20"
                 label="Discount (%):"
+                disabled={disabled}
                 {...register('promo.discount', {
                   valueAsNumber: true,
                   min: 0,
@@ -135,6 +138,7 @@ export const PromoCodeHook = ({
                 error={errors.cap?.message as string}
                 placeholder="100"
                 label="Number of uses:"
+                disabled={disabled}
                 {...register('promo.cap', {
                   valueAsNumber: true,
                   min: 0,
@@ -146,7 +150,7 @@ export const PromoCodeHook = ({
               <Button
                 type="submit"
                 className="w-24"
-                disabled={!isValid}
+                disabled={disabled || !isValid}
                 size="small"
                 loading={
                   setPromoCodeMutation.isPending ||
@@ -174,6 +178,7 @@ export const PromoCodeHook = ({
                   lockAddress={lockAddress}
                   hookAddress={hookAddress}
                   network={network}
+                  disabled={disabled}
                 />
               )
             })}
@@ -189,6 +194,7 @@ interface PromoCodeProps {
   lockAddress: string
   network: number
   hookAddress: string
+  disabled: boolean
 }
 
 export const PromoCode = ({
@@ -197,6 +203,7 @@ export const PromoCode = ({
   lockAddress,
   hookAddress,
   network,
+  disabled,
 }: PromoCodeProps) => {
   const [loading, setLoading] = useState(false)
   const [promoCodeDetails, setPromoCodeDetails] = useState<{
@@ -238,8 +245,9 @@ export const PromoCode = ({
         {loading && <LoadingIcon size={24} />}
         {!loading && (
           <TrashIcon
-            className="cursor-pointer"
+            className={disabled ? 'text-gray-400' : 'cursor-pointer'}
             onClick={async () => {
+              if (disabled) return
               setLoading(true)
               await savePromoCode({ code, discount: 0, cap: 0 })
               setLoading(false)

--- a/unlock-app/src/components/interface/locks/Settings/index.tsx
+++ b/unlock-app/src/components/interface/locks/Settings/index.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 import { SettingTerms } from './elements/SettingTerms'
@@ -20,11 +21,20 @@ import { SettingPayments } from './elements/SettingPayments'
 import { SettingEmail } from './elements/SettingEmail'
 import { SettingTab } from '~/components/content/lock/LocksSettingsContent'
 import { useAuthenticate } from '~/hooks/useAuthenticate'
+import { SettingDiscountCodes } from './elements/SettingDiscountCodes'
+import { shouldShowDiscountCodesTab } from './settingsTabs'
 
 interface LockSettingsPageProps {
   lockAddress: string
   network: number
   defaultTab?: SettingTab
+}
+
+interface SettingsTabConfig {
+  label: string
+  description?: string
+  id: SettingTab
+  children: ReactNode
 }
 
 export const NotManagerBanner = () => {
@@ -90,112 +100,137 @@ const LockSettingsPage = ({
 
   const isLoading = isLoadingLock || isLoadingManager
 
+  const tabs = useMemo<SettingsTabConfig[]>(() => {
+    const settingsTabs: SettingsTabConfig[] = [
+      {
+        id: 'general',
+        label: 'General',
+        children: (
+          <SettingGeneral
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            lock={lock}
+          />
+        ),
+      },
+      {
+        id: 'terms',
+        label: 'Membership Terms',
+        children: (
+          <SettingTerms
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            lock={lock}
+            isLoading={isLoading}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'Membership Terms include the price, currency, duration, payment mechanisms... as well as cancellation terms and transfer fees.',
+      },
+      {
+        id: 'payments',
+        label: 'Payments',
+        children: (
+          <SettingPayments
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            lock={lock}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          'Payments settings lets you change the price and currency of your memberships, as well as enable credit cards and recurring payments.',
+      },
+      {
+        id: 'roles',
+        label: 'Roles',
+        children: (
+          <SettingRoles
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          'Your Lock includes multiple roles, such as "Lock Manager". Here you can configure which addresses are assigned which roles.',
+      },
+      {
+        id: 'emails',
+        label: 'Emails',
+        children: (
+          <SettingEmail
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+          />
+        ),
+        description:
+          "Customize the emails sent to users when they purchase your lock's membership NFTs.",
+      },
+      {
+        id: 'advanced',
+        label: 'Advanced',
+        children: (
+          <SettingMisc
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            publicLockLatestVersion={publicLockLatestVersion}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'This section lets you configure referral fees, hooks and upgrade your lock to the latest version of the protocol.',
+      },
+    ]
+
+    if (shouldShowDiscountCodesTab({ isLoading, lock })) {
+      settingsTabs.splice(3, 0, {
+        id: 'discountCodes',
+        label: 'Discount Codes',
+        children: (
+          <SettingDiscountCodes
+            lockAddress={lockAddress}
+            network={network}
+            isManager={isManager}
+            isLoading={isLoading}
+            publicLockVersion={publicLockVersion}
+          />
+        ),
+        description:
+          'Create and manage discount codes directly for this paid lock.',
+      })
+    }
+
+    return settingsTabs
+  }, [
+    isLoading,
+    isManager,
+    lock,
+    lockAddress,
+    network,
+    publicLockLatestVersion,
+    publicLockVersion,
+  ])
+
   /**
    * Open default tab by id
    */
   useEffect(() => {
     if (!defaultTab) return
-    const defaultTabIndex = tabs?.findIndex(({ id }) => id === defaultTab)
-    if (defaultTabIndex === undefined) return
+    const defaultTabIndex = tabs.findIndex(({ id }) => id === defaultTab)
+    if (defaultTabIndex < 0) return
 
     setSelectedIndex(defaultTabIndex)
-  }, [defaultTab])
-
-  const tabs: {
-    label: string
-    description?: string
-    id: SettingTab
-    children: ReactNode
-  }[] = [
-    {
-      id: 'general',
-      label: 'General',
-      children: (
-        <SettingGeneral
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-          lock={lock}
-        />
-      ),
-    },
-    {
-      id: 'terms',
-      label: 'Membership Terms',
-      children: (
-        <SettingTerms
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          lock={lock}
-          isLoading={isLoading}
-          publicLockVersion={publicLockVersion}
-        />
-      ),
-      description:
-        'Membership Terms include the price, currency, duration, payment mechanisms... as well as cancellation terms and transfer fees.',
-    },
-    {
-      id: 'payments',
-      label: 'Payments',
-      children: (
-        <SettingPayments
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          lock={lock}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        'Payments settings lets you change the price and currency of your memberships, as well as enable credit cards and recurring payments.',
-    },
-    {
-      id: 'roles',
-      label: 'Roles',
-      children: (
-        <SettingRoles
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        'Your Lock includes multiple roles, such as "Lock Manager". Here you can configure which addresses are assigned which roles.',
-    },
-    {
-      id: 'emails',
-      label: 'Emails',
-      children: (
-        <SettingEmail
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-        />
-      ),
-      description:
-        "Customize the emails sent to users when they purchase your lock's membership NFTs.",
-    },
-    {
-      id: 'advanced',
-      label: 'Advanced',
-      children: (
-        <SettingMisc
-          lockAddress={lockAddress}
-          network={network}
-          isManager={isManager}
-          isLoading={isLoading}
-          publicLockLatestVersion={publicLockLatestVersion}
-          publicLockVersion={publicLockVersion}
-        />
-      ),
-      description:
-        'This section lets you configure referral fees, hooks and upgrade your lock to the latest version of the protocol.',
-    },
-  ]
+  }, [defaultTab, tabs])
 
   return (
     <SettingsContext.Provider

--- a/unlock-app/src/components/interface/locks/Settings/settingsTabs.ts
+++ b/unlock-app/src/components/interface/locks/Settings/settingsTabs.ts
@@ -1,0 +1,20 @@
+interface DiscountCodesTabLock {
+  keyPrice?: number | string | null
+}
+
+interface ShouldShowDiscountCodesTabProps {
+  isLoading: boolean
+  lock?: DiscountCodesTabLock
+}
+
+export const shouldShowDiscountCodesTab = ({
+  isLoading,
+  lock,
+}: ShouldShowDiscountCodesTabProps) => {
+  if (isLoading || lock?.keyPrice === undefined || lock?.keyPrice === null) {
+    return false
+  }
+
+  const keyPrice = Number(lock.keyPrice)
+  return Number.isFinite(keyPrice) && keyPrice > 0
+}


### PR DESCRIPTION
## Summary
- add a dedicated Discount Codes settings tab for paid locks
- reuse the existing capped promo-code hook and enable it on first save
- keep free locks on the existing settings list and disable mutations for non-managers
- handle unsupported PublicLock versions and networks with explicit states

## Prior work
This revives the approach from #16409 by @Zaid-L9 against current master. That author is credited as a co-author. This version adds read-only handling for non-managers, stricter paid-lock detection, broader tab tests, and omits unrelated changes from the prior diff.

## Testing
- `node .yarn/releases/yarn-4.10.3.cjs workspace @unlock-protocol/unlock-app vitest run src/__tests__/components/interface/locks/Settings/settingsTabs.test.ts --environment=jsdom` (3 tests passed)
- `node .yarn/releases/yarn-4.10.3.cjs workspace @unlock-protocol/unlock-app eslint <touched files>` (0 errors)
- `git diff --check`

CLA registration: #16579

Base USDC payout address: `0xd3CE8223E6b0F446a887953aF623B9c72233Ba39`