### PR TITLE
fix(locksmith): harden Privy login and log why logins are rejected

### DIFF
--- a/locksmith/__tests__/controllers/v2/authController.test.ts
+++ b/locksmith/__tests__/controllers/v2/authController.test.ts
@@ -4,6 +4,8 @@ import app from '../../app'
 import { afterAll, beforeAll, expect, vi } from 'vitest'
 import config from '../../../src/config/config'
 import { privy } from '../../../src/utils/privyClient'
+import { Session } from '../../../src/models'
+import { logger } from '../../../src/logger'
 
 vi.mock('../../../src/utils/privyClient', () => ({
   privy: {
@@ -149,5 +151,98 @@ describe('Auth login endpoints for locksmith', () => {
     expect(revokeResponse.status).toBe(200)
     expect(revokeResponse.body.message).toBe('Successfully revoked')
     expect(tokenResponse.status).toBe(401)
+  })
+})
+
+describe('Privy login hardening', () => {
+  const walletAddress = '0xabCD567890123456789012345678901234567890'
+
+  const mockPrivy = (tokenUserId: string, walletUserId: string) => {
+    if (!privy) {
+      throw new Error('Privy client is not initialized')
+    }
+    vi.mocked(privy.verifyAuthToken).mockResolvedValue({
+      userId: tokenUserId,
+      appId: 'mock-app-id',
+      issuer: 'mock-issuer',
+      issuedAt: Date.now(),
+      expiration: Date.now() + 1000 * 60 * 60 * 24,
+      sessionId: 'mock-session-id',
+    })
+    vi.mocked(privy.getUserByWalletAddress).mockResolvedValue({
+      id: walletUserId,
+      linkedAccounts: [{ type: 'wallet', address: walletAddress }],
+    } as any)
+  }
+
+  it('rejects a wallet that does not belong to the token user without creating a session', async () => {
+    expect.assertions(3)
+    mockPrivy('user-from-token', 'user-owning-wallet')
+    const before = await Session.count()
+
+    const response = await request(app)
+      .post('/v2/auth/privy')
+      .send({ accessToken: 'token', walletAddress })
+
+    expect(response.status).toBe(401)
+    expect(response.body.accessToken).toBeUndefined()
+    expect(await Session.count()).toBe(before)
+  })
+
+  it('returns 400 rather than 401 when the body was not parsed as JSON', async () => {
+    expect.assertions(2)
+    mockPrivy('user', 'user')
+
+    const response = await request(app)
+      .post('/v2/auth/privy')
+      .set('content-type', 'text/plain')
+      .send(JSON.stringify({ accessToken: 'token', walletAddress }))
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toBe('Access token is required')
+  })
+
+  it('logs request diagnostics when rejecting a login with 400', async () => {
+    expect.assertions(2)
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+    const response = await request(app)
+      .post('/v2/auth/privy')
+      .set('origin', 'https://app.unlock-protocol.com')
+      .send({ walletAddress })
+
+    expect(response.status).toBe(400)
+    expect(warn).toHaveBeenCalledWith(
+      'Privy login rejected',
+      expect.objectContaining({
+        reason: 'Access token is required',
+        origin: 'https://app.unlock-protocol.com',
+        contentType: expect.stringContaining('application/json'),
+        bodyKeys: ['walletAddress'],
+      })
+    )
+    warn.mockRestore()
+  })
+})
+
+describe('Authorization header handling', () => {
+  it('treats an unsupported authorization scheme as unauthenticated and logs it', async () => {
+    expect.assertions(3)
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+    const publicResponse = await request(app)
+      .get('/v2/auth/nonce')
+      .set('authorization', 'Basic abc')
+    const protectedResponse = await request(app)
+      .get('/v2/auth/user')
+      .set('authorization', 'Basic abc')
+
+    expect(publicResponse.status).toBe(200)
+    expect(protectedResponse.status).toBe(401)
+    expect(warn).toHaveBeenCalledWith(
+      'Unsupported authorization scheme',
+      expect.objectContaining({ scheme: 'basic' })
+    )
+    warn.mockRestore()
   })
 })

--- a/locksmith/src/controllers/v2/authController.ts
+++ b/locksmith/src/controllers/v2/authController.ts
@@ -121,17 +121,39 @@ export const login: RequestHandler = async (request, response) => {
   }
 }
 
+// Logs enough about a rejected Privy login to diagnose it from the logs alone:
+// the request body is not logged by the request logger, so record its shape.
+const rejectPrivyLogin = (
+  request: Parameters<RequestHandler>[0],
+  response: Parameters<RequestHandler>[1],
+  status: number,
+  reason: string
+) => {
+  logger.warn('Privy login rejected', {
+    reason,
+    status,
+    origin: request.headers.origin,
+    userAgent: request.headers['user-agent'],
+    contentType: request.headers['content-type'],
+    contentLength: request.headers['content-length'],
+    bodyKeys: Object.keys(request.body ?? {}),
+  })
+  response.status(status).json({ error: reason })
+}
+
 export const loginWithPrivy: RequestHandler = async (request, response) => {
   try {
-    const { accessToken, walletAddress } = request.body
+    // Express leaves `request.body` undefined when no body parser matched
+    // the content type, so treat that the same as an empty body.
+    const { accessToken, walletAddress } = request.body ?? {}
 
     if (!accessToken) {
-      response.status(400).json({ error: 'Access token is required' })
+      rejectPrivyLogin(request, response, 400, 'Access token is required')
       return
     }
 
     if (!walletAddress) {
-      response.status(400).json({ error: 'walletAddress is required' })
+      rejectPrivyLogin(request, response, 400, 'walletAddress is required')
       return
     }
 
@@ -145,10 +167,13 @@ export const loginWithPrivy: RequestHandler = async (request, response) => {
     const user = await privy.getUserByWalletAddress(walletAddress)
 
     if (!user || userAuthClaims.userId !== user.id) {
-      response.status(401).json({
-        error:
-          'The wallet you are authenticating with does not match your authentication token',
-      })
+      rejectPrivyLogin(
+        request,
+        response,
+        401,
+        'The wallet you are authenticating with does not match your authentication token'
+      )
+      return
     }
 
     // Create a new session

--- a/locksmith/src/utils/middlewares/auth.ts
+++ b/locksmith/src/utils/middlewares/auth.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { RequestHandler, response } from 'express'
+import { RequestHandler } from 'express'
 import { Application } from '../../models/application'
 import { logger } from '../../logger'
 import normalizer from '../normalizer'
@@ -115,10 +115,10 @@ export const authMiddleware: RequestHandler = async (req, _, next) => {
       }
       return next()
     }
-    response.status(400).send({
-      message: 'Unsupported authorization type',
-    })
-    return
+    // Unknown schemes are treated as unauthenticated rather than rejected:
+    // this middleware also fronts public routes.
+    logger.warn('Unsupported authorization scheme', { scheme: tokenType })
+    return next()
   } catch (error) {
     logger.info(error.message)
     return next()


### PR DESCRIPTION
# Description

Users are reporting they cannot connect; Railway's edge logs show `POST /v2/auth/privy` answering **400** for ~88% of attempts over the last 10 days (2,549 × 400 vs 349 × 200), from ~40 countries. The controller only returns 400 when `accessToken`/`walletAddress` is missing from the parsed body, the frontend never sends the request without both, and Locksmith logs nothing on that path — so today it is impossible to tell *why* those bodies arrive empty.

This PR fixes the defects found while tracing that path and adds the diagnostics needed to close the investigation:

- **Session created for a mismatched wallet.** The wallet/token mismatch branch sent a 401 but did not `return`, so it went on to create a session for the wrong wallet and then crashed on a second send (`Cannot set headers after they are sent`).
- **Unparsed bodies surfaced as 401.** Express 5 leaves `request.body` undefined when no body parser matched; destructuring it threw and the catch answered `401 Invalid access token` instead of `400 Access token is required`.
- **No diagnostics on rejection.** Every rejection now logs `origin`, `user-agent`, `content-type`, `content-length` and the body's keys (never values) to Better Stack.
- **Dead branch in `authMiddleware`.** The "Unsupported authorization type" branch used Express's `response` *prototype* (`import { response } from 'express'`), threw, and silently fell through. Since this middleware fronts public `/v2` routes too, the fall-through is now explicit and logged rather than turned into a 400 that would reject stray headers on public endpoints.

# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not applicable
- [x] I have added tests that prove the fix is effective
- [x] I have performed a self-review of my own code
- [x] Screenshots are not applicable because this has no visual changes

# Testing

- `locksmith`: 4 new tests in `__tests__/controllers/v2/authController.test.ts` (each watched failing first): mismatch does not create a session, `text/plain` body → 400, rejection logs diagnostics, unsupported auth scheme falls through with a warning.
- `vitest run __tests__/controllers/v2 __tests__/utils` — 222 passed, 2 skipped.
- `tsc --noEmit`, ESLint (0 errors), Prettier.

## Release Note Draft Snippet

Locksmith no longer creates a session when a Privy wallet does not match the authenticated user, and rejected logins are now logged with enough detail to diagnose them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyw4VrQMe4pkTe7aV6WEJd
