### PR TITLE
fix: sign with the authenticated wallet, not whichever Privy lists first

### DIFF
--- a/unlock-app/src/__tests__/hooks/useProvider.test.tsx
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+
+const AUTHENTICATED = '0x374355b89D26325c4C4Cd96f99753b82fd64b2Bb'
+const OTHER = '0x2268b701DdE76122ff70af751CafA39623799e49'
+
+const makeWallet = (address: string) => ({
+  address,
+  getEthereumProvider: vi.fn().mockResolvedValue({ __address: address }),
+})
+
+// Wallets Privy reports as connected. Reassigned per test.
+let connectedWallets: ReturnType<typeof makeWallet>[] = []
+const connectWallet = vi.fn()
+
+vi.mock('@privy-io/react-auth', () => ({
+  useWallets: () => ({ wallets: connectedWallets }),
+  // Must be callable with no arguments: passing callbacks reaches Privy
+  // internals that require a surrounding PrivyProvider.
+  useConnectWallet: () => ({ connectWallet }),
+}))
+
+const toastError = vi.fn<(message: string) => void>()
+vi.mock('@unlock-protocol/ui', () => ({
+  ToastHelper: {
+    error: (message: string) => toastError(message),
+    success: vi.fn(),
+  },
+}))
+
+const walletServiceConnect = vi.fn().mockResolvedValue(1)
+vi.mock('@unlock-protocol/unlock-js', () => ({
+  WalletService: class {
+    connect = walletServiceConnect
+    getAccount = vi.fn().mockResolvedValue(AUTHENTICATED)
+  },
+}))
+
+// Captures which underlying provider each BrowserProvider was built from, so
+// assertions can tell the two wallets apart.
+vi.mock('ethers', () => ({
+  ethers: {
+    BrowserProvider: class {
+      underlying: unknown
+      constructor(underlying: unknown) {
+        this.underlying = underlying
+      }
+      getNetwork = vi.fn().mockResolvedValue({ chainId: '8453' })
+      send = vi.fn().mockResolvedValue(undefined)
+    },
+  },
+}))
+
+import { useProvider } from '~/hooks/useProvider'
+import ProviderContext from '~/contexts/ProviderContext'
+import AuthenticationContext from '~/contexts/AuthenticationContext'
+
+const setProvider = vi.fn()
+
+// The provider already in context — deliberately the *wrong* wallet, matching
+// the state that produced the original bug.
+const staleProvider = {
+  underlying: { __address: OTHER },
+  getNetwork: vi.fn().mockResolvedValue({ chainId: '8453' }),
+  send: vi.fn().mockResolvedValue(undefined),
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    AuthenticationContext.Provider,
+    { value: { account: AUTHENTICATED, setAccount: vi.fn() } },
+    React.createElement(
+      ProviderContext.Provider,
+      { value: { provider: staleProvider, setProvider } },
+      children
+    )
+  )
+
+describe('useProvider', () => {
+  beforeEach(() => {
+    connectedWallets = []
+    connectWallet.mockClear()
+    toastError.mockClear()
+    setProvider.mockClear()
+    walletServiceConnect.mockClear()
+  })
+
+  it('picks the authenticated wallet by address, not by list position', async () => {
+    // Authenticated wallet is present but NOT first: indexing wallets[0] would
+    // pick the wrong one.
+    connectedWallets = [makeWallet(OTHER), makeWallet(AUTHENTICATED)]
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.getWalletService(8453)
+
+    expect(connectWallet).not.toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+
+    // The WalletService must be built from the authenticated wallet.
+    const usedProvider = walletServiceConnect.mock.calls[0][0]
+    expect(usedProvider.underlying).toEqual({ __address: AUTHENTICATED })
+  })
+
+  it('signs with the authenticated wallet, not the stale context provider', async () => {
+    // Context still holds the previously-connected wrong wallet.
+    connectedWallets = [makeWallet(AUTHENTICATED)]
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.getWalletService(8453)
+
+    const usedProvider = walletServiceConnect.mock.calls[0][0]
+    expect(usedProvider.underlying).not.toEqual({ __address: OTHER })
+    expect(usedProvider.underlying).toEqual({ __address: AUTHENTICATED })
+    // And the context is refreshed for subsequent renders.
+    expect(setProvider).toHaveBeenCalled()
+  })
+
+  it('throws instead of proceeding when the wrong wallet is connected', async () => {
+    connectedWallets = [makeWallet(OTHER)]
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+
+    await expect(result.current.getWalletService(8453)).rejects.toThrow(
+      /Wrong wallet connected/
+    )
+    // Crucially, it must not have built a WalletService on the wrong account:
+    // that is what surfaced as an unrelated contract revert.
+    expect(walletServiceConnect).not.toHaveBeenCalled()
+  })
+
+  it('prompts for the authenticated address and names it in the error', async () => {
+    connectedWallets = [makeWallet(OTHER)]
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+
+    await expect(result.current.getWalletService(8453)).rejects.toThrow(
+      /Wrong wallet connected/
+    )
+    expect(connectWallet).toHaveBeenCalledWith({
+      suggestedAddress: AUTHENTICATED,
+    })
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining(AUTHENTICATED)
+    )
+  })
+})

--- a/unlock-app/src/__tests__/hooks/useProvider.test.tsx
+++ b/unlock-app/src/__tests__/hooks/useProvider.test.tsx
@@ -60,13 +60,17 @@ import AuthenticationContext from '~/contexts/AuthenticationContext'
 
 const setProvider = vi.fn()
 
-// The provider already in context — deliberately the *wrong* wallet, matching
-// the state that produced the original bug.
-const staleProvider = {
-  underlying: { __address: OTHER },
+const makeContextProvider = (address: string, parentOrigin?: () => string) => ({
+  parentOrigin,
   getNetwork: vi.fn().mockResolvedValue({ chainId: '8453' }),
-  send: vi.fn().mockResolvedValue(undefined),
-}
+  send: vi.fn(async (method: string) =>
+    method === 'eth_accounts' ? [address] : undefined
+  ),
+})
+
+// Context holds a provider for a different address than the authenticated
+// account; WalletService must not be built from it.
+let contextProvider = makeContextProvider(OTHER)
 
 const wrapper = ({ children }: { children: React.ReactNode }) =>
   React.createElement(
@@ -74,7 +78,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
     { value: { account: AUTHENTICATED, setAccount: vi.fn() } },
     React.createElement(
       ProviderContext.Provider,
-      { value: { provider: staleProvider, setProvider } },
+      { value: { provider: contextProvider, setProvider } },
       children
     )
   )
@@ -82,6 +86,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
 describe('useProvider', () => {
   beforeEach(() => {
     connectedWallets = []
+    contextProvider = makeContextProvider(OTHER)
     connectWallet.mockClear()
     toastError.mockClear()
     setProvider.mockClear()
@@ -104,8 +109,8 @@ describe('useProvider', () => {
     expect(usedProvider.underlying).toEqual({ __address: AUTHENTICATED })
   })
 
-  it('signs with the authenticated wallet, not the stale context provider', async () => {
-    // Context still holds the previously-connected wrong wallet.
+  it('uses the authenticated wallet when context manages another account', async () => {
+    // The context provider does not manage the authenticated account.
     connectedWallets = [makeWallet(AUTHENTICATED)]
 
     const { result } = renderHook(() => useProvider(), { wrapper })
@@ -118,7 +123,7 @@ describe('useProvider', () => {
     expect(setProvider).toHaveBeenCalled()
   })
 
-  it('throws instead of proceeding when the wrong wallet is connected', async () => {
+  it('prompts for the authenticated wallet and refuses the wrong one', async () => {
     connectedWallets = [makeWallet(OTHER)]
 
     const { result } = renderHook(() => useProvider(), { wrapper })
@@ -126,24 +131,80 @@ describe('useProvider', () => {
     await expect(result.current.getWalletService(8453)).rejects.toThrow(
       /Wrong wallet connected/
     )
-    // Crucially, it must not have built a WalletService on the wrong account:
-    // that is what surfaced as an unrelated contract revert.
+    // WalletService must never be built from a provider for another account.
     expect(walletServiceConnect).not.toHaveBeenCalled()
-  })
-
-  it('prompts for the authenticated address and names it in the error', async () => {
-    connectedWallets = [makeWallet(OTHER)]
-
-    const { result } = renderHook(() => useProvider(), { wrapper })
-
-    await expect(result.current.getWalletService(8453)).rejects.toThrow(
-      /Wrong wallet connected/
-    )
     expect(connectWallet).toHaveBeenCalledWith({
       suggestedAddress: AUTHENTICATED,
     })
-    expect(toastError).toHaveBeenCalledWith(
-      expect.stringContaining(AUTHENTICATED)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('preserves a delegated provider when Privy has no connected wallet', async () => {
+    contextProvider = makeContextProvider(
+      OTHER,
+      () => 'https://checkout.example.com'
+    )
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.getWalletService(8453)
+
+    expect(walletServiceConnect).toHaveBeenCalledWith(contextProvider)
+    expect(connectWallet).not.toHaveBeenCalled()
+    expect(setProvider).not.toHaveBeenCalled()
+  })
+
+  it('preserves a delegated provider when Privy also has the authenticated wallet', async () => {
+    connectedWallets = [makeWallet(AUTHENTICATED)]
+    contextProvider = makeContextProvider(
+      OTHER,
+      () => 'https://checkout.example.com'
+    )
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.getWalletService(8453)
+
+    expect(walletServiceConnect).toHaveBeenCalledWith(contextProvider)
+    expect(setProvider).not.toHaveBeenCalled()
+  })
+
+  it('reuses a context provider whose default signer is authenticated', async () => {
+    const wallet = makeWallet(AUTHENTICATED)
+    connectedWallets = [wallet]
+    contextProvider = makeContextProvider(AUTHENTICATED)
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.getWalletService(8453)
+
+    expect(walletServiceConnect).toHaveBeenCalledWith(contextProvider)
+    expect(wallet.getEthereumProvider).not.toHaveBeenCalled()
+    expect(setProvider).not.toHaveBeenCalled()
+  })
+
+  it('watches an asset through the authenticated wallet provider', async () => {
+    connectedWallets = [makeWallet(OTHER), makeWallet(AUTHENTICATED)]
+
+    const { result } = renderHook(() => useProvider(), { wrapper })
+    await result.current.watchAsset({
+      address: '0xLock',
+      network: 8453,
+      tokenId: '42',
+    })
+
+    const activeProvider = setProvider.mock.calls[0][0]
+    expect(contextProvider.send).toHaveBeenCalledTimes(1)
+    expect(contextProvider.send).toHaveBeenCalledWith('eth_accounts', [])
+    expect(activeProvider.send).toHaveBeenNthCalledWith(
+      1,
+      'wallet_switchEthereumChain',
+      [{ chainId: '0x2105' }]
+    )
+    expect(activeProvider.send).toHaveBeenNthCalledWith(
+      2,
+      'wallet_watchAsset',
+      {
+        type: 'ERC721',
+        options: { address: '0xLock', tokenId: '42' },
+      }
     )
   })
 })

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -14,6 +14,10 @@ interface WatchAssetInterface {
   tokenId: string
 }
 
+interface ProviderWithSend {
+  send?: (method: string, params: unknown[]) => Promise<unknown>
+}
+
 export const useProvider = () => {
   const { setProvider, provider } = useContext(ProviderContext)
   const { account } = useContext(AuthenticationContext)
@@ -99,6 +103,18 @@ export const useProvider = () => {
     }
   }
 
+  const getProviderAccount = async (targetProvider?: ProviderWithSend) => {
+    try {
+      const accounts = await targetProvider?.send?.('eth_accounts', [])
+      if (!Array.isArray(accounts) || typeof accounts[0] !== 'string') {
+        return undefined
+      }
+      return accounts[0].toLowerCase()
+    } catch {
+      return undefined
+    }
+  }
+
   /**
    * Resolves the provider belonging to the authenticated account, prompting
    * the user to connect it if it is not already available.
@@ -108,9 +124,18 @@ export const useProvider = () => {
    * from a different address than the one the UI shows as connected.
    */
   const resolveAuthenticatedProvider = async () => {
-    if (!account) return provider
+    // Delegated providers are owned by the checkout's parent page. They may
+    // authenticate through SIWE without exposing a wallet through Privy.
+    if (!account || provider?.parentOrigin) return provider
 
     const authenticatedAddress = account.toLowerCase()
+
+    // Reuse the context provider when its default signer already matches.
+    // WalletService also uses signer index 0, so checking that same account
+    // avoids replacing the provider and re-rendering the application tree.
+    if ((await getProviderAccount(provider)) === authenticatedAddress) {
+      return provider
+    }
 
     // Privy exposes every connected wallet and makes no promise about their
     // order, so the authenticated one has to be looked up by address.
@@ -125,9 +150,6 @@ export const useProvider = () => {
       // state. The user retries once connected, by which point this hook has
       // re-rendered with the new wallet.
       connectWallet({ suggestedAddress: account })
-      ToastHelper.error(
-        `Please switch to address ${account} in your wallet, then try again.`
-      )
       return null
     }
 
@@ -138,17 +160,11 @@ export const useProvider = () => {
     // Keep the context in sync for later renders. The returned value is what
     // this call must use: `provider` from context is captured at render time
     // and will still hold the previous wallet for the rest of this call.
-    setProvider(browserProvider)
+    if (browserProvider) {
+      setProvider(browserProvider)
+    }
 
     return browserProvider
-  }
-
-  /**
-   * Ensures the connected wallet matches the authenticated account
-   * Returns true if successful, false otherwise
-   */
-  const ensureCorrectWallet = async () => {
-    return (await resolveAuthenticatedProvider()) !== null
   }
 
   /**
@@ -231,8 +247,11 @@ export const useProvider = () => {
     network,
     tokenId,
   }: WatchAssetInterface) => {
-    await switchProviderNetwork(network)
-    await provider.send('wallet_watchAsset', {
+    const activeProvider = await resolveAuthenticatedProvider()
+    if (!activeProvider) return
+
+    await switchProviderNetwork(network, activeProvider)
+    await activeProvider.send('wallet_watchAsset', {
       type: 'ERC721',
       options: {
         address,
@@ -249,6 +268,5 @@ export const useProvider = () => {
     account: provider ? account : undefined,
     watchAsset,
     provider,
-    ensureCorrectWallet,
   }
 }

--- a/unlock-app/src/hooks/useProvider.ts
+++ b/unlock-app/src/hooks/useProvider.ts
@@ -18,6 +18,7 @@ export const useProvider = () => {
   const { setProvider, provider } = useContext(ProviderContext)
   const { account } = useContext(AuthenticationContext)
   const { wallets } = useWallets()
+
   const { connectWallet } = useConnectWallet()
 
   const createBrowserProvider = (
@@ -55,7 +56,10 @@ export const useProvider = () => {
     }
   }
 
-  const addNetworkToWallet = async (networkId: number) => {
+  const addNetworkToWallet = async (
+    networkId: number,
+    targetProvider = provider
+  ) => {
     const {
       id,
       name: chainName,
@@ -72,19 +76,22 @@ export const useProvider = () => {
       blockExplorerUrls: [explorer.urls.base],
     }
 
-    return provider.send('wallet_addEthereumChain', [params], account)
+    return targetProvider.send('wallet_addEthereumChain', [params], account)
   }
 
-  const switchProviderNetwork = async (id: number) => {
+  const switchProviderNetwork = async (
+    id: number,
+    targetProvider = provider
+  ) => {
     try {
-      await provider.send('wallet_switchEthereumChain', [
+      await targetProvider.send('wallet_switchEthereumChain', [
         {
           chainId: `0x${id.toString(16)}`,
         },
       ])
     } catch (switchError: any) {
       if (switchError.code === 4902 || switchError.code === -32603) {
-        return addNetworkToWallet(id)
+        return addNetworkToWallet(id, targetProvider)
       } else {
         console.error('There was an error switching networks:', switchError)
         throw switchError
@@ -93,46 +100,55 @@ export const useProvider = () => {
   }
 
   /**
+   * Resolves the provider belonging to the authenticated account, prompting
+   * the user to connect it if it is not already available.
+   *
+   * Returns `null` when the authenticated wallet could not be connected, so
+   * callers must not fall back to the ambient provider: it may well be signing
+   * from a different address than the one the UI shows as connected.
+   */
+  const resolveAuthenticatedProvider = async () => {
+    if (!account) return provider
+
+    const authenticatedAddress = account.toLowerCase()
+
+    // Privy exposes every connected wallet and makes no promise about their
+    // order, so the authenticated one has to be looked up by address.
+    const wallet = wallets.find(
+      (w) => w.address?.toLowerCase() === authenticatedAddress
+    )
+
+    if (!wallet || typeof wallet.getEthereumProvider !== 'function') {
+      // Open the connect modal so the user can switch, but do not wait on it.
+      // `connectWallet` resolves nothing, and `wallets` is captured at render
+      // time, so re-reading it here would only ever report the pre-switch
+      // state. The user retries once connected, by which point this hook has
+      // re-rendered with the new wallet.
+      connectWallet({ suggestedAddress: account })
+      ToastHelper.error(
+        `Please switch to address ${account} in your wallet, then try again.`
+      )
+      return null
+    }
+
+    const browserProvider = createBrowserProvider(
+      await wallet.getEthereumProvider()
+    )
+
+    // Keep the context in sync for later renders. The returned value is what
+    // this call must use: `provider` from context is captured at render time
+    // and will still hold the previous wallet for the rest of this call.
+    setProvider(browserProvider)
+
+    return browserProvider
+  }
+
+  /**
    * Ensures the connected wallet matches the authenticated account
    * Returns true if successful, false otherwise
    */
   const ensureCorrectWallet = async () => {
-    if (!account) return true
-    // Get current connected address
-    const currentWalletAddress = wallets[0]?.address?.toLowerCase()
-    const authenticatedAddress = account.toLowerCase()
-
-    // If addresses match, we're good
-    if (currentWalletAddress === authenticatedAddress) return true
-
-    // If wallet not connected or wrong address, try to connect with the right one
-    try {
-      // Try to trigger wallet connection with the authenticated address
-      await connectWallet({
-        suggestedAddress: account!,
-      })
-
-      // Re-check if switch was successful
-      const newWallet = wallets[0]
-      const newWalletAddress = newWallet?.address?.toLowerCase()
-
-      if (newWalletAddress === authenticatedAddress) {
-        // If we've switched wallets, we need to update the provider
-        if (newWallet && currentWalletAddress !== newWalletAddress) {
-          const newProvider = await newWallet.getEthereumProvider()
-          setProvider(createBrowserProvider(newProvider))
-        }
-
-        return true
-      } else {
-        // If still not matching, show error
-        ToastHelper.error(`Please switch to address ${account} in your wallet.`)
-        return false
-      }
-    } catch (error) {
-      console.error('Error switching to authenticated wallet:', error)
-      return false
-    }
+    return (await resolveAuthenticatedProvider()) !== null
   }
 
   /**
@@ -154,11 +170,18 @@ export const useProvider = () => {
     }
 
     try {
-      // Ensure the wallet matches the authenticated account before proceeding
-      await ensureCorrectWallet()
+      // Ensure the wallet matches the authenticated account before proceeding.
+      // Signing with a different address than the UI reports produces failures
+      // that surface as unrelated contract reverts, so this must be fatal.
+      const activeProvider = await resolveAuthenticatedProvider()
+      if (!activeProvider) {
+        throw new Error(
+          `Wrong wallet connected. Please switch to ${account} in your wallet and try again.`
+        )
+      }
 
       // Get the current network
-      const network = await provider.getNetwork()
+      const network = await activeProvider.getNetwork()
       const currentChainId = parseInt(network.chainId)
 
       console.debug(
@@ -168,11 +191,11 @@ export const useProvider = () => {
       // compare the networkId with the current chainId
       if (networkId && networkId !== currentChainId) {
         // Prompt user to switch to the requested network
-        await switchProviderNetwork(networkId!)
+        await switchProviderNetwork(networkId!, activeProvider)
         await new Promise((resolve, reject): void => {
           const start = new Date().getTime()
           const interval = setInterval(async () => {
-            const network = await provider.getNetwork()
+            const network = await activeProvider.getNetwork()
             const currentChainId = parseInt(network.chainId)
             console.debug(
               `Currently connected to network: ${currentChainId} and want ${networkId!}`
@@ -192,9 +215,9 @@ export const useProvider = () => {
         })
       }
 
-      // instantiate the wallet service with the current provider
+      // instantiate the wallet service with the authenticated account's provider
       const { walletService: _walletService } =
-        await createWalletService(provider)
+        await createWalletService(activeProvider)
       return _walletService
     } catch (error: any) {
       console.error('Error in getWalletService:', error)

--- a/unlock-app/src/utils/networks.ts
+++ b/unlock-app/src/utils/networks.ts
@@ -45,7 +45,12 @@ export const useAvailableNetworks = (all = false) => {
         )
       }
     }
-    filterNetworksForUser()
+    filterNetworksForUser().catch((error) => {
+      console.error(
+        'Could not filter networks for the connected wallet:',
+        error
+      )
+    })
   }, [account])
 
   return availableNetworks


### PR DESCRIPTION
# Description

Fixes wallet-backed transactions using a different connected wallet from the account shown as authenticated.

Privy can return multiple connected wallets without guaranteeing their order. `useProvider` now resolves the wallet whose address matches the authenticated account, creates the `WalletService` from that wallet provider instead of a stale context provider, and stops the transaction with a clear prompt when the correct wallet is unavailable.

Delegated checkout providers remain owned by the parent page, matching context providers are reused without replacing provider identity, and asset watching uses the authenticated provider. Background network discovery also handles wallet mismatch rejections without leaving an unhandled promise.

Adds focused regression tests covering unordered wallets, stale context, delegated checkout with and without a Privy session, provider reuse, mismatched-wallet handling, and asset watching.

# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not applicable
- [x] I have added tests that prove the fix is effective
- [x] I have performed a self-review of my own code
- [x] Screenshots are not applicable because this has no visual changes

# Testing

- `yarn workspace @unlock-protocol/unlock-app vitest run --coverage.enabled=false` — 234 passed, 3 skipped
- `yarn workspace @unlock-protocol/unlock-app tsc --noEmit --pretty false`
- ESLint and Prettier checks on the changed files
- Repository pre-commit and pre-push hooks

## Release Note Draft Snippet

Fixed wallet-backed actions, including membership airdrops, so they sign with the authenticated wallet instead of another connected wallet.