### PR TITLE
fix(locksmith): block private WebSub hub.callback URLs (SSRF)

### DIFF
--- a/locksmith/__tests__/utils/safeCallbackUrl.test.ts
+++ b/locksmith/__tests__/utils/safeCallbackUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertSafeCallbackUrl,
+  isBlockedIp,
+} from '../../src/utils/safeCallbackUrl'
+
+describe('safeCallbackUrl', () => {
+  it('blocks loopback, private, link-local, and CGNAT IPv4', () => {
+    expect(isBlockedIp('127.0.0.1')).toBe(true)
+    expect(isBlockedIp('10.0.0.5')).toBe(true)
+    expect(isBlockedIp('192.168.1.1')).toBe(true)
+    expect(isBlockedIp('172.16.0.1')).toBe(true)
+    expect(isBlockedIp('169.254.169.254')).toBe(true)
+    expect(isBlockedIp('100.64.1.1')).toBe(true)
+    expect(isBlockedIp('8.8.8.8')).toBe(false)
+  })
+
+  it('rejects localhost and private literal callbacks', async () => {
+    await expect(
+      assertSafeCallbackUrl('http://localhost/callback')
+    ).rejects.toThrow(/not allowed/)
+    await expect(
+      assertSafeCallbackUrl('http://127.0.0.1/callback')
+    ).rejects.toThrow(/not allowed/)
+    await expect(
+      assertSafeCallbackUrl('http://169.254.169.254/latest/meta-data/')
+    ).rejects.toThrow(/not allowed/)
+  })
+
+  it('allows public https callbacks', async () => {
+    const url = await assertSafeCallbackUrl('https://example.com/websub')
+    expect(url).toContain('https://example.com/websub')
+  })
+})

--- a/locksmith/src/controllers/hookController.ts
+++ b/locksmith/src/controllers/hookController.ts
@@ -4,6 +4,7 @@ import * as z from 'zod'
 import crypto from 'crypto'
 import logger from '../logger'
 import { Hook } from '../models'
+import { assertSafeCallbackUrl } from '../utils/safeCallbackUrl'
 export type SubscribeParams = Partial<Record<'lock' | 'network', string>>
 export type SubscribeRequest = Request<SubscribeParams, Record<string, string>>
 
@@ -98,6 +99,9 @@ export class HookController {
   async verifySubscriber(hub: z.infer<typeof Hub>) {
     const challenge = this.getChallege()
 
+    // Block private/link-local/metadata callbacks before any outbound fetch (SSRF).
+    await assertSafeCallbackUrl(hub.callback)
+
     const callbackEndpoint = new URL(hub.callback)
     callbackEndpoint.searchParams.set('hub.challenge', challenge)
     callbackEndpoint.searchParams.set('hub.topic', hub.topic)
@@ -108,7 +112,9 @@ export class HookController {
     callbackEndpoint.searchParams.set('hub.mode', hub.mode)
     callbackEndpoint.searchParams.set('hub.secret', hub.secret!)
 
-    const result = await fetch(callbackEndpoint.toString())
+    const result = await fetch(callbackEndpoint.toString(), {
+      redirect: 'error',
+    })
     if (!result.ok) {
       throw new Error('Failed to confirm subscription intent')
     }
@@ -122,7 +128,9 @@ export class HookController {
       rejectionEndpoint.searchParams.set('hub.topic', hub.topic)
       rejectionEndpoint.searchParams.set('hub.reason', rejectedError.message)
       // Notify the callback url of the rejection reason
-      const res = await fetch(rejectionEndpoint.toString())
+      const res = await fetch(rejectionEndpoint.toString(), {
+        redirect: 'error',
+      })
       if (!res.ok) {
         throw new Error('Failed to notify the subscriber about rejection')
       }

--- a/locksmith/src/utils/safeCallbackUrl.ts
+++ b/locksmith/src/utils/safeCallbackUrl.ts
@@ -1,0 +1,97 @@
+import { lookup } from 'dns/promises'
+import net from 'net'
+
+/**
+ * Reject WebSub hub.callback URLs that would make Locksmith fetch private /
+ * link-local / metadata addresses (SSRF). Unauthenticated POST /api/hooks/*
+ * verifies subscriber intent by fetching the attacker-controlled callback.
+ */
+
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0
+}
+
+export function isBlockedIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const n = ipv4ToInt(ip)
+    const inRange = (base: string, prefix: number) => {
+      const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0
+      return (n & mask) === (ipv4ToInt(base) & mask)
+    }
+    return (
+      inRange('0.0.0.0', 8) ||
+      inRange('10.0.0.0', 8) ||
+      inRange('127.0.0.0', 8) ||
+      inRange('169.254.0.0', 16) ||
+      inRange('172.16.0.0', 12) ||
+      inRange('192.168.0.0', 16) ||
+      inRange('100.64.0.0', 10)
+    )
+  }
+
+  if (net.isIPv6(ip)) {
+    const normalized = ip.toLowerCase()
+    if (normalized === '::1' || normalized === '::') return true
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true
+    if (
+      normalized.startsWith('fe8') ||
+      normalized.startsWith('fe9') ||
+      normalized.startsWith('fea') ||
+      normalized.startsWith('feb')
+    ) {
+      return true
+    }
+    if (normalized.startsWith(':ffff:')) {
+      const v4 = normalized.slice(':ffff:'.length)
+      if (net.isIPv4(v4)) return isBlockedIp(v4)
+    }
+  }
+
+  return false
+}
+
+export async function assertSafeCallbackUrl(raw: string): Promise<string> {
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    throw new Error(`callback has an invalid url "${raw}"`)
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`callback protocol must be http(s), got "${parsed.protocol}"`)
+  }
+
+  const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  if (!host) {
+    throw new Error('callback hostname is required')
+  }
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+    throw new Error(`callback host "${host}" is not allowed`)
+  }
+
+  if (net.isIP(host)) {
+    if (isBlockedIp(host)) {
+      throw new Error(`callback host "${host}" is not allowed`)
+    }
+  } else {
+    let addresses: Array<{ address: string; family: number }>
+    try {
+      addresses = await lookup(host, { all: true, verbatim: true })
+    } catch {
+      throw new Error(`callback host "${host}" could not be resolved`)
+    }
+    if (!addresses.length) {
+      throw new Error(`callback host "${host}" could not be resolved`)
+    }
+    for (const { address } of addresses) {
+      if (isBlockedIp(address)) {
+        throw new Error(
+          `callback host "${host}" resolves to blocked address "${address}"`
+        )
+      }
+    }
+  }
+
+  return parsed.toString()
+}

--- a/locksmith/src/worker/helpers/notify.ts
+++ b/locksmith/src/worker/helpers/notify.ts
@@ -4,6 +4,7 @@ import { setTimeout, clearTimeout } from 'timers'
 import { Op } from 'sequelize'
 import { Hook, HookEvent } from '../../models'
 import { logger } from '../../logger'
+import { assertSafeCallbackUrl } from '../../utils/safeCallbackUrl'
 
 interface NotifyOptions {
   timeout?: number
@@ -36,11 +37,14 @@ export async function notify({
     })
     headers['X-Hub-Signature'] = `${algorithm}=${signature}`
   }
+  // Defense in depth for hooks persisted before callback SSRF checks.
+  await assertSafeCallbackUrl(hookCallback)
   const response = await fetch(hookCallback, {
     headers: headers,
     method: 'POST',
     body: content,
     signal: ac.signal,
+    redirect: 'error',
   }).catch((error) => {
     logger.error('Error in notify function: ', error)
     return {


### PR DESCRIPTION
## Summary
- Unauthenticated `POST /api/hooks/:network/*` accepted `hub.callback` with only zod `.url()` validation, then Locksmith `fetch`ed it during WebSub intent verification.
- An attacker could point the callback at loopback / private / link-local / cloud-metadata addresses (SSRF), and successful subscriptions later deliver lock/key events to that URL.
- Add `assertSafeCallbackUrl` (Hop-style IP class checks + DNS resolve), call it before verify/rejection/notify fetches, and set `redirect: 'error'` to block open-redirect pivots.

## Test plan
- [x] `yarn vitest run __tests__/utils/safeCallbackUrl.test.ts --coverage=false` → 3/3
- [ ] CI green on this PR

Tooling assist used for prep; commit authored/signed by me (no Cursor co-author trailer).

Made with [Cursor](https://cursor.com)