### PR TITLE
fix(locksmith): log to stdout in production and stop printing the database URL

### DIFF
--- a/locksmith/.op.env.production
+++ b/locksmith/.op.env.production
@@ -7,7 +7,6 @@ STORAGE_ENDPOINT=op://secrets/cloudflare/storage-endpoint-prod
 STORAGE_ACCESS_KEY_ID=op://secrets/cloudflare/storage-access-key-id-prod
 STORAGE_SECRET_ACCESS_KEY=op://secrets/cloudflare/storage-secret-access-key-prod
 STORAGE_PUBLIC_HOST=op://secrets/cloudflare/storage-public-host-prod
-LOGTAIL=op://secrets/logtail/logtail-prod
 PROVIDER_SECRET_KEY=op://secrets/rpc-providers/locksmith-secret-key
 PURCHASER_CREDENTIALS=op://secrets/purchaser/credentials-prod
 ON_HEROKU=true

--- a/locksmith/__tests__/logger.test.ts
+++ b/locksmith/__tests__/logger.test.ts
@@ -11,7 +11,11 @@ const loadLoggerWithEnv = async (nodeEnv: string) => {
     const { logger } = await import('../src/logger')
     return logger
   } finally {
-    process.env.NODE_ENV = previous
+    if (previous === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = previous
+    }
     vi.resetModules()
   }
 }

--- a/locksmith/__tests__/logger.test.ts
+++ b/locksmith/__tests__/logger.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Verifies the winston logger writes to stdout in every environment
+// ABOUTME: except tests, since Railway's log view is the only log sink.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import winston from 'winston'
+
+const loadLoggerWithEnv = async (nodeEnv: string) => {
+  const previous = process.env.NODE_ENV
+  process.env.NODE_ENV = nodeEnv
+  vi.resetModules()
+  try {
+    const { logger } = await import('../src/logger')
+    return logger
+  } finally {
+    process.env.NODE_ENV = previous
+    vi.resetModules()
+  }
+}
+
+describe('logger', () => {
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('writes to the console in production', async () => {
+    const logger = await loadLoggerWithEnv('production')
+    const consoleTransports = logger.transports.filter(
+      (transport) => transport instanceof winston.transports.Console
+    )
+    expect(consoleTransports).toHaveLength(1)
+    expect(consoleTransports[0].silent).toBeFalsy()
+  })
+
+  it('stays quiet in tests', async () => {
+    const logger = await loadLoggerWithEnv('test')
+    const consoleTransports = logger.transports.filter(
+      (transport) => transport instanceof winston.transports.Console
+    )
+    expect(consoleTransports).toHaveLength(1)
+    expect(consoleTransports[0].silent).toBe(true)
+  })
+
+  it('uses only the console transport', async () => {
+    const logger = await loadLoggerWithEnv('production')
+    expect(logger.transports).toHaveLength(1)
+  })
+})

--- a/locksmith/__tests__/worker/workerBoot.test.ts
+++ b/locksmith/__tests__/worker/workerBoot.test.ts
@@ -9,10 +9,16 @@ describe('worker module import', () => {
   })
 
   it('does not print the database URL', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const methods = ['log', 'info', 'warn', 'error', 'debug'] as const
+    const spies = methods.map((method) =>
+      vi.spyOn(console, method).mockImplementation(() => {})
+    )
     vi.resetModules()
     await import('../../src/worker/worker')
-    const printed = log.mock.calls.map((call) => call.join(' ')).join('\n')
+    const printed = spies
+      .flatMap((spy) => spy.mock.calls)
+      .map((call) => call.join(' '))
+      .join('\n')
     expect(printed).not.toMatch(/DATABASE|postgres(ql)?:\/\//)
   })
 })

--- a/locksmith/__tests__/worker/workerBoot.test.ts
+++ b/locksmith/__tests__/worker/workerBoot.test.ts
@@ -1,0 +1,18 @@
+// ABOUTME: Guards against the worker module printing secrets (such as the
+// ABOUTME: database URL with its password) to stdout when it is imported.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('worker module import', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('does not print the database URL', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.resetModules()
+    await import('../../src/worker/worker')
+    const printed = log.mock.calls.map((call) => call.join(' ')).join('\n')
+    expect(printed).not.toMatch(/DATABASE|postgres(ql)?:\/\//)
+  })
+})

--- a/locksmith/config/config.js
+++ b/locksmith/config/config.js
@@ -25,7 +25,6 @@ const config = {
     wedlocks: process.env.WEDLOCKS || 'http://localhost:1337',
   },
   recaptchaSecret: process.env.RECAPTCHA_SECRET,
-  logtailSourceToken: process.env.LOGTAIL,
   requestTimeout: '25s',
   defenderRelayCredentials,
   sentry: {

--- a/locksmith/package.json
+++ b/locksmith/package.json
@@ -38,8 +38,6 @@
     "@ambire/signature-validator": "1.4.1",
     "@aws-sdk/client-s3": "3.908.0",
     "@guildxyz/sdk": "2.6.9",
-    "@logtail/node": "0.5.4",
-    "@logtail/winston": "0.5.4",
     "@nuintun/qrcode": "5.0.2",
     "@openzeppelin/merkle-tree": "1.0.8",
     "@privy-io/server-auth": "1.32.5",

--- a/locksmith/src/config/config.ts
+++ b/locksmith/src/config/config.ts
@@ -118,7 +118,6 @@ const config = {
   eventCasterApiKey: process.env.EVENTCASTER_API_KEY,
   // Secret key to authenticate with the provider service
   providerSecretKey: process.env.PROVIDER_SECRET_KEY,
-  logtailSourceToken: process.env.LOGTAIL,
   sessionDuration: Number(process.env.SESSION_DURATION || 86400 * 60), // 60 days
   requestTimeout: '25s',
   databaseUrl: process.env.DATABASE_URL || '',

--- a/locksmith/src/logger.ts
+++ b/locksmith/src/logger.ts
@@ -1,7 +1,6 @@
+// ABOUTME: Application logger. Railway's log view (stdout) is the only log
+// ABOUTME: sink, so the console transport stays on everywhere except in tests.
 import winston from 'winston'
-import { Logtail } from '@logtail/node'
-import { LogtailTransport } from '@logtail/winston'
-import config from '../config/config'
 
 const { combine, timestamp, json, simple } = winston.format
 
@@ -14,19 +13,9 @@ export const logger = winston.createLogger({
 // No output in tests
 logger.add(
   new winston.transports.Console({
-    silent: !!(
-      process.env?.NODE_ENV &&
-      ['test', 'production'].indexOf(process.env?.NODE_ENV) > -1
-    ),
+    silent: process.env?.NODE_ENV === 'test',
     format: simple(),
   })
 )
-
-if (process.env.NODE_ENV === 'production') {
-  if (config.logtailSourceToken) {
-    const logtail = new Logtail(config.logtailSourceToken)
-    logger.add(new LogtailTransport(logtail))
-  }
-}
 
 export default logger

--- a/locksmith/src/worker/worker.ts
+++ b/locksmith/src/worker/worker.ts
@@ -52,8 +52,6 @@ const cronTabTesting = `
 
 const crontab = config.isProduction ? crontabProduction : cronTabTesting
 
-console.log('DATABASE', config.databaseUrl)
-
 export const addJob = async (jobName: string, payload: any, opts = {}) => {
   // Default priority for tasks is 0, we do not want to make clients wait
   return quickAddJob(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9527,60 +9527,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logtail/core@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@logtail/core@npm:0.5.4"
-  dependencies:
-    "@logtail/tools": "npm:^0.5.4"
-    "@logtail/types": "npm:^0.5.3"
-    serialize-error: "npm:8.1.0"
-  checksum: 10/8fd2fcc009ec88d968270f2308dd4e334029a4f793bae6450dc7f9bd2af6d1f07da864a4d3226e70408ec46b0a888ca0b98c9edca6be80a993e4e3bcf74a634d
-  languageName: node
-  linkType: hard
-
-"@logtail/node@npm:0.5.4, @logtail/node@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@logtail/node@npm:0.5.4"
-  dependencies:
-    "@logtail/core": "npm:^0.5.4"
-    "@logtail/types": "npm:^0.5.3"
-    "@msgpack/msgpack": "npm:^2.5.1"
-    "@types/stack-trace": "npm:^0.0.33"
-    minimatch: "npm:^9.0.5"
-    stack-trace: "npm:0.0.10"
-  checksum: 10/c1f64c227536e82755343a9baa209ac939801a455c06485014fd43b2a2e369a9fc8f962f95996ccee260232b72a8992aaabd2b46092ba768848b38603448278c
-  languageName: node
-  linkType: hard
-
-"@logtail/tools@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@logtail/tools@npm:0.5.4"
-  dependencies:
-    "@logtail/types": "npm:^0.5.3"
-  checksum: 10/e7371bc3c00be91582c2c0df166cd071c22a63e9d9d03b710d35f50ad6b6357bbe729a272d60ac4c5d30599feaf34cbc82daf2014666a369523de2db9dd6fb90
-  languageName: node
-  linkType: hard
-
-"@logtail/types@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "@logtail/types@npm:0.5.3"
-  checksum: 10/f7c4af77972f01ef176955626ded68e88a02a4dd7a8fdbbae7f002e77e95ee202b82b23b4035cc228157aff322f409aeca6652d9db88c962b82bb7898c6d2403
-  languageName: node
-  linkType: hard
-
-"@logtail/winston@npm:0.5.4":
-  version: 0.5.4
-  resolution: "@logtail/winston@npm:0.5.4"
-  dependencies:
-    "@logtail/node": "npm:^0.5.4"
-    "@logtail/types": "npm:^0.5.3"
-    winston-transport: "npm:^4.3.0"
-  peerDependencies:
-    winston: ">=3.2.1"
-  checksum: 10/a7dd15fa5164bf8aa4e07d828ff209ca2940c5c2477a2c2c0e9eb60d87d7f346a437f3601fd9a89f918e8f412b2bd07ff6c057fc230a0461912885d90e187b7f
-  languageName: node
-  linkType: hard
-
 "@lukeed/csprng@npm:^1.0.0":
   version: 1.1.0
   resolution: "@lukeed/csprng@npm:1.1.0"
@@ -10005,13 +9951,6 @@ __metadata:
     "@motionone/dom": "npm:^10.16.4"
     tslib: "npm:^2.3.1"
   checksum: 10/2400d31bbf5c3e02bc68f4b88d96d9c0672ba646bca0b6566e555cd7e8f14849a645f558f574e658fd90574a0b548b61712ae5edcee055c60288fd9382d711ea
-  languageName: node
-  linkType: hard
-
-"@msgpack/msgpack@npm:^2.5.1":
-  version: 2.8.0
-  resolution: "@msgpack/msgpack@npm:2.8.0"
-  checksum: 10/d90ab780c2c96fa5af22f38e0b76871d7c77d06fcf40786b64ada4e0ae02e17b216b38a5505fb4b7d1c339d95caee0669f5ec9004a2b392ce0cbe16afdbd9333
   languageName: node
   linkType: hard
 
@@ -19835,13 +19774,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stack-trace@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "@types/stack-trace@npm:0.0.33"
-  checksum: 10/cec5fbbe3bdcdef82763f917e99ca35a1b92ac96aa7982d09548072c5eff219d8216cf75f1ccfeec9686c91a035cc0d55dda6a76a222022616de275dc5d3a8c1
-  languageName: node
-  linkType: hard
-
 "@types/stylis@npm:4.2.5":
   version: 4.2.5
   resolution: "@types/stylis@npm:4.2.5"
@@ -20892,8 +20824,6 @@ __metadata:
     "@ambire/signature-validator": "npm:1.4.1"
     "@aws-sdk/client-s3": "npm:3.908.0"
     "@guildxyz/sdk": "npm:2.6.9"
-    "@logtail/node": "npm:0.5.4"
-    "@logtail/winston": "npm:0.5.4"
     "@nuintun/qrcode": "npm:5.0.2"
     "@openzeppelin/merkle-tree": "npm:1.0.8"
     "@privy-io/server-auth": "npm:1.32.5"
@@ -46856,15 +46786,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-error@npm:8.1.0":
-  version: 8.1.0
-  resolution: "serialize-error@npm:8.1.0"
-  dependencies:
-    type-fest: "npm:^0.20.2"
-  checksum: 10/2eef236d50edd2d7926e602c14fb500dc3a125ee52e9f08f67033181b8e0be5d1122498bdf7c23c80683cddcad083a27974e9e7111ce23165f4d3bcdd6d65102
-  languageName: node
-  linkType: hard
-
 "serialize-javascript@npm:^6.0.0, serialize-javascript@npm:^6.0.1, serialize-javascript@npm:^6.0.2":
   version: 6.0.2
   resolution: "serialize-javascript@npm:6.0.2"
@@ -47982,7 +47903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-trace@npm:0.0.10, stack-trace@npm:0.0.x":
+"stack-trace@npm:0.0.x":
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 10/7bd633f0e9ac46e81a0b0fe6538482c1d77031959cf94478228731709db4672fbbed59176f5b9a9fd89fec656b5dae03d084ef2d1b0c4c2f5683e05f2dbb1405
@@ -52826,7 +52747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston-transport@npm:^4.3.0, winston-transport@npm:^4.9.0":
+"winston-transport@npm:^4.9.0":
   version: 4.9.0
   resolution: "winston-transport@npm:4.9.0"
   dependencies:


### PR DESCRIPTION
# Description

Railway's log view is Locksmith's only log sink, but `logger.ts` silenced the winston console transport when `NODE_ENV=production`, assuming Logtail would receive the logs. Logtail is not used. Net effect: **every `logger.*` call in production is dropped** — including the Privy login diagnostics shipped in #16607 (verified: zero such lines in Railway since the deploy, despite ~250 rejected logins/day). Only `console.*` output ever reached Railway.

- `logger.ts`: console transport stays on everywhere except tests; Logtail transport, `logtailSourceToken` config, the `LOGTAIL` entry in `.op.env.production` and the `@logtail/node` / `@logtail/winston` dependencies are removed.
- `worker.ts`: remove `console.log('DATABASE', config.databaseUrl)` — it printed the full Postgres URL **with password** into Railway logs at every boot of both the web and worker services (the `addJob` import pulls the module into the web process too).

Note on volume: the express-winston request logger now also reaches Railway (one line per request). Current traffic is a few requests/second, well under Railway's 500 lines/second drop threshold.

# Checklist

- [x] 1 PR, 1 purpose: my Pull Request applies to a single purpose
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not applicable
- [x] I have added tests that prove the fix is effective
- [x] I have performed a self-review of my own code
- [x] Screenshots are not applicable because this has no visual changes

# Testing

- `__tests__/logger.test.ts`: console transport not silent under `NODE_ENV=production`, silent under `test`, and the only transport (watched the production case fail first).
- `__tests__/worker/workerBoot.test.ts`: importing `src/worker/worker` prints nothing matching `DATABASE` or a Postgres URL (watched it fail first).
- `tsc --noEmit`, ESLint (0 errors), `yarn install` to refresh `yarn.lock`.

## Release Note Draft Snippet

Locksmith logs are now visible in Railway in production, and the database connection string is no longer written to the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyw4VrQMe4pkTe7aV6WEJd
