### PR TITLE
chore: add SashaMIT to .clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -100,7 +100,8 @@
     "toosolid2003",
     "alvarengao",
     "9alekc1",
-    "claude[bot]"
+    "claude[bot]",
+    "SashaMIT"
   ],
   "message": "Thank you for your pull request and welcome to Unlock! We require contributors to sign our [Contributor License Agreement](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt), and we don't seem to have the users {{usersWithoutCLA}} on file. \nIn order for us to review and merge your code, please open _another_ pull request with a single modification: your github username added to the file `.clabot`.\nThank you! "
 }


### PR DESCRIPTION
## Why

cla-bot on #16593 / #16594 / #16595 requests a separate PR that only adds my GitHub username to `.clabot` to record CLA acceptance of [CLA.txt](https://github.com/unlock-protocol/unlock/blob/master/CLA.txt).

## Change

- Add `SashaMIT` to `.clabot` contributors (single-file change)

## Test plan

- [ ] cla-bot clears `verification/cla-signed` on the locksmith SSRF PRs after this merges


Made with [Cursor](https://cursor.com)