### PR TITLE
feat(events): add public all-events collection

### DIFF
--- a/locksmith/__tests__/operations/eventCollectionOperations.test.ts
+++ b/locksmith/__tests__/operations/eventCollectionOperations.test.ts
@@ -7,9 +7,13 @@ import {
   addManagerAddressOperation,
   createEventCollectionOperation,
   createEventCollectionSlug,
+  getEventCollectionOperation,
+  PUBLIC_EVENTS_COLLECTION_SLUG,
   removeManagerAddressOperation,
   updateEventCollectionOperation,
 } from '../../src/operations/eventCollectionOperations'
+import { EventStatus } from '@unlock-protocol/types'
+import { Op } from 'sequelize'
 
 // interface for link types
 interface Link {
@@ -61,8 +65,29 @@ vi.mock('../../src/utils/createSlug', () => ({
       .replace(/(^-|-$)/g, ''),
 }))
 
+vi.mock('../../src/operations/wedlocksOperations', () => ({
+  sendEmail: vi.fn(),
+}))
+
+vi.mock('../../src/operations/privyUserOperations', () => ({
+  getPrivyUserByAddress: vi.fn().mockResolvedValue({ success: false }),
+}))
+
+vi.mock('../../src/config/config', () => ({
+  default: {
+    unlockApp: 'https://app.unlock-protocol.com',
+  },
+}))
+
+vi.mock('../../src/logger', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}))
+
 describe('eventCollectionOperations', () => {
   let mockFindOne: ReturnType<typeof vi.fn>
+  let mockFindAll: ReturnType<typeof vi.fn>
   let scopedEventData: any
 
   beforeEach(() => {
@@ -70,8 +95,10 @@ describe('eventCollectionOperations', () => {
 
     // Mock the scoped EventData
     mockFindOne = vi.fn()
+    mockFindAll = vi.fn()
     scopedEventData = {
       findOne: mockFindOne,
+      findAll: mockFindAll,
     }
     ;(EventData.scope as any).mockReturnValue(scopedEventData)
   })
@@ -197,6 +224,62 @@ describe('eventCollectionOperations', () => {
       expect(EventCollection.findByPk).toHaveBeenCalledWith(
         'test-collection-with-special-characters'
       )
+    })
+
+    it('reserves the public events collection slug', async () => {
+      ;(EventCollection.findByPk as any).mockResolvedValueOnce(null)
+
+      const slug = await createEventCollectionSlug('All Events')
+
+      expect(slug).toBe('all-events-1')
+      expect(EventCollection.findByPk).toHaveBeenCalledOnce()
+      expect(EventCollection.findByPk).toHaveBeenCalledWith('all-events-1')
+    })
+  })
+
+  describe('getEventCollectionOperation', () => {
+    it('returns a read-only virtual collection of deployed Unlock events', async () => {
+      const event = {
+        slug: 'community-meetup',
+        data: {
+          name: 'Community meetup',
+          replyTo: 'private@example.com',
+          attributes: [],
+        },
+      }
+      mockFindAll.mockResolvedValue([event])
+
+      const result = await getEventCollectionOperation(
+        PUBLIC_EVENTS_COLLECTION_SLUG
+      )
+
+      expect(EventCollection.findByPk).not.toHaveBeenCalled()
+      expect(mockFindAll).toHaveBeenCalledWith({
+        where: {
+          status: EventStatus.DEPLOYED,
+          eventType: 'unlock',
+          checkoutConfigId: {
+            [Op.ne]: null,
+          },
+        },
+        order: [['createdAt', 'DESC']],
+      })
+      expect(result).toMatchObject({
+        slug: PUBLIC_EVENTS_COLLECTION_SLUG,
+        title: 'Explore Unlock Events',
+        managerAddresses: [],
+        isVirtual: true,
+        events: [
+          {
+            slug: 'community-meetup',
+            data: {
+              name: 'Community meetup',
+              attributes: [],
+            },
+          },
+        ],
+      })
+      expect(result.events[0].data).not.toHaveProperty('replyTo')
     })
   })
 

--- a/locksmith/src/operations/eventCollectionOperations.ts
+++ b/locksmith/src/operations/eventCollectionOperations.ts
@@ -8,6 +8,22 @@ import config from '../config/config'
 import logger from '../logger'
 import { getPrivyUserByAddress } from './privyUserOperations'
 import { Op } from 'sequelize'
+import { EventStatus } from '@unlock-protocol/types'
+import { removeProtectedAttributesFromObject } from '../utils/protectedAttributes'
+
+export const PUBLIC_EVENTS_COLLECTION_SLUG = 'all-events'
+
+const PUBLIC_EVENTS_COLLECTION = {
+  slug: PUBLIC_EVENTS_COLLECTION_SLUG,
+  title: 'Explore Unlock Events',
+  description:
+    'Discover public events created with Unlock Protocol. New deployed events appear here automatically.',
+  coverImage: '/images/illustrations/events/farcon-hero.png',
+  banner: '/images/illustrations/events/party.svg',
+  links: [],
+  managerAddresses: [],
+  isVirtual: true,
+} as const
 
 // event collection body schema
 const EventCollectionBody = z.object({
@@ -44,6 +60,10 @@ export async function createEventCollectionSlug(
 
   const baseSlug = kebabCase(cleanTitle)
   const slug = index ? `${baseSlug}-${index}` : baseSlug
+
+  if (slug === PUBLIC_EVENTS_COLLECTION_SLUG) {
+    return createEventCollectionSlug(title, 1)
+  }
 
   // Check if the slug already exists
   const existingCollection = await EventCollection.findByPk(slug)
@@ -111,6 +131,28 @@ export const createEventCollectionOperation = async (
  * @throws An error if the event collection is not found.
  */
 export const getEventCollectionOperation = async (slug: string) => {
+  if (slug === PUBLIC_EVENTS_COLLECTION_SLUG) {
+    const events = await EventData.scope('withoutId').findAll({
+      where: {
+        status: EventStatus.DEPLOYED,
+        eventType: 'unlock',
+        checkoutConfigId: {
+          [Op.ne]: null,
+        },
+      },
+      order: [['createdAt', 'DESC']],
+    })
+
+    events.forEach((event) => {
+      event.data = removeProtectedAttributesFromObject(event.data)
+    })
+
+    return {
+      ...PUBLIC_EVENTS_COLLECTION,
+      events,
+    }
+  }
+
   const eventCollection = await EventCollection.findByPk(slug, {
     include: [
       {

--- a/packages/unlock-js/openapi.yml
+++ b/packages/unlock-js/openapi.yml
@@ -596,6 +596,8 @@ components:
           type: array
           items:
             type: string
+        isVirtual:
+          type: boolean
         createdAt:
           type: string
           format: date-time

--- a/unlock-app/src/components/content/event/EventLandingPage.tsx
+++ b/unlock-app/src/components/content/event/EventLandingPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@unlock-protocol/ui'
 import Link from 'next/link'
 import { LockTypeLandingPage } from '~/components/interface/LockTypeLandingPage'
 import Image from 'next/image'
+import { TbCalendarEvent } from 'react-icons/tb'
 
 const customers = [
   {
@@ -136,9 +137,14 @@ export const EventLandingPageCallToAction = ({
   handleCreateEvent,
 }: EventLandingPageCallToActionProps) => {
   return (
-    <Button onClick={handleCreateEvent} className="my-8">
-      Get started for free
-    </Button>
+    <div className="flex flex-col sm:flex-row gap-3 my-8">
+      <Button onClick={handleCreateEvent}>Get started for free</Button>
+      <Link href="/events/all-events">
+        <Button variant="outlined-primary" iconLeft={<TbCalendarEvent />}>
+          Explore events
+        </Button>
+      </Link>
+    </div>
   )
 }
 

--- a/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
+++ b/unlock-app/src/components/content/events-collection/EventsCollectionDetailContent.tsx
@@ -84,6 +84,10 @@ export default function EventsCollectionDetailContent({
   const [isEventDetailDrawerOpen, setIsEventDetailDrawerOpen] = useState(false)
   const [selectedEvent, setSelectedEvent] = useState<any | null>(null)
 
+  const isVirtualCollection = Boolean(
+    (eventCollection as { isVirtual?: boolean } | undefined)?.isVirtual
+  )
+
   const hasValidEvents = useMemo(() => {
     return (
       eventCollection?.events?.some(
@@ -284,12 +288,14 @@ export default function EventsCollectionDetailContent({
             <div className="flex flex-col gap-6 lg:col-span-10">
               <div className="flex flex-col sm:flex-row items-center space-y-2 justify-between my-5">
                 <h2 className="text-3xl font-bold">Events</h2>
-                <Button onClick={handleAddEvent} className="w-full sm:w-auto">
-                  <div className="flex items-center gap-2">
-                    <Icon icon={TbPlus} size={20} />
-                    {isManager ? 'Add Event' : 'Submit Event'}
-                  </div>
-                </Button>
+                {!isVirtualCollection && (
+                  <Button onClick={handleAddEvent} className="w-full sm:w-auto">
+                    <div className="flex items-center gap-2">
+                      <Icon icon={TbPlus} size={20} />
+                      {isManager ? 'Add Event' : 'Submit Event'}
+                    </div>
+                  </Button>
+                )}
               </div>
               {hasValidEvents ? (
                 <>
@@ -333,15 +339,19 @@ export default function EventsCollectionDetailContent({
                 <ImageBar
                   src="/images/illustrations/no-locks.svg"
                   description={
-                    <div>
-                      No events have been added yet.{' '}
-                      <span
-                        onClick={handleAddEvent}
-                        className="text-brand-ui-primary cursor-pointer"
-                      >
-                        {isManager ? 'Add an event' : 'Submit an event'}
-                      </span>
-                    </div>
+                    isVirtualCollection ? (
+                      'No public events are available yet.'
+                    ) : (
+                      <div>
+                        No events have been added yet.{' '}
+                        <span
+                          onClick={handleAddEvent}
+                          className="text-brand-ui-primary cursor-pointer"
+                        >
+                          {isManager ? 'Add an event' : 'Submit an event'}
+                        </span>
+                      </div>
+                    )
                   }
                 />
               )}
@@ -352,13 +362,15 @@ export default function EventsCollectionDetailContent({
       </div>
 
       {/* Add Event Drawer */}
-      <AddEventsToCollectionDrawer
-        collectionSlug={eventCollection?.slug}
-        isOpen={isAddEventDrawerOpen}
-        setIsOpen={setIsAddEventDrawerOpen}
-        isManager={isManager!}
-        existingEventSlugs={existingEventSlugs}
-      />
+      {!isVirtualCollection && (
+        <AddEventsToCollectionDrawer
+          collectionSlug={eventCollection?.slug}
+          isOpen={isAddEventDrawerOpen}
+          setIsOpen={setIsAddEventDrawerOpen}
+          isManager={isManager!}
+          existingEventSlugs={existingEventSlugs}
+        />
+      )}
       {/* Event Detail Drawer */}
       {eventCollection?.slug && (
         <EventDetailDrawer


### PR DESCRIPTION
## Summary
- add a backend-only virtual `all-events` collection populated from deployed Unlock events with checkout configs
- strip protected event attributes and reserve the virtual slug from user-created collections
- make the collection read-only in the UI and add an `Explore events` entry point from the events landing page
- expose the virtual flag in the Locksmith OpenAPI schema

Fixes #16183

## Verification
- `yarn workspace @unlock-protocol/locksmith vitest run __tests__/operations/eventCollectionOperations.test.ts` (21 tests passed)
- targeted Locksmith and unlock-app ESLint (no errors)
- `yarn workspace @unlock-protocol/unlock-app tsc --noEmit`
- `yarn workspace @unlock-protocol/unlock-js generate:locksmith`

## Bounty payout
Please confirm the Scout Game Gold reward for this implementation. If accepted, the Base USDC payout address is `0xd3CE8223E6b0F446a887953aF623B9c72233Ba39`.