### PR TITLE
Hotfix production: build workspace packages before deploying provider and graph-service (#16610)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -109,6 +109,8 @@ jobs:
     with:
       workspace: '@unlock-protocol/provider'
       sync-secrets-command: yarn workspace @unlock-protocol/provider set-env-vars
+      # wrangler bundles these workspace packages from their dist/ output
+      pre-deploy-command: yarn workspace @unlock-protocol/types build && yarn workspace @unlock-protocol/networks build && yarn workspace @unlock-protocol/contracts build
       smoke-test-command: |
         body=$(curl --retry 5 --retry-all-errors --retry-delay 3 -fsS \
           -H 'Content-Type: application/json' \
@@ -125,6 +127,8 @@ jobs:
     with:
       workspace: graph-service
       sync-secrets-command: yarn workspace graph-service set-graph-urls
+      # wrangler bundles @unlock-protocol/networks from its dist/ output
+      pre-deploy-command: yarn workspace @unlock-protocol/types build && yarn workspace @unlock-protocol/networks build
       smoke-test-command: |
         headers=$(mktemp)
         curl --retry 5 --retry-all-errors --retry-delay 3 -fsS -D "$headers" -o /dev/null 'https://subgraph.unlock-protocol.com/1'


### PR DESCRIPTION
# Description

Hotfix cherry-pick of #16610 onto `production` (current head `a5b6966ac`).

Adds `pre-deploy-command` builds (`types` → `networks` [→ `contracts`]) to the `deploy-rpc-provider` and `deploy-graph-service` jobs so `wrangler` can bundle `@unlock-protocol/networks` / `@unlock-protocol/contracts`. Both jobs have failed on every production run since #16542, including tonight's `33346736817`.

Merging this triggers a production run, which is the real verification of the fix.

# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not applicable
- [x] I have added tests that prove the fix is effective — n/a, workflow config
- [x] I have performed a self-review of my own code
- [x] Screenshots are not applicable because this has no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyw4VrQMe4pkTe7aV6WEJd
