### PR TITLE
fix(ci): build workspace packages before deploying provider and graph-service

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -109,6 +109,8 @@ jobs:
     with:
       workspace: '@unlock-protocol/provider'
       sync-secrets-command: yarn workspace @unlock-protocol/provider set-env-vars
+      # wrangler bundles these workspace packages from their dist/ output
+      pre-deploy-command: yarn workspace @unlock-protocol/types build && yarn workspace @unlock-protocol/networks build && yarn workspace @unlock-protocol/contracts build
       smoke-test-command: |
         body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS \
           -H 'Content-Type: application/json' \
@@ -125,6 +127,8 @@ jobs:
     with:
       workspace: graph-service
       sync-secrets-command: yarn workspace graph-service set-graph-urls
+      # wrangler bundles @unlock-protocol/networks from its dist/ output
+      pre-deploy-command: yarn workspace @unlock-protocol/types build && yarn workspace @unlock-protocol/networks build
       smoke-test-command: |
         headers=$(mktemp)
         curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -D "$headers" -o /dev/null 'https://subgraph.unlock-protocol.com/1'


### PR DESCRIPTION
# Description

`deploy-rpc-provider` and `deploy-graph-service` in `production.yml` have failed on every production run since the Cloudflare worker deployments were unified (#16542), including tonight's hotfix run (`33346736817`):

```
✘ [ERROR] Could not resolve "@unlock-protocol/networks"
    The module "./dist/index.mjs" was not found on the file system
✘ [ERROR] Could not resolve "@unlock-protocol/contracts"
```

The reusable `_cloudflare-worker.yml` only runs `yarn install` before `wrangler deploy`; it never builds the workspace packages the workers bundle. `deploy-wedlocks` already solves this with `pre-deploy-command` for `email-templates`. This adds the same for:

- `graph-service`: `types` → `networks`
- `provider`: `types` → `networks` → `contracts`

(`networks` imports `HookType` from `types` at runtime, hence building `types` first.)

`master.yml` does not deploy these two workers to staging, which is why it never surfaced there.

# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not applicable
- [x] I have added tests that prove the fix is effective — n/a, workflow config; YAML parses and mirrors the existing `deploy-wedlocks` pattern
- [x] I have performed a self-review of my own code
- [x] Screenshots are not applicable because this has no visual changes

# Testing

Verified only by YAML parsing and by matching the working `deploy-wedlocks` job; the real check is the next production run. Note that #16609 (network retirement) touches both workers and will need this to actually deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyw4VrQMe4pkTe7aV6WEJd
